### PR TITLE
fix: ESSNTL-2666 - added pluralization when deleting multiple actions

### DIFF
--- a/src/containers/DeleteButtons.js
+++ b/src/containers/DeleteButtons.js
@@ -29,8 +29,8 @@ export const DeleteActionsButton = withRouter(
   connect(
     (state, { issues }) => ({
       label: `Remove action${issues.length > 1 ? 's' : ''}`,
-      dialogTitle: 'Remove action',
-      dialogConfirmationText: 'Remove action',
+      dialogTitle: `Remove action${issues.length > 1 ? 's' : ''}`,
+      dialogConfirmationText: `Remove action${issues.length > 1 ? 's' : ''}`,
     }),
     (dispatch, { remediation, issues, afterDelete }) => ({
       onDelete: async () => {


### PR DESCRIPTION
[ESSNTL-2666](https://issues.redhat.com/browse/ESSNTL-2666)

When deleting multiple actions the dialog has "actions" in plural

Before:
![image](https://user-images.githubusercontent.com/20592948/163326896-2da1a781-f469-40b0-b470-60999acba6af.png)

After:
![image](https://user-images.githubusercontent.com/20592948/163326849-b8bd154c-f12f-4ead-b200-8187a1371f56.png)
