### PR TITLE
Pass pf-react-core to inventory

### DIFF
--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -8,6 +8,7 @@ import AwesomeDebouncePromise from 'awesome-debounce-promise';
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import {
     Main, PageHeader, PageHeaderTitle, DateFormat, Skeleton,
     ConditionalFilter, conditionalFilterType
@@ -78,7 +79,8 @@ const ExecutorDetails = ({
             ReactRedux,
             react: React,
             reactRouterDom,
-            pfReactTable
+            pfReactTable,
+            pfReact: reactCore
         });
 
         getRegistry().register({

--- a/src/components/SystemForActionButton.js
+++ b/src/components/SystemForActionButton.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import * as pfReactTable from '@patternfly/react-table';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import { connect, useStore } from 'react-redux';
 import orderBy from 'lodash/orderBy';
 
@@ -47,7 +48,8 @@ const SystemForActionButton = ({ issue, remediation, onDelete }) => {
             ReactRedux,
             react: React,
             reactRouterDom,
-            pfReactTable
+            pfReactTable,
+            pfReact: reactCore
         });
 
         getRegistry().register({


### PR DESCRIPTION
There is a new feature brewing in chrome, building chrome with webpack [1]. This PR passes newly required dependencies. In future we'll use Federated modules [2] so there won't be a need for these changes, but this is required as a mid-step solution.

[1] https://github.com/RedHatInsights/insights-chrome/pull/842
[2] https://webpack.js.org/concepts/module-federation/