### PR TITLE
Inventory path changed and entity was removed

### DIFF
--- a/src/Utilities/urls.js
+++ b/src/Utilities/urls.js
@@ -5,7 +5,6 @@ export function buildInventoryUrl (systemId, tab) {
     return urijs(document.baseURI)
     .segment('platform')
     .segment('inventory')
-    .segment('entity')
     .segment(systemId)
     .segment(tab)
     .toString();


### PR DESCRIPTION
This PR https://github.com/RedHatInsights/insights-inventory-frontend/pull/49 removes the need of `/entity/` in path to inv detail.