### PR TITLE
Pass react redux to inventory loader as well

### DIFF
--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import AwesomeDebouncePromise from 'awesome-debounce-promise';
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import {
     Main, PageHeader, PageHeaderTitle, DateFormat, Skeleton,
     ConditionalFilter, conditionalFilterType
@@ -74,6 +75,7 @@ const ExecutorDetails = ({
             mergeWithEntities,
             INVENTORY_ACTION_TYPES
         } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable

--- a/src/components/SystemForActionButton.js
+++ b/src/components/SystemForActionButton.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import { connect, useStore } from 'react-redux';
 import orderBy from 'lodash/orderBy';
 
@@ -43,6 +44,7 @@ const SystemForActionButton = ({ issue, remediation, onDelete }) => {
             mergeWithEntities,
             INVENTORY_ACTION_TYPES
         } = await insights.loadInventory({
+            ReactRedux,
             react: React,
             reactRouterDom,
             pfReactTable


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.