### PR TITLE
Visual changes

### DIFF
--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 import { downloadPlaybook } from '../api';
-import { Button, Modal, TextContent, Text, TextVariants, Alert } from '@patternfly/react-core';
+import { Button, Modal, TextContent, Text, TextVariants, Alert, Tooltip } from '@patternfly/react-core';
 import { TableHeader, Table, TableBody, TableVariant } from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Skeleton } from '@redhat-cloud-services/frontend-components';
@@ -123,7 +123,12 @@ const ExecuteButton = ({
 
     const rows = [ ...connected, ...disconnected ].map(con =>
         ({ cells: [
-            con.executor_name || 'Direct connection',
+            {
+                title: (<Tooltip content={ `${con.executor_name}` }>
+                    <span>{ con.executor_name.length > 25 ? `${ con.executor_name.slice(0, 22)}...` : con.executor_name }</span>
+                </Tooltip> || 'Direct connection')
+
+            },
             con.system_count,
             isUserEntitled && { title: styledConnectionStatus(con.connection_status) }
         ]})

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -16,70 +16,73 @@ const styledConnectionStatus = (status) => ({
                 <CheckCircleIcon
                     className="ins-c-remediations-reboot-check-circle ins-c-remediations-connection-status"
                     aria-label="connection status" />
-            Ready
+                Ready
             </Text>
         </TextContent>),
     disconnected: (
         <TextContent>
             <Text component={ TextVariants.p }>
                 Connection issue
+                <Text component={ TextVariants.small } style={ { margin: '0px' } }>
+                    Receptor not responding
+                </Text>
+                <Button
+                    style={ { padding: '0px' } }
+                    key="troubleshoot"
+                    // eslint-disable-next-line no-console
+                    variant='link' onClick={ () => console.log('TODO: add link') }>
+                    Troubleshoot
+                </Button>
             </Text>
-            <Text component={ TextVariants.small }>
-                Receptor not responding
-            </Text>
-            <Button
-                key="troubleshoot"
-                // eslint-disable-next-line no-console
-                variant='link' onClick={ () => console.log('TODO: add link') }>
-                Troubleshoot
-            </Button>
         </TextContent>),
     no_executor: (
         <TextContent>
             <Text component={ TextVariants.p }>
-
                 Cannot remediate - Direct connection.
+                <Text component={ TextVariants.small } style={ { margin: '0px' } }>
+                    Connect your systems to Satellite to automatically remediate.
+                </Text>
+                <Button
+                    style={ { padding: '0px' } }
+                    key="download"
+                    // eslint-disable-next-line no-console
+                    variant='link' onClick={ () => console.log('TODO: add link') }>
+                    Learn how to connect
+                </Button>
             </Text>
-            <Text component={ TextVariants.small }>
-                 Connect your systems to Satellite to automatically remediate.
-            </Text>
-            <Button
-                key="download"
-                // eslint-disable-next-line no-console
-                variant='link' onClick={ () => console.log('TODO: add link') }>
-               Learn how to connect
-            </Button>
         </TextContent>),
     no_source: (<TextContent>
         <Text component={ TextVariants.p }>
             Cannot remediate - Satellite not configured
+            <Text component={ TextVariants.small } style={ { margin: '0px' } }>
+                Satellite not registered for Playbook execution
+            </Text>
+            <Button
+                style={ { padding: '0px' } }
+                key="configure"
+                // eslint-disable-next-line no-console
+                variant='link' onClick={ () => console.log('TODO: add link') }>
+                Learn how to register Satellite
+            </Button>
         </Text>
-        <Text component={ TextVariants.small }>
-           Satellite not registered for Playbook execution
-        </Text>
-        <Button
-            key="register"
-            // eslint-disable-next-line no-console
-            variant='link' onClick={ () => console.log('TODO: add link') }>
-            Learn how to register Satellite
-        </Button>
     </TextContent>),
     no_receptor: (<TextContent>
         <Text component={ TextVariants.p }>
             <ExclamationCircleIcon
-                className="ins-c-remediations-connection-status-error ins-c-remediations-connection-status"
+                className="ins-c-remediations-failure ins-c-remediations-connection-status"
                 aria-label="connection status" />
             Cannot remediate - Receptor not configured
+            <Text component={ TextVariants.small } style={ { margin: '0px' } }>
+                Configure Receptor to automatically remediate
+            </Text>
+            <Button
+                style={ { padding: '0px' } }
+                key="configure"
+                // eslint-disable-next-line no-console
+                variant='link' onClick={ () => console.log('TODO: add link') }>
+                Learn how to configure
+            </Button>
         </Text>
-        <Text component={ TextVariants.small }>
-            Configure Receptor to automatically remediate
-        </Text>
-        <Button
-            key="configure"
-            // eslint-disable-next-line no-console
-            variant='link' onClick={ () => console.log('TODO: add link') }>
-            Learn how to configure
-        </Button>
     </TextContent>)
 })[status];
 

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -124,9 +124,11 @@ const ExecuteButton = ({
     const rows = [ ...connected, ...disconnected ].map(con =>
         ({ cells: [
             {
-                title: (<Tooltip content={ `${con.executor_name}` }>
-                    <span>{ con.executor_name.length > 25 ? `${ con.executor_name.slice(0, 22)}...` : con.executor_name }</span>
-                </Tooltip> || 'Direct connection')
+                title: con.executor_name
+                    ? <Tooltip content={ `${con.executor_name}` }>
+                        <span>{ con.executor_name.length > 25 ? `${ con.executor_name.slice(0, 22)}...` : con.executor_name }</span>
+                    </Tooltip>
+                    : 'Direct connection'
 
             },
             con.system_count,

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -164,7 +164,7 @@ const ExecuteButton = ({
                     </Button>,
                     <Button
                         key="download"
-                        variant='link' onClick={ () => downloadPlaybook(remediationId) }>
+                        variant='secondary' onClick={ () => downloadPlaybook(remediationId) }>
                         Download playbook
                     </Button>,
                     (isDebug()

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -185,7 +185,7 @@ const ExecuteButton = ({
                         { isLoading
                             ? <Skeleton size='lg'/>
                             : <Text component={ TextVariants.p }>
-                                Playbook contains <b>{ `${pluralize(issueCount, 'issue')}` }</b> affecting
+                                Playbook contains <b>{ `${pluralize(issueCount, 'action')}` }</b> affecting
                                 <b>  { `${pluralize(systemCount, 'system')}.` } </b>
                             </Text> }
                         <Text component={ TextVariants.p }>

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -20,7 +20,7 @@ import {
     Breadcrumb, BreadcrumbItem,
     Split, SplitItem, ToolbarItem, ToolbarGroup
 } from '@patternfly/react-core';
-import { InProgressIcon, DownloadIcon } from '@patternfly/react-icons';
+import { InProgressIcon } from '@patternfly/react-icons';
 
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/files/Registry';
 import reducers from '../store/reducers';

--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -242,7 +242,6 @@ const ExecutorDetails = ({
                                 <ToolbarItem>
                                     <Button
                                         variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
-                                        <DownloadIcon /> { ' ' }
                                 Download playbook
                                     </Button>
                                 </ToolbarItem>
@@ -263,7 +262,7 @@ const ExecutorDetails = ({
                 <Card>
                     <CardHeader className='ins-m-card__header-bold'>
                         <Button
-                            variant='link' onClick={ () => downloadPlaybook(remediation.id) }>
+                            variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
                             Download playbook
                         </Button>
                     </CardHeader>

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -48,7 +48,7 @@ function skeleton () {
                         // <ToolbarItem><Button isDisabled> Create Remediation </Button></ToolbarItem>
                     }
                     <ToolbarItem>
-                        <Button variant='link' isDisabled> Download playbook </Button>
+                        <Button variant='secondary' isDisabled> Download playbook </Button>
                     </ToolbarItem>
                     <ToolbarItem>
                         <Dropdown

--- a/src/components/Status.scss
+++ b/src/components/Status.scss
@@ -3,3 +3,12 @@
 .ins-c-remediations-running { color: var(--pf-global--default-color--300); }
 
 td .ins-c-remediations-status-text { display: inline-block; min-width: 85px; }
+
+.ins-c-latest-activity .ins-l-description-list__description {
+    display: flex;
+    align-items: center;
+    .ins-c-latest-activity__date {
+        margin-left: 16px;
+        margin-right: 16px;
+    }
+}

--- a/src/components/SystemDetails.js
+++ b/src/components/SystemDetails.js
@@ -25,6 +25,7 @@ const PlaybookSystemDetails = ({ systemId, playbookRunSystemDetails }) => {
                 <SyntaxHighlighter
                     language="yaml"
                     showLineNumbers
+                    style={ { 'white-space': 'pre-wrap' } }
                     className={ outputClasses }>
                     { playbookRunSystemDetails && playbookRunSystemDetails.console || '' }
                 </SyntaxHighlighter>

--- a/src/components/SystemDetails.js
+++ b/src/components/SystemDetails.js
@@ -25,7 +25,6 @@ const PlaybookSystemDetails = ({ systemId, playbookRunSystemDetails }) => {
                 <SyntaxHighlighter
                     language="yaml"
                     showLineNumbers
-                    style={ { 'white-space': 'pre-wrap' } }
                     className={ outputClasses }>
                     { playbookRunSystemDetails && playbookRunSystemDetails.console || '' }
                 </SyntaxHighlighter>

--- a/src/components/SystemDetails.scss
+++ b/src/components/SystemDetails.scss
@@ -7,6 +7,7 @@
     border-color: var(--pf-global--Color--light-300);
     border-width: 2px;
     border-style: solid solid none solid;
+    white-space: pre-wrap;
 
     code {
         // style the line numbers
@@ -14,6 +15,8 @@
             padding: 8px;
             border-right: 2px solid var(--pf-global--Color--light-300);
             margin-right: 8px;
+            position: relative;
+            top: 12px;
         }
     }
 

--- a/src/components/SystemDetails.scss
+++ b/src/components/SystemDetails.scss
@@ -15,9 +15,12 @@
             padding: 8px;
             border-right: 2px solid var(--pf-global--Color--light-300);
             margin-right: 8px;
-            position: relative;
-            top: 12px;
         }
+         &:nth-of-type(2) {
+             position: relative;
+             top: 8px;
+             white-space: pre-wrap;
+         }
     }
 
     // add the border to the bottom since the spinner won't be there

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -7,7 +7,7 @@ import { downloadPlaybook } from '../api';
 import RemediationDetailsTable from '../components/RemediationDetailsTable';
 import RemediationActivityTable from '../components/RemediationActivityTable';
 import RemediationDetailsDropdown from '../components/RemediationDetailsDropdown';
-import { renderStatusIcon, normalizeStatus } from '../components/statusHelper';
+import { renderStatusIcon, normalizeStatus, StatusSummary } from '../components/statusHelper';
 import { isBeta } from '../config';
 import { ExecutePlaybookButton } from '../containers/ExecuteButtons';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
@@ -19,6 +19,7 @@ import classnames from 'classnames';
 import { capitalize } from '../Utilities/utils';
 import SkeletonTable from '../skeletons/SkeletonTable';
 import { LatestActivityPopover } from '../components/Popovers/LatestActivityPopover';
+import '../components/Status.scss';
 
 import {
     Main,
@@ -121,30 +122,30 @@ const RemediationDetails = ({
     };
 
     const renderLatestActivity = (playbookRuns) => {
-
         if (playbookRuns.length) {
-
             const mostRecent = playbookRuns[0];
-
-            return (
-                <FlexItem breakpointMods={ [{ modifier: FlexModifiers['spacer-xl'] }] }>
-                    <DescriptionList
-                        hasGutter
-                        needsPointer
-                        title='Latest activity'>
-                        <LatestActivityPopover mostRecent={ mostRecent }>
-                            <span><DateFormat type='relative' date={ mostRecent.updated_at } /></span>
-                            <Tooltip content={ <span>{ capitalize(mostRecent.status) }</span> }>
-                                { renderStatusIcon(normalizeStatus(mostRecent.status)) }
-                            </Tooltip>
-                        </LatestActivityPopover>
-                        <Link to={ `/${mostRecent.remediation_id}/${mostRecent.id}` }>View</Link>
-                    </DescriptionList>
-                </FlexItem>
-            );
+            return <FlexItem breakpointMods={ [{ modifier: FlexModifiers['spacer-xl'] }] }>
+                <DescriptionList
+                    needsPointer
+                    className='ins-c-latest-activity'
+                    title='Latest activity'>
+                    <StatusSummary
+                        executorStatus={ mostRecent.status }
+                        counts={ mostRecent.executors.reduce((acc, ex) => (
+                            {
+                                pending: acc.pending + ex.counts.pending,
+                                running: acc.running + ex.counts.running,
+                                success: acc.success + ex.counts.success,
+                                failure: acc.failure + ex.counts.failure,
+                                canceled: acc.canceled + ex.counts.canceled,
+                                acked: acc.acked + ex.counts.acked
+                            }), { pending: 0, running: 0, success: 0, failure: 0, canceled: 0, acked: 0 }) }
+                        permission={ {} } />
+                    <span className='ins-c-latest-activity__date'><DateFormat type='relative' date={ mostRecent.updated_at } /></span>
+                    <Link to={ `/${mostRecent.remediation_id}/${mostRecent.id}` }>View</Link>
+                </DescriptionList>
+            </FlexItem>;
         }
-
-        return;
     };
 
     const renderActivityState = (isEntitled, isReceptorConfigured, playbookRuns, remediation) => {
@@ -246,6 +247,7 @@ const RemediationDetails = ({
                                                 renderLatestActivity(playbookRuns)
                                             }
                                         </Flex>
+
                                         <DescriptionList className='ins-c-playbookSummary__settings' title='Playbook settings'>
                                             <Flex>
                                                 <FlexItem

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -241,10 +241,11 @@ const RemediationDetails = ({
                                                     { pluralize(totalSystems, 'system') }
                                                 </DescriptionList>
                                             </FlexItem>
-                                            { playbookRuns &&
-                                                renderLatestActivity(playbookRuns)
-                                            }
+
                                         </Flex>
+                                        { playbookRuns &&
+                                            renderLatestActivity(playbookRuns)
+                                        }
 
                                         <DescriptionList className='ins-c-playbookSummary__settings' title='Playbook settings'>
                                             <Flex>

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -7,7 +7,7 @@ import { downloadPlaybook } from '../api';
 import RemediationDetailsTable from '../components/RemediationDetailsTable';
 import RemediationActivityTable from '../components/RemediationActivityTable';
 import RemediationDetailsDropdown from '../components/RemediationDetailsDropdown';
-import { renderStatusIcon, normalizeStatus, StatusSummary } from '../components/statusHelper';
+import { normalizeStatus, StatusSummary } from '../components/statusHelper';
 import { isBeta } from '../config';
 import { ExecutePlaybookButton } from '../containers/ExecuteButtons';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
@@ -16,9 +16,7 @@ import ActivityTabUpsell from '../components/EmptyStates/ActivityTabUpsell';
 import NotConfigured from '../components/EmptyStates/NotConfigured';
 import DeniedState from '../components/DeniedState';
 import classnames from 'classnames';
-import { capitalize } from '../Utilities/utils';
 import SkeletonTable from '../skeletons/SkeletonTable';
-import { LatestActivityPopover } from '../components/Popovers/LatestActivityPopover';
 import '../components/Status.scss';
 
 import {
@@ -35,7 +33,7 @@ import {
     Button,
     Split, SplitItem,
     Flex, FlexItem, FlexModifiers,
-    Tabs, Tab, Tooltip,
+    Tabs, Tab,
     Title
 } from '@patternfly/react-core';
 

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -204,7 +204,7 @@ const RemediationDetails = ({
                                 <SplitItem>
                                     <Button
                                         isDisabled={ !remediation.issues.length }
-                                        variant='link' onClick={ () => downloadPlaybook(remediation.id) }>
+                                        variant='secondary' onClick={ () => downloadPlaybook(remediation.id) }>
                                         Download playbook
                                     </Button>
                                 </SplitItem>


### PR DESCRIPTION
Various visual/styling changes:

- Execute modal status
- Truncate Satellite names, add tooltip
- Use secondary style without icon for all Download playbook buttons
- Code view dost not break table when row is too long
- Code view line numbers match the row
- Use same status in remediation detail as used at other palces




