### PR TITLE
Fix final step link

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -5,7 +5,6 @@ export function capitalize(string) {
 /* eslint-disable camelcase */
 import React, { Fragment } from 'react';
 import { CloseIcon, RedoIcon } from '@patternfly/react-icons';
-import urijs from 'urijs';
 import * as api from '../api';
 import uniqWith from 'lodash/uniqWith';
 import isEqual from 'lodash/isEqual';
@@ -27,22 +26,18 @@ export const ISSUES_MULTIPLE = 'issues-multiple';
 export const TOGGLE_BULK_SELECT = 'toggle-bulk-select';
 
 // Get the current group since we can be mounted at two urls
-export const getGroup = () => {
-  const pathName = window.location.pathname.split('/');
-  return pathName[1] === 'beta' ? pathName[2] : pathName[1];
-};
+export const getGroup = () =>
+  window.location.pathname
+    .split('/')
+    .filter((s) => s !== 'beta' && s.length > 0)
+    .shift();
 
 export const getEnvUrl = () => {
   const pathName = window.location.pathname.split('/');
   return pathName[1] === 'beta' ? 'beta/' : '';
 };
 
-export const remediationUrl = (id) =>
-  urijs(document.baseURI)
-    .segment(getGroup())
-    .segment('remediations')
-    .segment(id)
-    .toString();
+export const remediationUrl = (id) => `${document.baseURI}${getGroup()}/remediations${id ? `/${id}` : ''}`;
 
 export const dedupeArray = (array) => [...new Set(array)];
 

--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -37,7 +37,8 @@ export const getEnvUrl = () => {
   return pathName[1] === 'beta' ? 'beta/' : '';
 };
 
-export const remediationUrl = (id) => `${document.baseURI}${getGroup()}/remediations${id ? `/${id}` : ''}`;
+export const remediationUrl = (id) =>
+  `${document.baseURI}${getGroup()}/remediations${id ? `/${id}` : ''}`;
 
 export const dedupeArray = (array) => [...new Set(array)];
 

--- a/src/modules/RemediationsModal/steps/progress.js
+++ b/src/modules/RemediationsModal/steps/progress.js
@@ -154,11 +154,12 @@ const Progress = ({ onClose, setOpen, submitRemediation, setState, state }) => {
         {percent === 100 && (
           <Button
             variant="link"
+            component="a"
             ouiaId="OpenPlaybookButton"
+            href={remediationUrl(playbook.id)}
             onClick={() => {
               onClose();
               setOpen(false);
-              window.location.href = remediationUrl(playbook.id);
             }}
           >
             Open playbook {playbook.name}

--- a/src/modules/tests/steps/progress.test.js
+++ b/src/modules/tests/steps/progress.test.js
@@ -52,7 +52,7 @@ describe('Progress', () => {
     );
 
     wrapper
-      .find('button[data-ouia-component-id="OpenPlaybookButton"]')
+      .find('a[data-ouia-component-id="OpenPlaybookButton"]')
       .simulate('click');
     expect(onClose).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15802

### Changes
- use template string to construing the URL
- use link for the review step link (better accessibility)

The `remediationUrl` method was returning an invalid URL
1. it had multiple `/beta` segments
2. it was concatenated with `,` character instead of `/`. I don't know why yet. I've used the exact same code in codesandbox and also in the browser console and the result was correct. But when used in code, we got the mangled URL. We can spend more time debugging it, but since the issue is reproducible in prod we need a fix ASAP.