### PR TITLE
Add tooltip to disabled "Execute playbook" button

### DIFF
--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -56,7 +56,7 @@ const ExecuteButton = ({
 
   return isEnabled() ? (
     <React.Fragment>
-      {buttonWithTooltip(isDisabled)}
+      {buttonWithTooltip()}
       {open && (
         <ExecuteModal
           isOpen={open}

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -10,6 +10,7 @@ import './Status.scss';
 const ExecuteButton = ({
   isLoading,
   isDisabled,
+  disabledStateText,
   data,
   getConnectionStatus,
   remediationId,
@@ -22,19 +23,10 @@ const ExecuteButton = ({
   setEtag,
 }) => {
   const [open, setOpen] = useState(false);
-  const [isUserEntitled, setIsUserEntitled] = useState(false);
   const [showRefreshMessage, setShowRefreshMessage] = useState(false);
 
   const isEnabled = () =>
     true || localStorage.getItem('remediations:fifi:debug') === 'true';
-
-  useEffect(() => {
-    window.insights.chrome.auth
-      .getUser()
-      .then((user) =>
-        setIsUserEntitled(user.entitlements.smart_management.is_entitled)
-      );
-  }, []);
 
   useEffect(() => {
     if (remediationStatus === 'changed') {
@@ -45,12 +37,9 @@ const ExecuteButton = ({
     }
   }, [remediationStatus]);
 
-  const buttonWithTooltip = (isDisabled) => {
+  const buttonWithTooltip = () => {
     return isDisabled ? (
-      <Tooltip
-        content="Your account must be configured with Cloud Connector to execute playbooks."
-        position="auto"
-      >
+      <Tooltip content={disabledStateText} position="auto">
         <Button isAriaDisabled>Execute playbook</Button>
       </Tooltip>
     ) : (
@@ -65,7 +54,7 @@ const ExecuteButton = ({
     );
   };
 
-  return isUserEntitled && isEnabled() ? (
+  return isEnabled() ? (
     <React.Fragment>
       {buttonWithTooltip(isDisabled)}
       {open && (
@@ -102,6 +91,7 @@ ExecuteButton.propTypes = {
   etag: PropTypes.string,
   setEtag: PropTypes.func,
   isDisabled: PropTypes.bool,
+  disabledStateText: PropTypes.string,
   getEndpoint: PropTypes.func,
   sources: PropTypes.object,
 };

--- a/src/components/__tests__/__snapshots__/ExecuteButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ExecuteButton.test.js.snap
@@ -32,7 +32,25 @@ exports[`Execute button fullfiled request 1`] = `
     }
   }
   status="fullfiled"
-/>
+>
+  <Button
+    onClick={[Function]}
+  >
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary"
+      data-ouia-component-id={0}
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Execute playbook
+    </button>
+  </Button>
+</ExecuteButton>
 `;
 
 exports[`Execute button pending request 1`] = `
@@ -49,5 +67,23 @@ exports[`Execute button pending request 1`] = `
     }
   }
   status="pending"
-/>
+>
+  <Button
+    onClick={[Function]}
+  >
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary"
+      data-ouia-component-id={1}
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Execute playbook
+    </button>
+  </Button>
+</ExecuteButton>
 `;

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -88,6 +88,17 @@ const RemediationDetails = ({
     history.push(tabIndex === 1 ? '?activity' : '?issues');
   };
 
+  const getDisabledStateText = () => {
+    if (!context.isReceptorConfigured) {
+      return 'Your account must be configured with Cloud Connector to execute playbooks.';
+    } else if (!context.permissions.execute) {
+      return 'You do not have the required execute permissions to perform this action.';
+    } else if (!context.hasSmartManagement) {
+      return 'Your account must be entitled to Smart Management to execute playbooks.';
+    }
+    return 'Unable to execute playbook.';
+  };
+
   useEffect(() => {
     loadRemediation(id).catch((e) => {
       if (e && e.response && e.response.status === 404) {
@@ -188,8 +199,10 @@ const RemediationDetails = ({
                     <ExecutePlaybookButton
                       isDisabled={
                         !context.isReceptorConfigured ||
-                        !context.permissions.execute
+                        !context.permissions.execute ||
+                        !context.hasSmartManagement
                       }
+                      disabledStateText={getDisabledStateText()}
                       remediationId={remediation.id}
                     ></ExecutePlaybookButton>
                   </SplitItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10306

Added disabled state tooltip texts depending on the context:
- 'Your account must be configured with Cloud Connector to execute playbooks.'
- 'You do not have the required execute permissions to perform this action.'
- 'Your account must be entitled to Smart Management to execute playbooks.'

"Execute playbook" button is always rendered from now, also when not entitled to Smart Management.
Updated snapshots.

![Snímek obrazovky pořízený 2021-02-04 17-33-55](https://user-images.githubusercontent.com/50696716/106924774-b6901b80-670f-11eb-957f-c0e74e7764bd.png)
