### PR TITLE
Get resolved issue count from filtered issues

### DIFF
--- a/src/components/EmptyStates/EmptyActions.js
+++ b/src/components/EmptyStates/EmptyActions.js
@@ -9,7 +9,7 @@ export const EmptyActions = (filtered) => {
     return (
         <Bullseye className='ins-c-no-actions'>
             <EmptyState>
-                { filtered === true
+                { filtered.filtered === true
                     ? <Title size="lg" headingLevel="h5">No actions found</Title>
                     : <Title size="lg" headingLevel="h5">This playbook is empty</Title> }
                 <EmptyStateBody>

--- a/src/components/RemediationSummary.js
+++ b/src/components/RemediationSummary.js
@@ -139,18 +139,7 @@ export const RemediationSummary = ({
 
     const getResolvedCount = (issues) => {
         let count = 0;
-        issues.forEach(i => {
-            let resolved = true;
-            i.systems.forEach(s => {
-                if (s.resolved === false) {
-                    resolved = false;
-                }
-            });
-            if (resolved) {
-                count = count + 1;
-            }
-        });
-
+        issues.map(i => i.systems.every(s => s.resolved) && count++);
         return count;
     };
 

--- a/src/components/RemediationSummary.js
+++ b/src/components/RemediationSummary.js
@@ -137,9 +137,28 @@ export const RemediationSummary = ({
         }
     };
 
+    const getResolvedCount = (issues) => {
+        let count = 0;
+        issues.forEach(i => {
+            let resolved = true;
+            i.systems.forEach(s => {
+                if (s.resolved === false) {
+                    resolved = false;
+                }
+            });
+            if (resolved) {
+                count = count + 1;
+            }
+        });
+
+        return count;
+    };
+
     const { stats } = remediation;
 
     const totalSystems = stats.systemsWithReboot + stats.systemsWithoutReboot;
+
+    const resolvedCount = getResolvedCount(remediation.issues);
 
     return (
         <Split>
@@ -149,10 +168,10 @@ export const RemediationSummary = ({
                     ariaTitle='Resolved issues chart'
                     constrainToVisibleArea={ true }
                     data={
-                        { x: 'Resolved', y: remediation.resolved_count / remediation.issues.length * 100 }
+                        { x: 'Resolved', y: resolvedCount / remediation.issues.length * 100 }
                     }
                     labels={ ({ data }) => data.x ? `${data.x}: ${data.y}%` : null }
-                    title={ `${remediation.resolved_count}/${remediation.issues.length}` }
+                    title={ `${resolvedCount}/${remediation.issues.length}` }
                     subTitle='Issues resolved'
                     subTitleComponent={ <ChartLabel y={ 102 } /> }
                     thresholds={ [{ value: 100, color: '#3E8635' }] }


### PR DESCRIPTION
This change allows the frontend (specifically within the chart on the details view) to calculate the number of resolved issues from a filtered list of issues. This is primarily to ensure that the number of resolved issues does not exceed the number of issues shown in the table below the chart (this could occur if you have an issue that has been resolved, but is no longer found in advisor/vulnerability/etc). Further work/design will be needed for these edge cases.