### PR TITLE
Low hanging fruit papercuts (phase 1)

### DIFF
--- a/src/components/ActivityDetails.js
+++ b/src/components/ActivityDetails.js
@@ -13,7 +13,8 @@ import {
     Card, CardHeader, CardBody,
     Stack, StackItem,
     Breadcrumb, BreadcrumbItem,
-    Split, SplitItem
+    Split, SplitItem,
+    Title
 } from '@patternfly/react-core';
 import {
     Table,
@@ -55,6 +56,9 @@ const ActivityDetail = ({
             <React.Fragment>
                 <PageHeader>
                     <Breadcrumb>
+                        <BreadcrumbItem>
+                            <Link to={ `/` }> Remediations </Link>
+                        </BreadcrumbItem>
                         <BreadcrumbItem>
                             <Link to={ `/${remediation.id}` }> { remediation.name } </Link>
                         </BreadcrumbItem>
@@ -117,7 +121,9 @@ const ActivityDetail = ({
                 <Main>
                     <Stack gutter='md'>
                         <Card>
-                            <CardHeader className='ins-m-card__header-bold'>Results by connection</CardHeader>
+                            <CardHeader className='ins-m-card__header-bold'>
+                                <Title headingLevel="h4" size="xl">Results by connection</Title>
+                            </CardHeader>
                             <CardBody>
                                 <Table
                                     aria-label="Collapsible table"

--- a/src/components/Alerts/NoReceptorBanner.js
+++ b/src/components/Alerts/NoReceptorBanner.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import propTypes from 'prop-types';
 
-import { Alert, AlertActionCloseButton, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
 
 const NoReceptorBanner = ({ ...props }) => {
     return (
@@ -13,7 +12,7 @@ const NoReceptorBanner = ({ ...props }) => {
             <Stack gutter='md'>
                 <StackItem>Configure your systems with Cloud Connector to fix systems across all your Satellite instances.</StackItem>
                 <StackItem>
-                    <a href="#">Learn how to configure</a> {/* TODO */}
+                    <a href="#">Learn how to configure</a> { /* TODO */ }
                 </StackItem>
             </Stack>
         </Alert>

--- a/src/components/Alerts/NoReceptorBanner.js
+++ b/src/components/Alerts/NoReceptorBanner.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+import { Alert, AlertActionCloseButton, Stack, StackItem } from '@patternfly/react-core';
+
+const NoReceptorBanner = ({ ...props }) => {
+    return (
+        <Alert
+            variant="info"
+            isInline
+            title="Do more with Find it Fix it capabilities"
+            { ...props }>
+            <Stack gutter='md'>
+                <StackItem>Configure your systems with Cloud Connector to fix systems across all your Satellite instances.</StackItem>
+                <StackItem>
+                    <a href="#">Learn how to configure</a> {/* TODO */}
+                </StackItem>
+            </Stack>
+        </Alert>
+    );
+};
+
+export default NoReceptorBanner;

--- a/src/components/Alerts/UpsellBanner.js
+++ b/src/components/Alerts/UpsellBanner.js
@@ -6,7 +6,7 @@ import { Alert, AlertActionCloseButton, Stack, StackItem } from '@patternfly/rea
 const UpsellBanner = ({ onClose, ...props }) => {
     return (
         <Alert
-            variant="default"
+            variant="info"
             isInline
             title="Do more with Find it Fix it capabilities"
             action={ <AlertActionCloseButton onClose={ onClose }/> }
@@ -14,7 +14,7 @@ const UpsellBanner = ({ onClose, ...props }) => {
             <Stack gutter='md'>
                 <StackItem>Upgrade to Red Hat Smart Management to remediate all your systems, across regions and geographies</StackItem>
                 <StackItem>
-                    <a href="https://access.redhat.com/products/cloud_management_services_for_rhel/evaluation">Try it for 90 days</a>
+                    <a href="https://access.redhat.com/products/cloud_management_services_for_rhel/evaluation">Learn more</a>
                 </StackItem>
             </Stack>
         </Alert>

--- a/src/components/Alerts/__tests__/__snapshots__/UpsellBanner.test.js.snap
+++ b/src/components/Alerts/__tests__/__snapshots__/UpsellBanner.test.js.snap
@@ -9,7 +9,7 @@ exports[`UpsellBanner component should render 1`] = `
   }
   isInline={true}
   title="Do more with Find it Fix it capabilities"
-  variant="default"
+  variant="info"
 >
   <Stack
     gutter="md"
@@ -21,7 +21,7 @@ exports[`UpsellBanner component should render 1`] = `
       <a
         href="https://access.redhat.com/products/cloud_management_services_for_rhel/evaluation"
       >
-        Try it for 90 days
+        Learn more
       </a>
     </StackItem>
   </Stack>

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -20,6 +20,7 @@ export default function ConfirmationDialog ({
             title={ title }
             isOpen={ isOpen }
             onClose={ () => onClose(false) }
+            isFooterLeftAligned
             actions={ [
                 <Button key="cancel" variant="secondary" onClick={ () => onClose(false) }>Cancel</Button>,
                 <Button key="confirm" variant="primary" onClick={ () => onClose(true) }>Confirm</Button>

--- a/src/components/DeleteButton.js
+++ b/src/components/DeleteButton.js
@@ -28,10 +28,9 @@ class DeleteButton extends Component {
         return (
             <React.Fragment>
                 <Button
-                    className='ins-c-button__danger-link'
                     onClick={ this.onButtonClicked }
                     isDisabled={ this.props.isDisabled }
-                    variant="link">
+                    variant={ this.props.variant }>
                     { this.props.label }
                 </Button>
                 {
@@ -47,11 +46,13 @@ DeleteButton.propTypes = {
     label: PropTypes.string,
     dialogMessage: PropTypes.string,
     isDisabled: PropTypes.bool,
-    onDelete: PropTypes.func.isRequired
+    onDelete: PropTypes.func.isRequired,
+    variant: PropTypes.string
 };
 
 DeleteButton.defaultProps = {
-    label: 'Delete'
+    label: 'Delete',
+    variant: 'link'
 };
 
 export default DeleteButton;

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -134,12 +134,12 @@ const ExecuteButton = ({
             <Button
                 isDisabled={ isDisabled }
                 onClick={ () => { setOpen(true); getConnectionStatus(remediationId); } }>
-        Execute Playbook
+        Execute playbook
             </Button>
             <Modal
                 className="ins-c-dialog"
                 width={ '50%' }
-                title={ 'Execute Playbook' }
+                title={ 'Execute playbook' }
                 isOpen={ open }
                 onClose={ () => {
                     setShowRefreshMessage(false);
@@ -152,12 +152,12 @@ const ExecuteButton = ({
                         variant="primary"
                         isDisabled={ connected.length === 0 }
                         onClick={ () => { runRemediation(remediationId, etag); } }>
-                        { isLoading ? 'Execute Playbook' : `Execute Playbook on ${pluralize(connectedCount, 'system')}` }
+                        { isLoading ? 'Execute playbook' : `Execute playbook on ${pluralize(connectedCount, 'system')}` }
                     </Button>,
                     <Button
                         key="download"
                         variant='link' onClick={ () => downloadPlaybook(remediationId) }>
-                        Download Playbook
+                        Download playbook
                     </Button>,
                     (isDebug()
                         ? <Button

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -39,7 +39,7 @@ import PlaybookSystemDetails from './SystemDetails';
 import ExecutorDetailsSkeleton from '../skeletons/ExecutorDetailsSkeleton';
 import RunFailed from './Alerts/RunFailed';
 import { inventoryUrlBuilder } from '../Utilities/urls';
-
+import './ExecutorDetails.scss';
 import { PermissionContext } from '../App';
 let refreshInterval;
 
@@ -151,7 +151,7 @@ const ExecutorDetails = ({
 
     const renderInventorycard = (status) => <Main>
         <Stack gutter="md">
-            <Card>
+            <Card className='ins-c-card__playbook-log'>
                 <CardBody>
                     { InventoryTable && <InventoryTable
                         ref={ inventory }
@@ -274,6 +274,9 @@ const ExecutorDetails = ({
             <PageHeader>
                 <Breadcrumb>
                     <BreadcrumbItem>
+                        <Link to={ `/` }> Remediations </Link>
+                    </BreadcrumbItem>
+                    <BreadcrumbItem>
                         <Link to={ `/${remediation.id}` }> { remediation.name } </Link>
                     </BreadcrumbItem>
                     <BreadcrumbItem>
@@ -297,16 +300,6 @@ const ExecutorDetails = ({
                     <StackItem>
                         <Split gutter="md">
                             <SplitItem>
-                                <DescriptionList className='ins-c-playbookSummary__settings' title='Run on'>
-                                    <DateFormat type='exact' date={ playbookRun.data.created_at } />
-                                </DescriptionList>
-                            </SplitItem>
-                            <SplitItem>
-                                <DescriptionList className='ins-c-playbookSummary__settings' title='Run by'>
-                                    { `${playbookRun.data.created_by.first_name} ${playbookRun.data.created_by.last_name}` }
-                                </DescriptionList>
-                            </SplitItem>
-                            <SplitItem>
                                 <DescriptionList className='ins-c-playbookSummary__settings' title='Run status'>
                                     { executor.status
                                         ? <StatusSummary
@@ -316,7 +309,16 @@ const ExecutorDetails = ({
                                         : <Skeleton size='lg' />
 
                                     }
-
+                                </DescriptionList>
+                            </SplitItem>
+                            <SplitItem>
+                                <DescriptionList className='ins-c-playbookSummary__settings' title='Run by'>
+                                    { `${playbookRun.data.created_by.first_name} ${playbookRun.data.created_by.last_name}` }
+                                </DescriptionList>
+                            </SplitItem>
+                            <SplitItem>
+                                <DescriptionList className='ins-c-playbookSummary__settings' title='Run on'>
+                                    <DateFormat type='exact' date={ playbookRun.data.created_at } />
                                 </DescriptionList>
                             </SplitItem>
                         </Split>

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -234,7 +234,7 @@ const ExecutorDetails = ({
                                     <Button
                                         variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
                                         <DownloadIcon /> { ' ' }
-                                Download Playbook
+                                Download playbook
                                     </Button>
                                 </ToolbarItem>
                             </ToolbarGroup>
@@ -255,7 +255,7 @@ const ExecutorDetails = ({
                     <CardHeader className='ins-m-card__header-bold'>
                         <Button
                             variant='link' onClick={ () => downloadPlaybook(remediation.id) }>
-                            Download Playbook
+                            Download playbook
                         </Button>
                     </CardHeader>
 

--- a/src/components/ExecutorDetails.scss
+++ b/src/components/ExecutorDetails.scss
@@ -1,0 +1,5 @@
+.ins-c-card__playbook-log {
+    .ins-c-primary-toolbar { padding: 0; }
+    .ins-c-table__toolbar { padding-left: 0; padding-right: 0 }
+    .ins-c-tag-count { padding: 0; }
+}

--- a/src/components/Layouts/DescriptionList.scss
+++ b/src/components/Layouts/DescriptionList.scss
@@ -1,7 +1,7 @@
 .ins-l-description-list {
     .ins-l-description-list__title {
         margin-bottom: 6px; // form-element-spacer
-        font-size: var(--pf-global--FontSize--md);
+        font-size: var(--pf-global--FontSize--sm);
     }
     .ins-l-description-list__description {
         font-size: var(--pf-global--FontSize--md);

--- a/src/components/RemediationActivityTable.js
+++ b/src/components/RemediationActivityTable.js
@@ -15,7 +15,7 @@ import { StatusSummary, normalizeStatus } from './statusHelper';
 
 import { PermissionContext } from '../App';
 
-import './RemediationActivityTable.scss'
+import './RemediationActivityTable.scss';
 
 const RemediationActivityTable = ({ remediation, playbookRuns }) => {
 

--- a/src/components/RemediationActivityTable.js
+++ b/src/components/RemediationActivityTable.js
@@ -15,6 +15,8 @@ import { StatusSummary, normalizeStatus } from './statusHelper';
 
 import { PermissionContext } from '../App';
 
+import './RemediationActivityTable.scss'
+
 const RemediationActivityTable = ({ remediation, playbookRuns }) => {
 
     const [ rows, setRows ] = useState([]);
@@ -98,7 +100,12 @@ const RemediationActivityTable = ({ remediation, playbookRuns }) => {
     ];
 
     return (
-        <Table aria-label="Collapsible table" onCollapse={ handleOnCollapse } rows={ rows } cells={ columns }>
+        <Table
+            className='ins-c-activity-table'
+            aria-label="Collapsible table"
+            onCollapse={ handleOnCollapse }
+            rows={ rows }
+            cells={ columns }>
             <TableHeader />
             <TableBody />
         </Table>

--- a/src/components/RemediationActivityTable.scss
+++ b/src/components/RemediationActivityTable.scss
@@ -3,4 +3,7 @@
     .pf-c-table__expandable-row {
         th { padding-top: 24px; }
     }
+    .ins-c-remediations-status-bar {
+        max-width: max-content;
+    }
 }

--- a/src/components/RemediationActivityTable.scss
+++ b/src/components/RemediationActivityTable.scss
@@ -1,14 +1,1 @@
-.ins-activity-status{
-    &__text {
-        &-passed { color: var(--pf-global--success-color--200); }
-        &-failed { color: var(--pf-global--danger-color--200); }
-        &-in_progress { color: var(--pf-global--Color--200); }
-    }
-    &__icon {
-        font-size: 16px;
-        padding-left: var(--pf-global--spacer--md);
-        &-passed { color: var(--pf-global--success-color--200); }
-        &-failed { color: var(--pf-global--danger-color--200); }
-        &-in_progress { color: var(--pf-global--Color--200); }
-    }
-}
+// Activity Table

--- a/src/components/RemediationActivityTable.scss
+++ b/src/components/RemediationActivityTable.scss
@@ -1,1 +1,6 @@
 // Activity Table
+.ins-c-activity-table {
+    .pf-c-table__expandable-row {
+        th { padding-top: 24px; }
+    }
+}

--- a/src/components/RemediationDetailsSystemDropdown.js
+++ b/src/components/RemediationDetailsSystemDropdown.js
@@ -33,7 +33,6 @@ function RemediationDetailsSystemDropdown ({ remediation, issue, system, onDelet
                 isPlain
             >
                 <Button
-                    className=' ins-c-button__danger-link'
                     onClick={ () => setDeleteDialogOpen(true) }
                     variant="link"
                 >

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -143,6 +143,7 @@ function RemediationDetailsTable (props) {
                     <ToolbarItem>
                         { permission.permissions.write &&
                             <DeleteActionsButton
+                                variant='secondary'
                                 isDisabled={ !selectedIds.length }
                                 remediation={ props.remediation }
                                 issues={ selectedIds }

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -48,7 +48,7 @@ function skeleton () {
                         // <ToolbarItem><Button isDisabled> Create Remediation </Button></ToolbarItem>
                     }
                     <ToolbarItem>
-                        <Button variant='link' isDisabled> Download Playbook </Button>
+                        <Button variant='link' isDisabled> Download playbook </Button>
                     </ToolbarItem>
                     <ToolbarItem>
                         <Dropdown
@@ -164,7 +164,7 @@ function RemediationTable (props) {
                             isDisabled={ !selectedIds.length }
                             onClick= { () => downloadAll(selectedIds, value.data) }
                         >
-                            Download Playbook
+                            Download playbook
                         </Button>
                     </ToolbarItem>
                     <ToolbarItem>

--- a/src/components/Status.scss
+++ b/src/components/Status.scss
@@ -1,3 +1,5 @@
 .ins-c-remediations-success { color: var(--pf-global--success-color--200); }
 .ins-c-remediations-failure { color: var(--pf-global--danger-color--100); }
 .ins-c-remediations-running { color: var(--pf-global--secondary-color--100); }
+
+td .ins-c-remediations-status-text { display: inline-block; min-width: 85px; }

--- a/src/components/Status.scss
+++ b/src/components/Status.scss
@@ -1,5 +1,5 @@
 .ins-c-remediations-success { color: var(--pf-global--success-color--200); }
 .ins-c-remediations-failure { color: var(--pf-global--danger-color--100); }
-.ins-c-remediations-running { color: var(--pf-global--secondary-color--100); }
+.ins-c-remediations-running { color: var(--pf-global--default-color--300); }
 
 td .ins-c-remediations-status-text { display: inline-block; min-width: 85px; }

--- a/src/components/SystemDetails.js
+++ b/src/components/SystemDetails.js
@@ -7,6 +7,8 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { Spinner } from '@patternfly/react-core';
 import classnames from 'classnames';
 
+import { Title } from '@patternfly/react-core';
+
 import './SystemDetails.scss';
 
 const PlaybookSystemDetails = ({ systemId, playbookRunSystemDetails }) => {
@@ -17,6 +19,7 @@ const PlaybookSystemDetails = ({ systemId, playbookRunSystemDetails }) => {
     );
 
     return <React.Fragment>
+        <Title headingLevel="h4" size="xl" className='ins-c-job-output__title'>Playbook log</Title>
         { systemId && systemId === playbookRunSystemDetails.system_id ?
             <React.Fragment>
                 <SyntaxHighlighter

--- a/src/components/SystemDetails.scss
+++ b/src/components/SystemDetails.scss
@@ -1,4 +1,6 @@
 
+.ins-c-job-output__title { padding-bottom: var(--pf-global--spacer--lg)}
+
 .ins-c-job-output {
     max-height: 500px;
     padding: 0 !important;

--- a/src/components/SystemForActionButton.js
+++ b/src/components/SystemForActionButton.js
@@ -98,7 +98,6 @@ const SystemForActionButton = ({ issue, remediation, onDelete }) => {
                             {
                                 title: (
                                     <Button
-                                        className=' ins-c-button__danger-link'
                                         onClick={ () => setDeleteDialogOpen(true) }
                                         variant="link"
                                     >

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -47,12 +47,12 @@ export const renderStatus = (status, text) => ({
 
 const statusTextClass = 'ins-c-remediations-status-text';
 export const statusText = (executorStatus) => ({
-    running: <b className={`${statusTextClass} ins-c-remediations-running`}> Running </b>,
-    pending: <b className={`${statusTextClass} ins-c-remediations-running`}> Pending </b>,
-    acked: <b className={`${statusTextClass} ins-c-remediations-running`}> Acked </b>,
-    success: <b className={`${statusTextClass} ins-c-remediations-success`}> Suceeded </b>,
-    failure: <b className={`${statusTextClass} ins-c-remediations-failure`}> Failed </b>,
-    canceled: <b className={`${statusTextClass} ins-c-remediations-failure`}> Canceled </b>
+    running: <b className={ `${statusTextClass} ins-c-remediations-running` }> Running </b>,
+    pending: <b className={ `${statusTextClass} ins-c-remediations-running` }> Pending </b>,
+    acked: <b className={ `${statusTextClass} ins-c-remediations-running` }> Acked </b>,
+    success: <b className={ `${statusTextClass} ins-c-remediations-success` }> Suceeded </b>,
+    failure: <b className={ `${statusTextClass} ins-c-remediations-failure` }> Failed </b>,
+    canceled: <b className={ `${statusTextClass} ins-c-remediations-failure` }> Canceled </b>
 })[executorStatus];
 
 export const StatusSummary = ({ executorStatus, permission, hasCancel, counts, remediationName, remediationId, playbookId }) => {

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -45,13 +45,14 @@ export const renderStatus = (status, text) => ({
     </Flex>
 })[status];
 
+const statusTextClass = 'ins-c-remediations-status-text';
 export const statusText = (executorStatus) => ({
-    running: <b className="ins-c-remediations-running"> Running </b>,
-    pending: <b className="ins-c-remediations-running"> Pending </b>,
-    acked: <b className="ins-c-remediations-running"> Acked </b>,
-    success: <b className="ins-c-remediations-success"> Suceeded </b>,
-    failure: <b className="ins-c-remediations-failure"> Failed </b>,
-    canceled: <b className="ins-c-remediations-failure"> Canceled </b>
+    running: <b className={`${statusTextClass} ins-c-remediations-running`}> Running </b>,
+    pending: <b className={`${statusTextClass} ins-c-remediations-running`}> Pending </b>,
+    acked: <b className={`${statusTextClass} ins-c-remediations-running`}> Acked </b>,
+    success: <b className={`${statusTextClass} ins-c-remediations-success`}> Suceeded </b>,
+    failure: <b className={`${statusTextClass} ins-c-remediations-failure`}> Failed </b>,
+    canceled: <b className={`${statusTextClass} ins-c-remediations-failure`}> Canceled </b>
 })[executorStatus];
 
 export const StatusSummary = ({ executorStatus, permission, hasCancel, counts, remediationName, remediationId, playbookId }) => {

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -89,13 +89,14 @@ export const StatusSummary = ({ executorStatus, permission, hasCancel, counts, r
         </Flex>
     );
 
+    const pluralize = (number, str) => number === 1 ? `${number} ${str}` : `${number} ${str}s`;
     const tooltipText = ` Run: ${capitalize(executorStatus)} |
-    Success: ${counts.success} |
-    Failed: ${counts.failure} |
-    Canceled: ${counts.canceled} |
-    Pending: ${counts.pending} |
-    Running: ${counts.running}
-    ${counts.acked && !counts.acked.isNaN() ? `| Acked: ${counts.acked}` : ''}`;
+    Success: ${pluralize(counts.success, 'system')} |
+    Failed: ${pluralize(counts.failure, 'system')} |
+    Canceled: ${pluralize(counts.canceled, 'system')} |
+    Pending: ${pluralize(counts.pending, 'system')} |
+    Running: ${pluralize(counts.running, 'system')}
+    ${counts.acked && !counts.acked.isNaN() ? `| Acked: ${pluralize(counts.acked, 'system')}` : ''}`;
 
     if (executorStatus) {
         return <Tooltip

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -34,7 +34,8 @@ import {
     Button,
     Split, SplitItem,
     Flex, FlexItem, FlexModifiers,
-    Tabs, Tab, Tooltip
+    Tabs, Tab, Tooltip,
+    Title
 } from '@patternfly/react-core';
 
 import RemediationDetailsSkeleton from '../skeletons/RemediationDetailsSkeleton';
@@ -203,7 +204,7 @@ const RemediationDetails = ({
                                     <Button
                                         isDisabled={ !remediation.issues.length }
                                         variant='link' onClick={ () => downloadPlaybook(remediation.id) }>
-                                        Download Playbook
+                                        Download playbook
                                     </Button>
                                 </SplitItem>
                                 <SplitItem>
@@ -222,7 +223,9 @@ const RemediationDetails = ({
                         }
                         <StackItem>
                             <Card>
-                                <CardHeader className='ins-m-card__header-bold'>Playbook Summary</CardHeader>
+                                <CardHeader className='ins-m-card__header-bold'>
+                                    <Title headingLevel="h4" size="xl">Playbook summary</Title>
+                                </CardHeader>
                                 <CardBody>
                                     <Flex className='ins-c-playbookSummary' breakpointMods={ [{ modifier: FlexModifiers.column }] }>
                                         <Flex className='ins-c-playbookSummary__overview'>

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -251,7 +251,7 @@ const RemediationDetails = ({
                                                         { 'ins-c-reboot-status__disabled': !remediation.auto_reboot }
                                                     ) }
                                                     breakpointMods={ [{ modifier: FlexModifiers['spacer-xl'] }] }>
-                                                    Autoreboot:&nbsp;
+                                                    Auto reboot:&nbsp;
                                                     <b>
                                                         { generateAutoRebootStatus(
                                                             remediation.auto_reboot,
@@ -277,7 +277,7 @@ const RemediationDetails = ({
                         </StackItem>
                         <StackItem className='ins-c-playbookSummary__tabs'>
                             <Tabs activeKey={ activeTabKey } onSelect={ handleTabClick }>
-                                <Tab eventKey={ 0 } title='Issues'>
+                                <Tab eventKey={ 0 } title='Actions'>
                                     <RemediationDetailsTable remediation={ remediation } status={ selectedRemediationStatus }/>
                                 </Tab>
                                 <Tab eventKey={ 1 } title='Activity'>

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -45,6 +45,7 @@ import EmptyActivityTable from '../components/EmptyStates/EmptyActivityTable';
 import { PermissionContext } from '../App';
 
 import './RemediationDetails.scss';
+import NoReceptorBanner from '../components/Alerts/NoReceptorBanner';
 
 const RemediationDetails = ({
     match,
@@ -219,6 +220,11 @@ const RemediationDetails = ({
                         { !context.hasSmartManagement && upsellBannerVisible &&
                             <StackItem>
                                 <UpsellBanner onClose={ () => handleUpsellToggle() }/>
+                            </StackItem>
+                        }
+                        { !context.isReceptorConfigured &&
+                            <StackItem>
+                                <NoReceptorBanner/>
                             </StackItem>
                         }
                         <StackItem>

--- a/src/skeletons/ActivityDetailsSkeleton.js
+++ b/src/skeletons/ActivityDetailsSkeleton.js
@@ -12,7 +12,8 @@ import {
     Card, CardHeader, CardBody,
     Stack, StackItem,
     Breadcrumb, BreadcrumbItem,
-    Split, SplitItem
+    Split, SplitItem,
+    Title
 } from '@patternfly/react-core';
 
 import DescriptionList from '../components/Layouts/DescriptionList';
@@ -55,7 +56,9 @@ const ActivityDetailsSkeleton = () => {
         <Main>
             <Stack gutter="md">
                 <Card>
-                    <CardHeader className='ins-m-card__header-bold'>Results by connection</CardHeader>
+                    <CardHeader className='ins-m-card__header-bold'>
+                        <Title headingLevel="h4" size="xl">Results by connection</Title>
+                    </CardHeader>
                     <CardBody>
                         <SkeletonTable />
                     </CardBody>

--- a/src/skeletons/ExecutorDetailsSkeleton.js
+++ b/src/skeletons/ExecutorDetailsSkeleton.js
@@ -62,7 +62,7 @@ const ExecutorDetailsSkeleton = () => {
                 <Card>
                     <CardHeader className='ins-m-card__header-bold'>
                         <Button>
-                        Download Playbook
+                        Download playbook
                         </Button>
                     </CardHeader>
 

--- a/src/skeletons/RemediationDetailsSkeleton.js
+++ b/src/skeletons/RemediationDetailsSkeleton.js
@@ -22,7 +22,8 @@ import {
     Breadcrumb, BreadcrumbItem,
     Split, SplitItem,
     Button,
-    ToolbarItem, ToolbarGroup
+    ToolbarItem, ToolbarGroup,
+    Title
 } from '@patternfly/react-core';
 
 import { isBeta } from '../config';
@@ -49,7 +50,7 @@ const RemediationDetailsSkeleton = () => {
                     </LevelItem>
                     <LevelItem>
                         <Split gutter="md">
-                            <SplitItem><Button isDisabled variant='link'> Download Playbook </Button></SplitItem>
+                            <SplitItem><Button isDisabled variant='link'> Download playbook </Button></SplitItem>
                             <SplitItem>
                                 <Dropdown
                                     toggle={ <KebabToggle isDisabled={ true } /> }
@@ -65,7 +66,9 @@ const RemediationDetailsSkeleton = () => {
                 <Stack gutter="md">
                     <StackItem>
                         <Card>
-                            <CardHeader className='ins-m-card__header-bold'>Playbook Summary</CardHeader>
+                            <CardHeader className='ins-m-card__header-bold'>
+                                <Title headingLevel="h4" size="xl">Playbook summary</Title>
+                            </CardHeader>
                             <CardBody>
                                 <Flex className='ins-c-playbookSummary' breakpointMods={ [{ modifier: FlexModifiers.column }] }>
                                     <Flex className='ins-c-playbookSummary__overview'>

--- a/src/skeletons/RemediationDetailsSkeleton.js
+++ b/src/skeletons/RemediationDetailsSkeleton.js
@@ -84,7 +84,7 @@ const RemediationDetailsSkeleton = () => {
                                     <DescriptionList className='ins-c-playbookSummary__settings' title='Playbook settings'>
                                         <Flex>
                                             <FlexItem className='ins-m-inline-flex' breakpointMods={ [{ modifier: FlexModifiers['spacer-xl'] }] }>
-                                                Autoreboot: <Skeleton className='ins-m-isInline-md' size='md'/>
+                                                Auto reboot: <Skeleton className='ins-m-isInline-md' size='md'/>
                                             </FlexItem>
                                             <FlexItem className='ins-m-inline-flex'>
                                                 <Skeleton className='ins-m-isInline-sm' size='sm'/> systems require reboot


### PR DESCRIPTION
Overall
- Playbook summary sentence case - Should be “Playbook summary” 
- Buttons should be sentence case (“Execute playbook”, “Download playbook”)

Actions
- Labels look like they are 16px, should be 14px heading label 
- Auto reboot to be 2 words
- “Issues” tab should be “Actions” to match what is shown. 
- "Remove System" Should be not red text as per UXD guidelines
- System modal align buttons to the left
- Issues table Remove action should be in a secondary button style
- activity table Spacing in the expand pane is off. 
- status tooltip says “systems” after all the numbers
- fixed floating tooltip - should be closer to the actual content. Hopefully centered on it.
- Status text should have min-width for the label so we can line up all these things (85px)
- adds a banner when receptor is not configured

Executor Details
- Label style issue on details page
- Results by connection not correct title level
- Missing a level of the breadcrumb - “Remediations” then playbook then run
- Executor Detials Header details are actually supposed to be a bit diff (Status is first, followed by “Playbook run by” and “Playbook run on”)
- Toolbar alignment all sorts of off
- Download paybook should be sentence case - “Download playbook”
- Alignment issue on tags

Playbook Log
- Missing the title on this - should have title of “Playbook log” in xl

Execute Playbook modal
- Capitalization of playbook - Should be sentence case
