### PR TITLE
fix: ESSNTL-2827 - Playbook output has a new line for each line

### DIFF
--- a/src/components/RemediationsLogViewer.js
+++ b/src/components/RemediationsLogViewer.js
@@ -4,6 +4,9 @@ import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
 import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 const RemediationsLogViewer = ({ data }) => {
+  // New line after each line
+  data = data.replaceAll('\n', '\n\n').slice(0, -1);
+
   return (
     <LogViewer
       data={data}


### PR DESCRIPTION
[ESSNTL-2827](https://issues.redhat.com/browse/ESSNTL-2827)

Playbook output has a new line for each line

I'm not sure if this is the best way to handle this, open for suggestions

If you want to review this PR I can provide you an account with this playbook

Before:
![image](https://user-images.githubusercontent.com/20592948/174024837-e1cc7586-44aa-4beb-9f53-a49d2381fcf5.png)

After:
![image](https://user-images.githubusercontent.com/20592948/174024947-8fbb15f6-a318-4dc1-85f1-abc877fe780b.png)


