### PR TITLE
Fix broken modal styling in mobile

### DIFF
--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Modal } from '@patternfly/react-core';
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import './ConfirmationDialog.scss';
 
@@ -21,7 +21,7 @@ export default function ConfirmationDialog({
         </div>
       }
       className="ins-c-dialog"
-      width={'50%'}
+      variant={ModalVariant.small}
       isOpen={isOpen}
       onClose={() => onClose(false)}
       isFooterLeftAligned

--- a/src/components/Modals/SystemsStatusModal.js
+++ b/src/components/Modals/SystemsStatusModal.js
@@ -3,7 +3,12 @@ import orderBy from 'lodash/orderBy';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
 
 import PropTypes from 'prop-types';
-import { Modal, ToolbarItem, ToolbarGroup } from '@patternfly/react-core';
+import {
+  Modal,
+  ModalVariant,
+  ToolbarItem,
+  ToolbarGroup,
+} from '@patternfly/react-core';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import {
@@ -73,7 +78,7 @@ export const SystemsStatusModal = ({
     <React.Fragment>
       <Modal
         className="ins-c-dialog"
-        width={'50%'}
+        variant={ModalVariant.small}
         title={`System${issue.systems.length > 1 ? 's' : ''} for action ${
           issue.description
         }`}


### PR DESCRIPTION
Use the Modal variant rather than a percentage so that the modal renders properly in mobile.

jira: https://issues.redhat.com/browse/RHCLOUD-13022

Before
<img width="524" alt="Screen Shot 2021-03-19 at 12 37 48 PM" src="https://user-images.githubusercontent.com/1287144/111814566-02a6b200-88b1-11eb-9e9c-f305b5c7fe22.png">

After
<img width="522" alt="Screen Shot 2021-03-19 at 12 43 13 PM" src="https://user-images.githubusercontent.com/1287144/111814567-02a6b200-88b1-11eb-8300-5018dc4436cc.png">
