### PR TITLE
Bind endpoint to Execute Playbook button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3167,20 +3167,19 @@
       }
     },
     "@redhat-cloud-services/remediations-client": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/remediations-client/-/remediations-client-1.0.47.tgz",
-      "integrity": "sha512-5UJMXij66kSvKIhpH1yy6gBjyVNhJKycXWzXhdTIs6xxBiOfmFPLa1Ci8QLJyi7iOuy7rVxRI18Z/d5Jp8WbQA==",
+      "version": "1.0.49",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/remediations-client/-/remediations-client-1.0.49.tgz",
+      "integrity": "sha512-PWHkZh/ZCUiVkn+fi2IsjUxrb51p/lyJeivlxw+gvT64zwyRV2hxEXaRDyC5A28sEoqEl8WCd+BN8/lSgFfKLg==",
       "requires": {
         "axios": "^0.19.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
+          "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
           "requires": {
-            "follow-redirects": "1.5.10",
-            "is-buffer": "^2.0.2"
+            "follow-redirects": "1.5.10"
           }
         },
         "debug": {
@@ -3198,11 +3197,6 @@
           "requires": {
             "debug": "=3.1.0"
           }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },
@@ -9431,15 +9425,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9462,8 +9454,7 @@
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -9630,7 +9621,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "0.0.5",
     "@redhat-cloud-services/frontend-components-remediations": "0.0.3",
     "@redhat-cloud-services/frontend-components-utilities": "0.0.5",
-    "@redhat-cloud-services/remediations-client": "^1.0.47",
+    "@redhat-cloud-services/remediations-client": "^1.0.49",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",

--- a/src/actions.js
+++ b/src/actions.js
@@ -74,3 +74,8 @@ export const runRemediation = (id, etag) => {
     };
 };
 
+export const setEtag = (etag) => ({
+    type: ACTION_TYPES.SET_ETAG,
+    payload: { etag }
+});
+

--- a/src/actions.js
+++ b/src/actions.js
@@ -70,7 +70,7 @@ export const toggleExecutePlaybookBanner = () => ({
 export const runRemediation = (id, etag) => {
     return {
         type: ACTION_TYPES.RUN_REMEDIATION,
-        payload: remediations.runRemediation(id, { headers: { 'If-None-Match': etag }})
+        payload: remediations.runRemediation(id, { headers: { 'If-Match': etag }})
     };
 };
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -66,3 +66,11 @@ export const getConnectionStatus = (id) => {
 export const toggleExecutePlaybookBanner = () => ({
     type: ACTION_TYPES.EXECUTE_PLAYBOOK_BANNER
 });
+
+export const runRemediation = (id, etag) => {
+    return {
+        type: ACTION_TYPES.RUN_REMEDIATION,
+        payload: remediations.runRemediation(id, { headers: { 'If-None-Match': etag }})
+    };
+};
+

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -83,7 +83,7 @@ const styledConnectionStatus = (status) => ({
     </TextContent>)
 })[status];
 
-const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlaybookBanner, remediationId, issueCount, runRemediation, etag, remediationStatus }) => {
+const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlaybookBanner, remediationId, issueCount, runRemediation, etag, remediationStatus, setEtag }) => {
     const [ open, setOpen ] = useState(false);
     const [ isUserEntitled, setIsUserEntitled ] = useState(false);
     const [ showRefreshMessage, setShowRefreshMessage ] = useState(false);
@@ -143,6 +143,12 @@ const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlay
                         key="download"
                         variant='link' onClick={ () => downloadPlaybook(remediationId) }>
                         Download Playbook
+                    </Button>,
+                    <Button
+                        key="reset-etag"
+                        isDisabled={ !isEnabled }
+                        onClick={ () => setEtag('test') }>
+                        Reset etag
                     </Button>
                 ] }
             >
@@ -199,7 +205,8 @@ ExecuteButton.propTypes = {
     remediationId: PropTypes.string,
     remediationStatus: PropTypes.string,
     issueCount: PropTypes.number,
-    etag: PropTypes.string
+    etag: PropTypes.string,
+    setEtag: PropTypes.func
 };
 
 ExecuteButton.defaultProps = {

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -83,11 +83,22 @@ const styledConnectionStatus = (status) => ({
     </TextContent>)
 })[status];
 
-const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlaybookBanner, remediationId, issueCount, runRemediation, etag, remediationStatus, setEtag }) => {
+const ExecuteButton = ({
+    isLoading,
+    data,
+    getConnectionStatus,
+    toggleExecutePlaybookBanner,
+    remediationId,
+    issueCount,
+    runRemediation,
+    etag,
+    remediationStatus,
+    setEtag }) => {
     const [ open, setOpen ] = useState(false);
     const [ isUserEntitled, setIsUserEntitled ] = useState(false);
     const [ showRefreshMessage, setShowRefreshMessage ] = useState(false);
     const isEnabled = () => localStorage.getItem('remediations:fifi:debug') === 'true';
+    const isDebug = () => localStorage.getItem('remediations:debug') === 'true';
 
     useEffect(() => {
         window.insights.chrome.auth.getUser().then(user => setIsUserEntitled(user.entitlements.smart_management.is_entitled));
@@ -144,17 +155,18 @@ const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlay
                         variant='link' onClick={ () => downloadPlaybook(remediationId) }>
                         Download Playbook
                     </Button>,
-                    <Button
-                        key="reset-etag"
-                        isDisabled={ !isEnabled }
-                        onClick={ () => setEtag('test') }>
+                    (isDebug()
+                        ? <Button
+                            key="reset-etag"
+                            onClick={ () => setEtag('test') }>
                         Reset etag
-                    </Button>
+                        </Button>
+                        : null)
                 ] }
             >
                 <div>
                     { showRefreshMessage
-                        ? <Alert variant="info" isInline
+                        ? <Alert variant="warning" isInline
                             title="The connection status of systems associated with this Playbook has changed. Please review again." />
                         : null }
                     <TextContent>

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -84,7 +84,7 @@ const styledConnectionStatus = (status) => ({
     </TextContent>)
 })[status];
 
-const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlaybookBanner, remediationId, issueCount }) => {
+const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlaybookBanner, remediationId, issueCount, runRemediation, etag }) => {
     const [ open, setOpen ] = useState(false);
     const [ isUserEntitled, setIsUserEntitled ] = useState(false);
     const isEnabled = () => localStorage.getItem('remediations:fifi:debug') === 'true';
@@ -126,6 +126,7 @@ const ExecuteButton = ({ isLoading, data, getConnectionStatus, toggleExecutePlay
                         onClick={ () => {
                             setOpen(false);
                             toggleExecutePlaybookBanner();
+                            runRemediation(remediationId, etag);
                         } }>
                         { isLoading ? 'Execute Playbook' : `Execute Playbook on ${pluralize(connectedCount, 'system')}` }
                     </Button>,
@@ -181,8 +182,10 @@ ExecuteButton.propTypes = {
     data: PropTypes.array,
     getConnectionStatus: PropTypes.func,
     toggleExecutePlaybookBanner: PropTypes.func,
+    runRemediation: PropTypes.func,
     remediationId: PropTypes.string,
-    issueCount: PropTypes.number
+    issueCount: PropTypes.number,
+    etag: PropTypes.string
 };
 
 ExecuteButton.defaultProps = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,8 @@ const asyncActions = flatMap([
     'PATCH_REMEDIATION_ISSUE',
     'GET_RESOLUTIONS',
     'GET_CONNECTION_STATUS',
-    'EXECUTE_PLAYBOOK_BANNER'
+    'EXECUTE_PLAYBOOK_BANNER',
+    'RUN_REMEDIATION'
 ], a => [ a, `${a}_PENDING`, `${a}_FULFILLED`, `${a}_REJECTED` ]);
 
 export const ACTION_TYPES = keyBy([ ...asyncActions ], k => k);

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,7 @@ const asyncActions = flatMap([
     'RUN_REMEDIATION'
 ], a => [ a, `${a}_PENDING`, `${a}_FULFILLED`, `${a}_REJECTED` ]);
 
-export const ACTION_TYPES = keyBy([ ...asyncActions ], k => k);
+const actions = [ 'SET_ETAG' ];
+export const ACTION_TYPES = keyBy([ ...asyncActions, ...actions ], k => k);
 
 export const SEARCH_DEBOUNCE_DELAY = 500;

--- a/src/containers/ExecuteButtons.js
+++ b/src/containers/ExecuteButtons.js
@@ -6,11 +6,12 @@ import { getConnectionStatus, runRemediation, toggleExecutePlaybookBanner } from
 import ExecuteButton from '../components/ExecuteButton';
 
 export const ExecutePlaybookButton = withRouter(connect(
-    ({ connectionStatus: { data, status, etag }, selectedRemediation }) => ({
+    ({ connectionStatus: { data, status, etag }, selectedRemediation, runRemediation }) => ({
         data,
         isLoading: status !== 'fulfilled',
         issueCount: selectedRemediation.remediation.issues.length,
-        etag
+        etag,
+        remediationStatus: runRemediation.status
     }),
     (dispatch) => ({
         getConnectionStatus: (id) => {

--- a/src/containers/ExecuteButtons.js
+++ b/src/containers/ExecuteButtons.js
@@ -1,15 +1,16 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { getConnectionStatus, toggleExecutePlaybookBanner } from '../actions';
+import { getConnectionStatus, runRemediation, toggleExecutePlaybookBanner } from '../actions';
 
 import ExecuteButton from '../components/ExecuteButton';
 
 export const ExecutePlaybookButton = withRouter(connect(
-    ({ connectionStatus: { data, status }, selectedRemediation }) => ({
+    ({ connectionStatus: { data, status, etag }, selectedRemediation }) => ({
         data,
         isLoading: status !== 'fulfilled',
-        issueCount: selectedRemediation.remediation.issues.length
+        issueCount: selectedRemediation.remediation.issues.length,
+        etag
     }),
     (dispatch) => ({
         getConnectionStatus: (id) => {
@@ -17,6 +18,9 @@ export const ExecutePlaybookButton = withRouter(connect(
         },
         toggleExecutePlaybookBanner: () => {
             dispatch(toggleExecutePlaybookBanner());
+        },
+        runRemediation: (id, etag) => {
+            dispatch(runRemediation(id, etag));
         }
     })
 )(ExecuteButton));

--- a/src/containers/ExecuteButtons.js
+++ b/src/containers/ExecuteButtons.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { getConnectionStatus, runRemediation, toggleExecutePlaybookBanner } from '../actions';
+import { getConnectionStatus, runRemediation, toggleExecutePlaybookBanner, setEtag } from '../actions';
 
 import ExecuteButton from '../components/ExecuteButton';
 
@@ -22,6 +22,10 @@ export const ExecutePlaybookButton = withRouter(connect(
         },
         runRemediation: (id, etag) => {
             dispatch(runRemediation(id, etag));
+        },
+        setEtag: (etag) => {
+            dispatch(setEtag(etag));
         }
+
     })
 )(ExecuteButton));

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -137,6 +137,10 @@ const reducers = {
         [ACTION_TYPES.GET_CONNECTION_STATUS_REJECTED]: () => ({
             status: 'rejected',
             data: []
+        }),
+        [ACTION_TYPES.SET_ETAG]: (state, action) => ({
+            ...state,
+            etag: action.etag
         })
     }, {
         status: 'initial'

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -160,6 +160,19 @@ const reducers = {
                 ]
             };
         }
+    }),
+
+    runRemediation: applyReducerHash({
+        [ACTION_TYPES.RUN_REMEDIATION_PENDING]: () => ({
+            status: 'pending'
+        }),
+        [ACTION_TYPES.RUN_REMEDIATION_FULFILLED]: (state, action) => ({
+            status: 'fulfilled',
+            data: action.payload.data
+        }),
+        [ACTION_TYPES.RUN_REMEDIATION_REJECTED]: (state, action) => ({
+            status: action.payload.response.status === 412 ? 'changed' : 'rejected'
+        })
     }, {
         status: 'initial'
     })


### PR DESCRIPTION
Bind endpoint to Execute Playbook button.

To show `Reset etag` button you should type `localStorage.setItem('remediations:fifi:debug', true)` into browser console.

![Screenshot from 2020-01-27 13-51-17](https://user-images.githubusercontent.com/9535558/73176214-2e466600-410c-11ea-86bd-8eebc3228625.png)
![Screenshot from 2020-01-28 10-47-14](https://user-images.githubusercontent.com/9535558/73253677-43c79880-41bd-11ea-839a-6bcc31be6bd4.png)


