### PR TITLE
fix preflight modal check

### DIFF
--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -110,8 +110,8 @@ export const ExecuteModal = ({
       sources.status === 'fulfilled' &&
         sources.data[`${con.endpoint_id}`] &&
         sources.data[`${con.endpoint_id}`].availability_status_error
-    )
-  }
+    );
+  };
 
   const rows = [...connected, ...disconnected].map((con) => ({
     cells: [
@@ -130,7 +130,7 @@ export const ExecuteModal = ({
       },
       con.system_count,
       isUserEntitled && {
-        title: generateRowsStatus(con)
+        title: generateRowsStatus(con),
       },
     ],
   }));

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -62,14 +62,14 @@ export const ExecuteModal = ({
   useEffect(() => {
     const [con, dis] = data.reduce(
       ([pass, fail], e) =>
-        e.connection_status === 'connected'
-          ? [[...pass, { ...e, connection_status: 'loading' }], fail]
+        e && e.connection_status === 'connected'
+          ? [[...pass, { ...e }], fail]
           : [pass, [...fail, e]],
       [[], []]
     );
     setConnected(con);
     setDisconnected(dis);
-    con.map((c) => getEndpoint(c.endpoint_id));
+    con.map((c) => c.endpoint_id && getEndpoint(c.endpoint_id));
   }, [data]);
 
   useEffect(() => {
@@ -104,6 +104,15 @@ export const ExecuteModal = ({
     }
   }, [sources]);
 
+  const generateRowsStatus = (con) => {
+    return styledConnectionStatus(
+      con.connection_status,
+      sources.status === 'fulfilled' &&
+        sources.data[`${con.endpoint_id}`] &&
+        sources.data[`${con.endpoint_id}`].availability_status_error
+    )
+  }
+
   const rows = [...connected, ...disconnected].map((con) => ({
     cells: [
       {
@@ -121,12 +130,7 @@ export const ExecuteModal = ({
       },
       con.system_count,
       isUserEntitled && {
-        title: styledConnectionStatus(
-          con.connection_status,
-          sources.status === 'fulfilled' &&
-            sources.data[`${con.endpoint_id}`] &&
-            sources.data[`${con.endpoint_id}`].availability_status_error
-        ),
+        title: generateRowsStatus(con)
       },
     ],
   }));
@@ -138,7 +142,7 @@ export const ExecuteModal = ({
 
   return (
     <Modal
-      className="ins-c-execute-modal"
+      className="remediations ins-c-execute-modal"
       variant={isDebug() ? ModalVariant.large : ModalVariant.small}
       title={'Execute playbook'}
       isOpen={isOpen}

--- a/src/components/Modals/__tests__/__snapshots__/ExecuteModal.test.js.snap
+++ b/src/components/Modals/__tests__/__snapshots__/ExecuteModal.test.js.snap
@@ -24,7 +24,7 @@ exports[`Execute modal renders ExecuteModal component when given data 1`] = `
   aria-describedby=""
   aria-label=""
   aria-labelledby=""
-  className="ins-c-execute-modal"
+  className="remediations ins-c-execute-modal"
   hasNoBodyWrapper={false}
   isFooterLeftAligned={true}
   isOpen={true}
@@ -173,7 +173,7 @@ exports[`Execute modal renders ExecuteModal with refresh message when showRefres
   aria-describedby=""
   aria-label=""
   aria-labelledby=""
-  className="ins-c-execute-modal"
+  className="remediations ins-c-execute-modal"
   hasNoBodyWrapper={false}
   isFooterLeftAligned={true}
   isOpen={true}


### PR DESCRIPTION
Direct connection was always saying "checking", looks like the status was being set to "loading". Unsure why we were doing that, but removing it seems to fix the issue.

If there's a better way to do this because that line was needed, someone please let me know 😄 

@PanSpagetka 

This also adds the right classname to the modal so that the styles are there