### PR TITLE
Fix sorting change when expanding item

### DIFF
--- a/src/components/ActivityDetails.js
+++ b/src/components/ActivityDetails.js
@@ -59,7 +59,7 @@ const ActivityDetail = ({
                         </BreadcrumbItem>
                         <BreadcrumbItem isActive> <DateFormat type='exact' date={ playbookRun.data.created_at } /> </BreadcrumbItem>
                     </Breadcrumb>
-                    <Stack gutter>
+                    <Stack gutter='md'>
                         <StackItem>
                             <PageHeaderTitle title={
                                 normalizeStatus(playbookRun.data.status) === 'running'
@@ -77,7 +77,7 @@ const ActivityDetail = ({
                             } />
                         </StackItem>
                         <StackItem>
-                            <Split gutter>
+                            <Split gutter='md'>
                                 <SplitItem>
                                     <DescriptionList className='ins-c-playbookSummary__settings' title='Run on'>
                                         <DateFormat type='exact' date={ playbookRun.data.created_at } />

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -18,7 +18,7 @@ import {
     Card, CardHeader, CardBody,
     Stack, StackItem,
     Breadcrumb, BreadcrumbItem,
-    Split, SplitItem
+    Split, SplitItem, ToolbarItem, ToolbarGroup
 } from '@patternfly/react-core';
 import { InProgressIcon, DownloadIcon } from '@patternfly/react-icons';
 
@@ -148,46 +148,6 @@ const ExecutorDetails = ({
         <Stack gutter="md">
             <Card>
                 <CardHeader className='ins-m-card__header-bold'>
-                    <TableToolbar>
-                        <ConditionalFilter
-                            items={ [
-                                {   value: 'display_name',
-                                    label: 'Name',
-                                    filterValues: { placeholder: 'Filter by name', type: conditionalFilterType.text,
-                                        value: filter.value,
-                                        onChange: (e, selected) => {
-                                            setFilter({ ...filter, value: selected });
-                                            setFilteredSystems(systems.filter(s => s[filter.key].includes(selected)));
-                                        },
-                                        onSubmit: (e, selected) => {
-                                            setFilteredSystems(systems.filter(s => s[selected].includes(filter.value)));
-                                        }
-                                    }
-                                },
-                                {
-                                    value: 'status',
-                                    label: 'Status',
-                                    filterValues: { placeholder: 'Filter by status', type: conditionalFilterType.text,
-                                        value: filter.value,
-                                        onChange: (e, selected) => {
-                                            setFilter({ ...filter, value: selected });
-                                            setFilteredSystems(systems.filter(s => s[filter.key].includes(selected)));
-                                        },
-                                        onSubmit: (e, selected) => {
-                                            setFilteredSystems(systems.filter(s => s[selected].includes(filter.value)));
-                                        }
-                                    }
-                                }
-                            ] }
-                            value={ filter.key }
-                            onChange={ (e, selected) => setFilter({ key: selected, value: '' }) }
-                        />
-                        <Button
-                            variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
-                            <DownloadIcon /> { ' ' }
-                            Download Playbook
-                        </Button>
-                    </TableToolbar>
 
                 </CardHeader>
 
@@ -227,7 +187,51 @@ const ExecutorDetails = ({
                                 onCollapseInventory(isOpen, id);
 
                             } }
-                    /> }
+                    >
+                        <TableToolbar>
+                            <ToolbarGroup>
+                                <ToolbarItem>
+                                    <ConditionalFilter
+                                        items={ [
+                                            {
+                                                value: 'display_name',
+                                                label: 'Name',
+                                                filterValues: {
+                                                    placeholder: 'Filter by name', type: conditionalFilterType.text,
+                                                    value: filter.value,
+                                                    onChange: (e, selected) => {
+                                                        setFilter({ ...filter, value: selected });
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                value: 'status',
+                                                label: 'Status',
+                                                filterValues: {
+                                                    placeholder: 'Filter by status', type: conditionalFilterType.text,
+                                                    value: filter.value,
+                                                    onChange: (e, selected) => {
+                                                        setFilter({ ...filter, value: selected });
+                                                    }
+                                                }
+                                            }
+                                        ] }
+                                        value={ filter.key }
+                                        onChange={ (e, selected) => setFilter({ key: selected, value: '' }) }
+                                    />
+                                </ToolbarItem>
+                            </ToolbarGroup>
+                            <ToolbarGroup>
+                                <ToolbarItem>
+                                    <Button
+                                        variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
+                                        <DownloadIcon /> { ' ' }
+                                Download Playbook
+                                    </Button>
+                                </ToolbarItem>
+                            </ToolbarGroup>
+                        </TableToolbar>
+                    </InventoryTable> }
                 </CardBody>
             </Card>
         </Stack>

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -56,7 +56,6 @@ const ExecutorDetails = ({
 }) => {
     const [ executor, setExecutor ] = useState({});
     const [ systems, setSystems ] = useState([]);
-    const [ filteredSystems, setFilteredSystems ] = useState([]);
     const [ filter, setFilter ] = useState({ key: 'display_name', value: '' });
     const [ InventoryTable, setInventoryTable ] = useState();
     const [ page, setPage ] = useState(1);
@@ -273,7 +272,7 @@ const ExecutorDetails = ({
                     </BreadcrumbItem>
                     <BreadcrumbItem isActive> { executor.executor_name } </BreadcrumbItem>
                 </Breadcrumb>
-                <Stack gutter>
+                <Stack gutter='md'>
                     <StackItem>
                         <PageHeaderTitle title={
                             normalizeStatus(executor.status) === 'Running'
@@ -287,7 +286,7 @@ const ExecutorDetails = ({
                         } />
                     </StackItem>
                     <StackItem>
-                        <Split gutter>
+                        <Split gutter='md'>
                             <SplitItem>
                                 <DescriptionList className='ins-c-playbookSummary__settings' title='Run on'>
                                     <DateFormat type='exact' date={ playbookRun.data.created_at } />

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -173,6 +173,7 @@ const reducers = {
 
             };
         },
+
         [ACTION_TYPES.EXPAND_INVENTORY_TABLE]: (state, action) => {
             return {
                 ...state,
@@ -216,6 +217,10 @@ const reducers = {
     playbookRunSystems: applyReducerHash({
         [ACTION_TYPES.GET_PLAYBOOK_RUN_SYSTEMS_FULFILLED]: (state, action) => ({
             ...action.payload
+        }),
+        [ACTION_TYPES.GET_PLAYBOOK_RUN_SYSTEMS_PENDING]: (state) => ({
+            ...state,
+            status: 'pending'
         })
     }, {
         data: [],

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -176,11 +176,11 @@ const reducers = {
         [ACTION_TYPES.EXPAND_INVENTORY_TABLE]: (state, action) => {
             return {
                 ...state,
-                rows: [ ...state.rows.filter(row => row.id !== action.payload.id),
-                    { ...state.rows.find(row => row.id === action.payload.id), isOpen: action.payload.isOpen
-                    }
-                ]
-            };}
+                rows:
+                    state.rows.map(row => ({ ...row, isOpen: row.id === action.payload.id ? action.payload.isOpen : false }))
+
+            };
+        }
     }),
 
     playbookRuns: applyReducerHash({


### PR DESCRIPTION
Fixes issues:
- the filters/buttons are not on the same row as pagination
- no padding between the filter and the button
- when a system row of a finished system is expanded it starts to poll (even though the system is not running)
- when I expand a row it's order in the list changes