### PR TITLE
Move onRemediationsCreated to data structure

### DIFF
--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -49,13 +49,15 @@ const RemediationButton = ({
       </Button>
       {remediationsData && (
         <RemediationWizard
-          onRemediationCreated={onRemediationCreated}
           setOpen={(isOpen) =>
             setRemediationsData((prevData) =>
               isOpen === false ? null : prevData
             )
           }
-          data={remediationsData || {}}
+          data={{
+            onRemediationCreated,
+            ...(remediationsData || {}),
+          }}
         />
       )}
     </React.Fragment>


### PR DESCRIPTION
When the remediation was created it didn't properly send `onRemediationCreated` because it was in wrong place.