### PR TITLE
Adding sources and getEndpoint props to ExecuteModal call

### DIFF
--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -105,8 +105,8 @@ export const ExecuteModal = ({
 
     return (
         <Modal
-            className="ins-c-dialog"
-            variant={ ModalVariant.small }
+            className="ins-c-execute-modal"
+            variant={ isDebug() ? ModalVariant.large : ModalVariant.small }
             title={ 'Execute playbook' }
             isOpen={ isOpen }
             onClose={ onClose }

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -61,17 +61,19 @@ export const ExecuteModal = ({
             )
         }));
 
-        const [ con, dis ] = updatedData.reduce(
-            ([ pass, fail ], e) => (
-                isAvailable(e.connection_status, sources.status, sources.data[`${e.endpoint_id}`])
-                    ? [
-                        [ ...pass, { ...e }], fail ]
-                    : [ pass, [ ...fail, { ...e }] ]
-            )
-            , [ [], [] ]
-        );
-        setConnected(con);
-        setDisconnected(dis);
+        if (sources.status === 'fulfilled') {
+            const [ con, dis ] = updatedData.reduce(
+                ([ pass, fail ], e) => (
+                    isAvailable(e.connection_status, sources.status, sources.data[`${e.endpoint_id}`])
+                        ? [
+                            [ ...pass, { ...e }], fail ]
+                        : [ pass, [ ...fail, { ...e }] ]
+                )
+                , [ [], [] ]
+            );
+            setConnected(con);
+            setDisconnected(dis);
+        }
     }, [ sources ]);
 
     const rows = [ ...connected, ...disconnected ].map(con =>

--- a/src/components/Modals/ExecuteModal.scss
+++ b/src/components/Modals/ExecuteModal.scss
@@ -1,2 +1,13 @@
+@import '@patternfly/patternfly/sass-utilities/_all';
+
 .ins-c-remediations-connection-status { margin-right: var(--pf-global--spacer--xs); }
 .ins-c-remediations-connection-status-error { color: var(--pf-chart-global--danger--Color--100); }
+
+@media only screen and (max-width: $pf-global--breakpoint--sm) {
+    .pf-c-modal-box__footer {
+        flex-wrap: wrap;
+        .pf-c-button {
+            margin-bottom: var(--pf-c-modal-box__footer--c-button--MarginRight);
+        }
+    }
+}

--- a/src/components/Modals/__tests__/__snapshots__/ExecuteModal.test.js.snap
+++ b/src/components/Modals/__tests__/__snapshots__/ExecuteModal.test.js.snap
@@ -24,7 +24,7 @@ exports[`Execute modal renders ExecuteModal component when given data 1`] = `
   aria-describedby=""
   aria-label=""
   aria-labelledby=""
-  className="ins-c-dialog"
+  className="ins-c-execute-modal"
   hasNoBodyWrapper={false}
   isFooterLeftAligned={true}
   isOpen={true}
@@ -121,7 +121,7 @@ exports[`Execute modal renders ExecuteModal with refresh message when showRefres
   aria-describedby=""
   aria-label=""
   aria-labelledby=""
-  className="ins-c-dialog"
+  className="ins-c-execute-modal"
   hasNoBodyWrapper={false}
   isFooterLeftAligned={true}
   isOpen={true}

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -26,7 +26,7 @@ import * as debug from '../Utilities/debug';
 import keyBy from 'lodash/keyBy';
 
 import { downloadPlaybook } from '../api';
-import { getConnectionStatus, runRemediation, setEtag, getPlaybookRuns, loadRemediation } from '../actions';
+import { getConnectionStatus, runRemediation, setEtag, getPlaybookRuns, loadRemediation, getEndpoint } from '../actions';
 
 import { PermissionContext } from '../App';
 import { ExecuteModal } from './Modals/ExecuteModal';
@@ -123,6 +123,7 @@ function RemediationTable (props) {
     const selectedRemediation = reduxSelector(state => state.selectedRemediation);
     const connectionStatus = reduxSelector(state => state.connectionStatus);
     const runningRemediation = reduxSelector(state => state.runRemediation);
+    const sources = reduxSelector(state => state.sources);
     const dispatch = useDispatch();
 
     function loadRemediations () {
@@ -236,6 +237,8 @@ function RemediationTable (props) {
                         dispatch(runRemediation(id, etag)).then(() => dispatch(getPlaybookRuns(id)));
                     } }
                     setEtag = { (etag) => { dispatch(setEtag(etag)); } }
+                    getEndpoint = { (id) => { dispatch(getEndpoint(id)); } }
+                    sources = { sources }
                 />
             }
             <PrimaryToolbar


### PR DESCRIPTION
Was missing two props when calling ExecuteModal from RemediationTable. Also added a check to make sure that the getEndpoint action completed before attempting to read 'sources.data' from redux. When running an execute from the landing page the ExecuteModal would attempt to read sources.data[id] before sources contained any data.

@PanSpagetka Let me know if you have a problem with this approach since you're more familiar with that workflow. 