### PR TITLE
Updating red for 'reboot required' icon + text

### DIFF
--- a/src/components/ResolutionModal/ChooseResolutionModal.scss
+++ b/src/components/ResolutionModal/ChooseResolutionModal.scss
@@ -1,4 +1,5 @@
 @import '@red-hat-insights/insights-frontend-components/Utilities/_mixins.scss';
+@import '@patternfly/patternfly-next/sass-utilities/colors.scss';
 
 .ins-c-resolution-modal {
 
@@ -12,8 +13,8 @@
         span {
             // 4px because the battery icon is 1px bigger than the reboot icon
             @include rem('margin-left', 4px);
-            color: red;
+            color: $pf-color-red-100;
         }
-        svg { fill: red; }
+        svg { fill: $pf-color-red-100; }
     }
 }


### PR DESCRIPTION
For some reason, I had put in the default `red` instead of PF's red. Updated to reflect the true red color.