### PR TITLE
fixing checkboxes on choose resolution modal

### DIFF
--- a/src/components/ResolutionModal/ChooseResolutionModal.scss
+++ b/src/components/ResolutionModal/ChooseResolutionModal.scss
@@ -1,14 +1,6 @@
 @import '@red-hat-insights/insights-frontend-components/Utilities/_mixins.scss';
 
 .ins-c-resolution-modal {
-
-    .ins-c-resolution-choice__details {
-        .pf-l-stack__item:not(:first-of-type) {
-            @include rem('margin-left', 15px);
-        }
-    }
-
-    .ins-c-resolution-option .pf-c-check{
-        align-content: baseline;
-    }
+    .ins-c-resolution-choice__details { @include rem("margin-left", 5px); }
+    .ins-c-resolution-option .pf-c-check { align-items: baseline; }
 }

--- a/src/components/ResolutionModal/ChooseResolutionModal.scss
+++ b/src/components/ResolutionModal/ChooseResolutionModal.scss
@@ -3,8 +3,12 @@
 .ins-c-resolution-modal {
 
     .ins-c-resolution-choice__details {
-        .pf-l-stack__item:not(:first-child) {
+        .pf-l-stack__item:not(:first-of-type) {
             @include rem('margin-left', 15px);
         }
+    }
+
+    .ins-c-resolution-option .pf-c-check{
+        align-content: baseline;
     }
 }


### PR DESCRIPTION
It looks like PF updated and messed up some radio buttons and the labels.

Before:
![image](https://user-images.githubusercontent.com/12520842/51345373-d0972c80-1a68-11e9-85a8-9a34a4cb82b3.png)

After:
![image](https://user-images.githubusercontent.com/12520842/51345809-ed802f80-1a69-11e9-9289-c299f2c303d0.png)

