### PR TITLE
Substitute * in RBAC permission for Remediate button

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -427,3 +427,19 @@ export const getIssuesMultiple = (
       };
     })
     .filter((record) => record.alternate > 0);
+
+export const matchPermissions = (permissionA, permissionB) => {
+  const segmentsA = permissionA.split(':');
+  const segmentsB = permissionB.split(':');
+
+  if (segmentsA.length !== segmentsB.length) {
+    return false;
+  }
+
+  return segmentsA.every(
+    (segmentA, index) =>
+      segmentA === segmentsB[index] ||
+      segmentA === '*' ||
+      segmentsB[index] === '*'
+  );
+};

--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 import validate from './RemediationsModal/validate';
 
-import { CAN_REMEDIATE } from '../Utilities/utils';
+import { CAN_REMEDIATE, matchPermissions } from '../Utilities/utils';
 import { Button, Tooltip } from '@patternfly/react-core';
 import RemediationWizard from './RemediationsModal';
 
@@ -20,7 +20,9 @@ const RemediationButton = ({
   useEffect(() => {
     insights.chrome.getUserPermissions('remediations').then((permissions) => {
       setHasPermissions(
-        permissions.some(({ permission }) => permission === CAN_REMEDIATE)
+        permissions.some(({ permission }) =>
+          matchPermissions(permission, CAN_REMEDIATE)
+        )
       );
     });
   }, []);


### PR DESCRIPTION
Remediations here were matching permissions literally and not substituting *, which means for example when user has `remediations:*:*` permission it won't let them do the Remediate action requiring `remediations:remediation:write`, even though it should, solution is to match any substring between : to *, instead of doing whole string matching with ===

This lead to Remediation button not working when it should in Vulnerability app.