### PR TITLE
Disable default columns

### DIFF
--- a/src/components/ExecutorDetails.js
+++ b/src/components/ExecutorDetails.js
@@ -159,6 +159,7 @@ const ExecutorDetails = ({
         <Card className="ins-c-card__playbook-log">
           <CardBody>
             <InventoryTable
+              disableDefaultColumns
               ref={inventory}
               onLoad={({ INVENTORY_ACTION_TYPES, mergeWithEntities }) =>
                 register({

--- a/src/components/Modals/SystemsStatusModal.js
+++ b/src/components/Modals/SystemsStatusModal.js
@@ -88,6 +88,7 @@ export const SystemsStatusModal = ({
       >
         <div className="ins-c-toolbar__filter">
           <InventoryTable
+            disableDefaultColumns
             onLoad={({ mergeWithEntities, INVENTORY_ACTION_TYPES }) =>
               getRegistry().register({
                 ...mergeWithEntities(

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -52,6 +52,7 @@ const SystemsTableWrapper = ({ remediation, registry, refreshRemediation }) => {
 
   return (
     <InventoryTable
+      disableDefaultColumns
       variant="compact"
       showTags
       noDetail


### PR DESCRIPTION
This should prevent broken columns when the updated inventory table arrives.