### PR TITLE
Fixed Dialog text in Remove Action

### DIFF
--- a/src/components/DeleteButton.js
+++ b/src/components/DeleteButton.js
@@ -34,6 +34,8 @@ class DeleteButton extends Component {
         </Button>
         {dialogOpen && (
           <ConfirmationDialog
+            title={this.props.dialogTitle}
+            confirmText={this.props.dialogConfirmationText}
             text={this.props.dialogMessage}
             onClose={this.onDialogClose}
           />
@@ -45,7 +47,9 @@ class DeleteButton extends Component {
 
 DeleteButton.propTypes = {
   label: PropTypes.string,
+  dialogTitle: PropTypes.string,
   dialogMessage: PropTypes.string,
+  dialogConfirmationText: PropTypes.string,
   isDisabled: PropTypes.bool,
   onDelete: PropTypes.func.isRequired,
   variant: PropTypes.string,

--- a/src/containers/DeleteButtons.js
+++ b/src/containers/DeleteButtons.js
@@ -29,6 +29,8 @@ export const DeleteActionsButton = withRouter(
   connect(
     (state, { issues }) => ({
       label: `Remove action${issues.length > 1 ? 's' : ''}`,
+      dialogTitle: 'Remove action',
+      dialogConfirmationText: 'Remove action',
     }),
     (dispatch, { remediation, issues, afterDelete }) => ({
       onDelete: async () => {


### PR DESCRIPTION
Previously the Confirmation dialog was showing wrong text when user clicked Remove Action
Fix:
![image](https://user-images.githubusercontent.com/20592948/156580767-b8e66398-5eab-4469-acff-d5fa13456317.png)
