### PR TITLE
Fixes/card selector when hiding archived

### DIFF
--- a/src/components/PlaybookCard.js
+++ b/src/components/PlaybookCard.js
@@ -211,7 +211,7 @@ export const PlaybookCard = ({
                         loadRemediation(remediation.id)
                     ], () => { setLoaded(true); }, dispatch);
                 }
-            }, 60000);
+            }, 15000);
             return () => clearInterval(interval);
         }
     }, [ poll ]);

--- a/src/components/PlaybookCard.js
+++ b/src/components/PlaybookCard.js
@@ -41,7 +41,6 @@ const PlaybookCardHeader = ({
     permission
 }) => {
     const [ isOpen, setIsOpen ] = useState(false);
-    const [ isChecked, setIsChecked ] = useState(false);
     const [ isArchived, setIsArchived ] = useState(archived);
     const dispatch = useDispatch();
     const dropdownItems = [];
@@ -129,10 +128,7 @@ const PlaybookCardHeader = ({
                     name={ `${remediation.id}-checkbox` }
                     checked={ selector.getSelectedIds().includes(remediation.id) }
                     onChange={ (e) => {
-                        setIsChecked(e.target.checked);
-                        isChecked
-                            ? selector.props.onSelect(e, false, remediationIdx)
-                            : selector.props.onSelect(e, true, remediationIdx);
+                        selector.props.onSelect(e, e.target.checked, remediationIdx);
                     } }
                     aria-label={ `${remediation.id}-checkbox` }
                 />
@@ -215,7 +211,7 @@ export const PlaybookCard = ({
                         loadRemediation(remediation.id)
                     ], () => { setLoaded(true); }, dispatch);
                 }
-            }, 15000);
+            }, 60000);
             return () => clearInterval(interval);
         }
     }, [ poll ]);

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -84,19 +84,13 @@ function RemediationTable ({
     if (!showArchived) {
         cards = value.data.reduce((result, remediation) => {
             if (remediation.archived !== true) {
-                result.push({
-                    id: remediation.id,
-                    archived: remediation.archived
-                });
+                result.push(remediation);
             }
 
             return result;
         }, []);
     } else {
-        cards = value.data.map(remediation => ({
-            id: remediation.id,
-            archived: remediation.archived
-        }));
+        cards = value.data.map(remediation => (remediation));
     }
 
     if (cards.length === 0) {
@@ -136,25 +130,23 @@ function RemediationTable ({
                 </StackItem>
                 <StackItem>
                     <Grid sm={ 12 } md={ 6 } lg={ 4 } hasGutter>
-                        { value.data.map((remediation, idx) => {
+                        { cards.map((remediation, idx) => {
                             return (
-                                !showArchived && remediation.archived
-                                    ? <React.Fragment/>
-                                    : <GridItem key={ remediation.id }>
-                                        <PlaybookCard
-                                            remediation={ remediation }
-                                            remediationIdx={ idx }
-                                            archived={ remediation.archived }
-                                            selector={ selector }
-                                            setExecuteOpen={ setExecuteOpen }
-                                            executeOpen={ executeOpen }
-                                            update={ setShouldUpdateGrid }
-                                            loadRemediation={ loadRemediation }
-                                            getConnectionStatus={ getConnectionStatus }
-                                            downloadPlaybook={ downloadPlaybook }
-                                            permission={ permission }
-                                        />
-                                    </GridItem>
+                                <GridItem key={ remediation.id }>
+                                    <PlaybookCard
+                                        remediation={ remediation }
+                                        remediationIdx={ idx }
+                                        archived={ remediation.archived }
+                                        selector={ selector }
+                                        setExecuteOpen={ setExecuteOpen }
+                                        executeOpen={ executeOpen }
+                                        update={ setShouldUpdateGrid }
+                                        loadRemediation={ loadRemediation }
+                                        getConnectionStatus={ getConnectionStatus }
+                                        downloadPlaybook={ downloadPlaybook }
+                                        permission={ permission }
+                                    />
+                                </GridItem>
                             );
                         }) }
                     </Grid>

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -139,7 +139,7 @@ function RemediationTable ({
                         { value.data.map((remediation, idx) => {
                             return (
                                 !showArchived && remediation.archived
-                                    ? null
+                                    ? <React.Fragment/>
                                     : <GridItem key={ remediation.id }>
                                         <PlaybookCard
                                             remediation={ remediation }

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -165,10 +165,12 @@ function Home () {
                                     onClick: showArchived ?
                                         () => {
                                             setShowArchived(false);
+                                            selector.reset();
                                             localStorage.setItem('remediations:showArchived', 'false');
                                         } :
                                         () => {
                                             setShowArchived(true);
+                                            selector.reset();
                                             localStorage.setItem('remediations:showArchived', 'true');
                                         }
                                 }]} }


### PR DESCRIPTION
This PR fixes a bug with the card checkboxes that appears when you hide archived playbooks. The fix is changing from rendering a null/empty react fragment to not attempting to render anything at all for archived playbooks when not showing archived.