### PR TITLE
add NewRemediationButton

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,14 @@
 import { ACTION_TYPES } from './constants';
-import { getRemediations } from './api';
+import * as api from './api';
 
 export const loadRemediations = () => ({
     type: ACTION_TYPES.LOAD_REMEDIATIONS,
-    payload: getRemediations()
+    payload: api.getRemediations()
 });
+
+export const createRemediation = (data) => {
+    return {
+        type: ACTION_TYPES.CREATE_REMEDIATIONS,
+        payload: api.createRemediation(data)
+    };
+};

--- a/src/api.js
+++ b/src/api.js
@@ -2,19 +2,36 @@ import { API_BASE } from './config';
 
 import urijs from 'urijs';
 
+const headers = {
+    // TODO: this is only needed temporarily until the app is properly onboarded
+    'x-rh-insights-use-path-prefix': '1'
+};
+
+function json (r) {
+    if (r.ok) {
+        return r.json();
+    }
+
+    throw new Error(`Unexpected response code ${r.status}`);
+}
+
 export function getRemediations () {
     const uri = urijs(API_BASE).segment('remediations').toString();
 
     return fetch(uri, {
-        headers: {
-            // TODO: this is only needed temporarily until the app is properly onboarded
-            'x-rh-insights-use-path-prefix': '1'
-        }
-    }).then(r => {
-        if (r.ok) {
-            return r.json();
-        }
+        headers
+    }).then(json);
+}
 
-        throw new Error(`Unexpected response code ${r.status}`);
-    });
+export function createRemediation (data) {
+    const uri = urijs(API_BASE).segment('remediations').toString();
+
+    return fetch(uri, {
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            ...headers
+        },
+        method: 'POST',
+        body: JSON.stringify(data)
+    }).then(json);
 }

--- a/src/components/CreatePlanModal/ModalSteps/PlanName.js
+++ b/src/components/CreatePlanModal/ModalSteps/PlanName.js
@@ -39,6 +39,7 @@ class PlanName extends Component {
                             onChange={ this.handleTextInputChange }
                             placeholder="What do you want to call your grand plan?"
                             aria-label='Name your plan'
+                            autoFocus
                         />
                     </FormGroup>
                 </Form>

--- a/src/components/NewRemediationButton.js
+++ b/src/components/NewRemediationButton.js
@@ -1,0 +1,100 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import * as actions from '../actions';
+
+import { Wizard } from '@red-hat-insights/insights-frontend-components';
+import { Button } from '@patternfly/react-core';
+
+import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
+
+// Wizard Steps
+import PlanName from '../components/CreatePlanModal/ModalSteps/PlanName';
+
+class NewRemediationButton extends Component {
+
+    constructor (props, ctx) {
+        super(props, ctx);
+        this.props = props;
+        this.store = ctx.store;
+        this.state = {
+            open: false
+        };
+    };
+
+    setOpen = open => this.setState({ open });
+
+    openModal = () => this.setOpen(true);
+
+    closeModal = () => {
+        this.setOpen(false);
+        this.newRemediation(this.planNameStep.state.value);
+    };
+
+    newRemediation = (name) => {
+        name = (!name || !name.length) ? 'Unnamed remediation' : name;
+
+        this.store.dispatch(actions.createRemediation({
+            name,
+            add: {
+                issues: [{
+                    id: 'vulnerabilities:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074',
+                    resolution: 'selinux_mitigate'
+                }, {
+                    id: 'advisor:network_bond_opts_config_issue|NETWORK_BONDING_OPTS_DOUBLE_QUOTES_ISSUE'
+                }],
+                systems: [
+                    '34b9f7d9-fc81-4e0f-bef0-c4b402a1510e',
+                    'faa8c67c-345a-44b3-bb8a-d1bc89c36446',
+                    'da8355c0-b259-490d-a9ec-8c1bc0ba7e98'
+                ]
+            }
+        }))
+        .then(({ value }) => {
+            this.store.dispatch(addNotification({
+                variant: 'success',
+                title: 'Remediation created',
+                description: `Remediation ${value.name} has been created`,
+                dismissDelay: 8000
+            }));
+
+            return value;
+        })
+        .then(remediation => this.props.onCreated(remediation));
+    }
+
+    render() {
+        // Wizard Content
+        const steps = [
+            <PlanName key='PlanName' ref={ ref => this.planNameStep = ref }/>
+        ];
+
+        return (
+            <React.Fragment>
+                <Button variant='primary' onClick={ () => this.openModal() }>Demo Remediation</Button>
+                <Wizard
+                    isLarge = { true }
+                    title="Create Remediation"
+                    className='ins-c-plan-modal'
+                    handleModalToggle = { this.closeModal }
+                    isOpen= { this.state.open }
+                    content = { steps }
+                />
+            </React.Fragment>
+        );
+    }
+}
+
+NewRemediationButton.contextTypes = {
+    store: PropTypes.object
+};
+
+NewRemediationButton.propTypes = {
+    onCreated: PropTypes.func
+};
+
+NewRemediationButton.defaultProps = {
+    onCreated: f => f
+};
+
+export default NewRemediationButton;

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,8 @@ import keyBy from 'lodash/keyBy';
 import flatMap from 'lodash/flatMap';
 
 const asyncActions = flatMap([
-    'LOAD_REMEDIATIONS'
+    'LOAD_REMEDIATIONS',
+    'CREATE_REMEDIATIONS'
 ], a => [ a, `${a}_PENDING`, `${a}_FULFILLED`, `${a}_REJECTED` ]);
 
 export const ACTION_TYPES = keyBy([ ...asyncActions ], k => k);

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -8,6 +8,7 @@ import * as actions from '../actions';
 import { Main, PageHeader, PageHeaderTitle, Wizard } from '@red-hat-insights/insights-frontend-components';
 import { Button } from '@patternfly/react-core';
 import RemediationTable from '../components/RemediationTable';
+import NewRemediationButton from '../components/NewRemediationButton';
 
 import { addNotification } from '@red-hat-insights/insights-frontend-components/components/Notifications';
 
@@ -68,6 +69,7 @@ class Home extends Component {
                 <PageHeader>
                     <PageHeaderTitle title='Remediations'></PageHeaderTitle>
                     <Button variant='primary' onClick={ this.handleModalToggle }>Create Remediation</Button>
+                    <NewRemediationButton onCreated = { this.loadRemediations } />
                 </PageHeader>
                 <Main>
                     <ConnectedRemediationTable />


### PR DESCRIPTION
Not useful per se but serves temporarily as an easy way to create a new demo remediation and to verify that the frontend is connected to API properly.
Will serve as a basis for the hot-loadable component.