### PR TITLE
Add important to progress display property.

### DIFF
--- a/src/components/PlaybookCard.scss
+++ b/src/components/PlaybookCard.scss
@@ -11,6 +11,7 @@
             margin-right: var(--pf-global--spacer--sm);
             position: relative;
             bottom: 2px; // because we want to have this inline with the text, we can't use flex
+            font-weight: var(--pf-global--FontWeight--normal) !important;
         }
         &--name { 
             word-break: break-word;
@@ -33,7 +34,7 @@
     }
 
     &__progress {
-        display: block;
+        display: block !important;
         --pf-c-progress__bar--before--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
         --pf-c-progress__indicator--BackgroundColor: var(--pf-global--primary-color--100);
         &--success {


### PR DESCRIPTION
task: https://projects.engineering.redhat.com/browse/RHCLOUD-8832

We are dealing with the CSS loading issue. The styles break after you open the inventory component because it adds a new style tag to the DOM head. CSS always gives priority to the last styles sheet with particular CSS rule (in this case its `.pf-c-progress` display property). The display property defined in `PlaybookCard.scss` is overridden by the default progress display property to `display: grid` which is appended by the lazy-loaded inventory component somewhere at the end of the head tag.

Unfortunately, we can't fix it inside the inventory component, because we would have to remove the style import, which would break the component styling in apps which do not add the progress styling or if its using code splitting and the browser did not load any component with the progress component in it.

Adding `!important` breaks the default rule behavior and will give priority to the last rule with `!important` flag.

@Jason-RH @ryelo @aleccohan have you noticed any other styling issues after the inventory component is loaded?

![important-card](https://user-images.githubusercontent.com/22619452/91980047-f600a900-ed26-11ea-84e6-26b11bc9adfe.gif)
