### PR TITLE
Hotfix review step by conditional inv rendering

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -5,6 +5,7 @@ export function capitalize(string) {
 /* eslint-disable camelcase */
 import React, { Fragment } from 'react';
 import { CloseIcon, RedoIcon } from '@patternfly/react-icons';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import * as api from '../api';
 import uniqWith from 'lodash/uniqWith';
 import isEqual from 'lodash/isEqual';
@@ -104,18 +105,16 @@ export const buildRows = (
             {
               parent: index * 2,
               fullWidth: true,
+              allSystemsNamed: allSystemsNamed.filter((system) =>
+                curr.systems.includes(system.id)
+              ),
+              allSystems: curr.systems,
               cells: [
                 {
                   title: (
-                    <Router>
-                      <SystemsTableWithContext
-                        allSystemsNamed={allSystemsNamed.filter((system) =>
-                          curr.systems.includes(system.id)
-                        )}
-                        allSystems={curr.systems}
-                        disabledColumns={['updated']}
-                      />
-                    </Router>
+                    <Bullseye>
+                      <Spinner />
+                    </Bullseye>
                   ),
                   props: { colSpan: 5, className: 'pf-m-no-padding' },
                 },
@@ -127,9 +126,27 @@ export const buildRows = (
     []
   );
 
+const buildSystemRow = (allSystemsNamed = [], allSystems = []) => (
+  <Router>
+    <SystemsTableWithContext
+      allSystemsNamed={allSystemsNamed}
+      allSystems={allSystems}
+      disabledColumns={['updated']}
+    />
+  </Router>
+);
+
 export const onCollapse = (event, rowKey, isOpen, rows, setRows) => {
   let temp = [...rows];
   rows[rowKey].isOpen = isOpen;
+  temp[rowKey + 1].cells = [
+    {
+      title: buildSystemRow(
+        rows[rowKey + 1].allSystemsNamed,
+        rows[rowKey + 1].allSystems
+      ),
+    },
+  ];
   setRows(temp);
 };
 

--- a/src/modules/tests/steps/review.test.js
+++ b/src/modules/tests/steps/review.test.js
@@ -98,7 +98,7 @@ describe('Review', () => {
     });
     wrapper.update();
     expect(wrapper.find('Form')).toHaveLength(1);
-    expect(wrapper.find('table')).toHaveLength(3);
+    expect(wrapper.find('table')).toHaveLength(1);
     expect(wrapper.find(BodyRow)).toHaveLength(4);
     expect(wrapper.find('button')).toHaveLength(8);
   });

--- a/src/modules/tests/steps/reviewActions.test.js
+++ b/src/modules/tests/steps/reviewActions.test.js
@@ -87,7 +87,7 @@ describe('ReviewActions', () => {
       );
     });
     expect(wrapper.find('input[type="radio"]')).toHaveLength(2);
-    expect(wrapper.find('table')).toHaveLength(2);
+    expect(wrapper.find('table')).toHaveLength(1);
     expect(wrapper.find(BodyRow)).toHaveLength(2);
   });
 


### PR DESCRIPTION
### Fix DDoS error

When navigating to review step with many systems the DDoS protection kicks in because we are rendering inventory for each collapsed row. This is not good because each inventory table performs 2 requests for chrome's fed modules. This PR fixes such issue by rendering inventory table only if row is expanded.