### PR TITLE
Display no data modal when no remediable issues are passed

### DIFF
--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -6,6 +6,7 @@ import validate from './RemediationsModal/validate';
 import { CAN_REMEDIATE, matchPermissions } from '../Utilities/utils';
 import { Button, Tooltip } from '@patternfly/react-core';
 import RemediationWizard from './RemediationsModal';
+import NoDataModal from './RemediationsModal/NoDataModal';
 
 const RemediationButton = ({
   isDisabled,
@@ -16,6 +17,7 @@ const RemediationButton = ({
 }) => {
   const [hasPermissions, setHasPermissions] = useState(false);
   const [remediationsData, setRemediationsData] = useState();
+  const [isNoDataModalOpen, setNoDataModalOpen] = useState(false);
 
   useEffect(() => {
     insights.chrome.getUserPermissions('remediations').then((permissions) => {
@@ -45,6 +47,11 @@ const RemediationButton = ({
         isDisabled={isDisabled}
         onClick={() => {
           Promise.resolve(dataProvider()).then((data) => {
+            if (!data) {
+              setNoDataModalOpen(true);
+              return;
+            }
+
             validate(data);
             setRemediationsData(data);
           });
@@ -53,6 +60,7 @@ const RemediationButton = ({
       >
         {children}
       </Button>
+      <NoDataModal isOpen={isNoDataModalOpen} setOpen={setNoDataModalOpen} />
       {remediationsData && (
         <RemediationWizard
           setOpen={(isOpen) =>

--- a/src/modules/RemediationsModal/NoDataModal.js
+++ b/src/modules/RemediationsModal/NoDataModal.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+
+export const NoDataModal = ({ isOpen, setOpen }) => {
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title="Remediate with Ansible"
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      actions={[
+        <Button key="confirm" variant="primary" onClick={() => setOpen(false)}>
+          Back to Insights
+        </Button>,
+      ]}
+    >
+      None of the selected issues can be remediated with Ansible.
+      <br />
+      <br />
+      To remediate these issues, review the manual remediation steps associated
+      with each.
+    </Modal>
+  );
+};
+
+NoDataModal.propTypes = {
+  isOpen: propTypes.bool,
+  setOpen: propTypes.func,
+};
+
+export default NoDataModal;


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/VULN-2041
Mockup: https://marvelapp.com/prototype/gbhbja0/screen/83265660

### Possible situations
1. User has no items selected -> Remediate button should be disabled - this is controlled by apps
2. User has selected items, but none are remediable (remediation is manual or there is none) -> Remediation button
3. User has selected items and some or all are remediable -> show Wizard and remediate normally

This PR implements situation 2.

Apps using Remediation button component are responsible for disabling/enabling the button. Apps should send `false` instead of data object, when nothing selected is remediable.

## Mockup:
![mockup](https://user-images.githubusercontent.com/8426204/154269020-254c8cae-5d49-4162-8caf-01f61c5c2c3f.png)

## Actual:
![actual](https://user-images.githubusercontent.com/8426204/154268992-453b75b5-54ac-41bd-8651-b77515eb05ed.png)