### PR TITLE
Fix sorting in the Remediation wizard Inventory tables

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -408,7 +408,7 @@ export const getIssuesMultiple = (
         action: issues.find((i) => i.id === issue.id).description,
         resolution: description,
         needsReboot,
-        systems: dedupeArray([...(issue.systems || []), systems]),
+        systems: dedupeArray([...(issue.systems || []), ...systems]),
         id: issue.id,
         alternate: issueResolutions?.length - 1,
       };

--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -306,7 +306,7 @@ const sortByAttr = (systems, attribute, direction) =>
     ? systems.sort(
         (a, b) =>
           ((a[attribute] > b[attribute] && 1) || -1) *
-          (direction === 'asc' ? -1 : 1)
+          (direction === 'asc' ? 1 : -1)
       )
     : [];
 
@@ -327,10 +327,7 @@ export const fetchSystemsInfo = async (
     ? allSystemsNamed.reduce(
         (acc, curr) => [
           ...acc,
-          ...(curr.name.toLowerCase().includes(hostnameOrId) ||
-          curr.id.toLowerCase().includes(hostnameOrId)
-            ? [curr.id]
-            : []),
+          ...(curr.name.toLowerCase().includes(hostnameOrId) ? [curr.id] : []),
         ],
         []
       )

--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -301,7 +301,7 @@ export const changeBulkSelect = (state, action) => {
   };
 };
 
-const sortByAttr = (systems, attribute, direction) =>
+export const sortByAttr = (systems, attribute, direction) =>
   Array.isArray(systems)
     ? systems.sort(
         (a, b) =>

--- a/src/modules/RemediationsModal/common/SystemsTable.js
+++ b/src/modules/RemediationsModal/common/SystemsTable.js
@@ -55,12 +55,12 @@ const SystemsTable = ({
       onRefresh={(options) => inventory.current.onRefreshData(options)}
       ref={inventory}
       getEntities={(_i, config, showTags, defaultGetEntities) =>
-        fetchSystemsInfo({
-          ...config,
+        fetchSystemsInfo(
+          config,
           sortableColumns,
           allSystemsNamed,
-          defaultGetEntities,
-        })
+          defaultGetEntities
+        )
       }
       onLoad={({ mergeWithEntities, INVENTORY_ACTION_TYPES }) => {
         registry.register(

--- a/src/modules/RemediationsModal/common/SystemsTable.js
+++ b/src/modules/RemediationsModal/common/SystemsTable.js
@@ -55,7 +55,12 @@ const SystemsTable = ({
       onRefresh={(options) => inventory.current.onRefreshData(options)}
       ref={inventory}
       getEntities={(_i, config, showTags, defaultGetEntities) =>
-        fetchSystemsInfo(config, allSystemsNamed, defaultGetEntities)
+        fetchSystemsInfo({
+          ...config,
+          sortableColumns,
+          allSystemsNamed,
+          defaultGetEntities,
+        })
       }
       onLoad={({ mergeWithEntities, INVENTORY_ACTION_TYPES }) => {
         registry.register(

--- a/src/modules/RemediationsModal/common/SystemsTable.js
+++ b/src/modules/RemediationsModal/common/SystemsTable.js
@@ -19,6 +19,7 @@ const SystemsTable = ({
   bulkSelect,
 }) => {
   const inventory = useRef(null);
+  const sortableColumns = ['display_name'];
 
   return (
     <InventoryTable
@@ -28,7 +29,23 @@ const SystemsTable = ({
         stale: true,
       }}
       columns={(columns) =>
-        columns.filter((column) => !disabledColumns.includes(column.key))
+        columns.reduce(
+          (acc, curr) => [
+            ...acc,
+            ...(!disabledColumns.includes(curr.key)
+              ? [
+                  {
+                    ...curr,
+                    props: {
+                      ...(curr.props || {}),
+                      isStatic: !sortableColumns.includes(curr.key),
+                    },
+                  },
+                ]
+              : []),
+          ],
+          []
+        )
       }
       noDetail
       variant="compact"

--- a/src/modules/RemediationsModal/steps/reviewSystems.js
+++ b/src/modules/RemediationsModal/steps/reviewSystems.js
@@ -10,7 +10,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import isEqual from 'lodash/isEqual';
 import SystemsTable from '../common/SystemsTable';
-import { TOGGLE_BULK_SELECT } from '../../../Utilities/utils';
+import { dedupeArray, TOGGLE_BULK_SELECT } from '../../../Utilities/utils';
 import './reviewSystems.scss';
 
 const ReviewSystems = ({ issues, systems, allSystems, registry, ...props }) => {
@@ -32,9 +32,10 @@ const ReviewSystems = ({ issues, systems, allSystems, registry, ...props }) => {
 
   useEffect(() => {
     const value = issues?.reduce((acc, curr) => {
-      const tempSystems = [...systems, ...(curr.systems || [])].filter((id) =>
-        selected?.includes(id)
-      );
+      const tempSystems = dedupeArray([
+        ...systems,
+        ...(curr.systems || []),
+      ]).filter((id) => selected?.includes(id));
       return {
         ...acc,
         ...(tempSystems.length > 0 ? { [curr.id]: tempSystems } : {}),

--- a/src/modules/tests/utils.test.js
+++ b/src/modules/tests/utils.test.js
@@ -256,13 +256,20 @@ describe('fetchSystemsInfo', () => {
   it('should fetch systems correctly', async () => {
     const value = await fetchSystemsInfo(
       { page: 1, per_page: 1 },
+      ['display_name'],
       [{ id: '123' }, { id: '456' }],
-      (systems) => Promise.resolve({ result: systems })
+      (systems) => Promise.resolve({ results: systems })
     );
     expect(value).toEqual({
+      orderBy: undefined,
+      orderDirection: undefined,
       page: 1,
       per_page: 1,
-      result: ['123'],
+      results: ['123'],
+      sortBy: {
+        direction: undefined,
+        key: undefined,
+      },
       total: 2,
     });
   });
@@ -270,18 +277,25 @@ describe('fetchSystemsInfo', () => {
   it('should fetch filtered systems correctly', async () => {
     const value = await fetchSystemsInfo(
       { page: 1, per_page: 2, filters: { hostnameOrId: '12' } },
+      ['display_name'],
       [
         { id: '123', name: 'test' },
         { id: '456', name: 'test' },
         { id: '789', name: '12test' },
       ],
-      (systems) => Promise.resolve({ result: systems })
+      (systems) => Promise.resolve({ results: systems })
     );
     expect(value).toEqual({
+      orderBy: undefined,
+      orderDirection: undefined,
       page: 1,
       per_page: 2,
-      result: ['123', '789'],
-      total: 2,
+      results: ['789'],
+      sortBy: {
+        direction: undefined,
+        key: undefined,
+      },
+      total: 1,
     });
   });
 });

--- a/src/modules/tests/utils.test.js
+++ b/src/modules/tests/utils.test.js
@@ -2,20 +2,21 @@
 /* eslint-disable camelcase */
 import * as dependency from '../../api/index';
 import {
+  EXISTING_PLAYBOOK,
+  MANUAL_RESOLUTION,
+  SELECTED_RESOLUTIONS,
+  SYSTEMS,
+  EXISTING_PLAYBOOK_SELECTED,
   entitySelected,
   getResolution,
   changeBulkSelect,
   loadEntitiesFulfilled,
   submitRemediation,
-  EXISTING_PLAYBOOK,
-  MANUAL_RESOLUTION,
-  SELECTED_RESOLUTIONS,
-  EXISTING_PLAYBOOK_SELECTED,
   fetchSystemsInfo,
   splitArray,
   getPlaybookSystems,
   createNotification,
-  SYSTEMS,
+  sortByAttr,
 } from '../../Utilities/utils';
 import { remediationWizardTestData } from './testData';
 
@@ -249,6 +250,26 @@ describe('changeBulkSelect', () => {
       rows: [{ id: '123', selected: true }],
       selected: ['123'],
     });
+  });
+});
+
+describe('sortByAttr', () => {
+  const systems = [{ name: 'a' }, { name: 'c' }, { name: 'b' }];
+
+  it('should sort asc correctly', () => {
+    const value = sortByAttr(systems, 'name', 'asc');
+    expect(value).toEqual([{ name: 'a' }, { name: 'b' }, { name: 'c' }]);
+  });
+
+  it('should sort desc correctly', () => {
+    const systems = [{ name: 'a' }, { name: 'c' }, { name: 'b' }];
+    const value = sortByAttr(systems, 'name', 'desc');
+    expect(value).toEqual([{ name: 'c' }, { name: 'b' }, { name: 'a' }]);
+  });
+
+  it('should return an empty array on invalid value', () => {
+    const value = sortByAttr(undefined, 'name', 'desc');
+    expect(value).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-14888

- implemented local sorting by `name` for Remediation wizard InventoryTables
- hidden not possible working options
- added test coverage for the sorting helper function
- removed a bug causing wrong systems counts because of duplicates
- updated tests

![sorting](https://user-images.githubusercontent.com/50696716/128861629-d2f07fb5-f941-43c9-b4af-ec106964bd0b.png)

@karelhala 