### PR TITLE
Fixes/card pagination

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,9 +1,9 @@
 import { ACTION_TYPES } from './constants';
 import { remediations, resolutions, getRemediationStatus, sources } from './api';
 
-export const loadRemediations = (sortBy = 'updated_at', sortDir = 'desc', filter, limit, offset) => ({
+export const loadRemediations = (sortBy = 'updated_at', sortDir = 'desc', filter, limit, offset, hideArchived) => ({
     type: ACTION_TYPES.LOAD_REMEDIATIONS,
-    payload: remediations.getRemediations(`${sortDir === 'desc' ? '-' : ''}${sortBy}`, filter, limit, offset)
+    payload: remediations.getRemediations(`${sortDir === 'desc' ? '-' : ''}${sortBy}`, filter, limit, offset, hideArchived)
 });
 
 export const loadRemediation = (id) => ({

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,9 +1,9 @@
 import { ACTION_TYPES } from './constants';
 import { remediations, resolutions, getRemediationStatus, sources } from './api';
 
-export const loadRemediations = (sortBy = 'updated_at', sortDir = 'desc', filter, limit, offset, hideArchived) => ({
+export const loadRemediations = (sortBy = 'updated_at', sortDir = 'desc', filter, limit, offset, system, hideArchived) => ({
     type: ACTION_TYPES.LOAD_REMEDIATIONS,
-    payload: remediations.getRemediations(`${sortDir === 'desc' ? '-' : ''}${sortBy}`, filter, limit, offset, hideArchived)
+    payload: remediations.getRemediations(`${sortDir === 'desc' ? '-' : ''}${sortBy}`, filter, limit, offset, system, hideArchived)
 });
 
 export const loadRemediation = (id) => ({

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -51,7 +51,12 @@ function RemediationTable ({
 
     function load () {
         const column = SORTING_ITERATEES[sorter.sortBy];
-        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, showArchived);
+        if (showArchived) {
+            loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset);
+        } else {
+            const hideArchived = true;
+            loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, undefined, hideArchived);
+        }
     }
 
     useEffect(() => {
@@ -72,13 +77,9 @@ function RemediationTable ({
 
     useEffect(() => {
         if (remediations.value) {
-            if (!showArchived) {
-                setRemediationCount(value.meta.total);
-            } else {
-                setRemediationCount(value.meta.total);
-            }
+            setRemediationCount(value.meta.total);
         }
-    }, [ remediations, showArchived ]);
+    }, [ remediations ]);
 
     // Skeleton Loading
     if (status !== 'fulfilled') {

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -51,7 +51,7 @@ function RemediationTable ({
 
     function load () {
         const column = SORTING_ITERATEES[sorter.sortBy];
-        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset);
+        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, showArchived);
     }
 
     useEffect(() => {
@@ -72,7 +72,11 @@ function RemediationTable ({
 
     useEffect(() => {
         if (remediations.value) {
-            setRemediationCount(cards.length);
+            if (!showArchived) {
+                setRemediationCount(value.meta.total);
+            } else {
+                setRemediationCount(value.meta.total);
+            }
         }
     }, [ remediations, showArchived ]);
 

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -61,7 +61,12 @@ function Home () {
 
     function load () {
         const column = SORTING_ITERATEES[sorter.sortBy];
-        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, showArchived);
+        if (showArchived) {
+            loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset);
+        } else {
+            const hideArchived = true;
+            loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, undefined, hideArchived);
+        }
     }
 
     useEffect(load, []);
@@ -70,7 +75,7 @@ function Home () {
         if (remediations.status === 'fulfilled' && filter.value === filterText) {
             setShouldUpdateGrid(true);
         }
-    }, [ sorter.sortBy, sorter.sortDir, filter.value, pagination.pageSize, pagination.pageDebounced ]);
+    }, [ sorter.sortBy, sorter.sortDir, filter.value, pagination.pageSize, pagination.pageDebounced, showArchived ]);
 
     useEffect(() => {
         filter.setValue(filterText);

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -61,7 +61,7 @@ function Home () {
 
     function load () {
         const column = SORTING_ITERATEES[sorter.sortBy];
-        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset);
+        loadRemediations(column, sorter.sortDir, filter.value, pagination.pageSize, pagination.offset, showArchived);
     }
 
     useEffect(load, []);


### PR DESCRIPTION
This PR adds the new 'hide_archived' query parameter to loadRemediations. This enables proper pagination values when hiding the archived playbooks