### PR TITLE
change insights segment from /overview to /rules

### DIFF
--- a/src/Utilities/urls.js
+++ b/src/Utilities/urls.js
@@ -45,7 +45,7 @@ export function buildIssueUrl (id) {
 
     switch (parts[0]) {
         case 'advisor':
-            return appUrl(parts[0]).segment('overview').segment('by_id').segment(parts[1]).toString();
+            return appUrl(parts[0]).segment('rules').segment('by_id').segment(parts[1]).toString();
         case 'vulnerabilities':
             return appUrl(parts[0]).segment('cves').segment(parts[1]).toString();
         default:

--- a/src/Utilities/urls.js
+++ b/src/Utilities/urls.js
@@ -45,7 +45,7 @@ export function buildIssueUrl (id) {
 
     switch (parts[0]) {
         case 'advisor':
-            return appUrl(parts[0]).segment('rules').segment('by_id').segment(parts[1]).toString();
+            return appUrl(parts[0]).segment('rules').segment(parts[1]).toString();
         case 'vulnerabilities':
             return appUrl(parts[0]).segment('cves').segment(parts[1]).toString();
         default:


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHCLOUD-2673

The actual url should be something like

`https://cloud.redhat.com/insights/rules/foo` instead of `https://cloud.redhat.com/insights/overview/by_id/foo`