### PR TITLE
fix ExecutModal connection status

### DIFF
--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -19,8 +19,6 @@ const ExecuteButton = ({
   runRemediation,
   etag,
   remediationStatus,
-  getEndpoint,
-  sources,
   setEtag,
   setActiveAlert,
 }) => {
@@ -75,8 +73,6 @@ const ExecuteButton = ({
           issueCount={issueCount}
           runRemediation={runRemediation}
           setEtag={setEtag}
-          getEndpoint={getEndpoint}
-          sources={sources}
           setActiveAlert={setActiveAlert}
         />
       )}
@@ -97,8 +93,6 @@ ExecuteButton.propTypes = {
   setEtag: PropTypes.func,
   isDisabled: PropTypes.bool,
   disabledStateText: PropTypes.string,
-  getEndpoint: PropTypes.func,
-  sources: PropTypes.object,
   setActiveAlert: PropTypes.func,
 };
 

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -57,12 +57,14 @@ export const ExecuteModal = ({
       );
   }, []);
 
-  const combineStatuses = (status, availability) =>
-    status === 'connected'
+  const combineStatuses = (status, availability, executor_type) => {
+    //RHC hosts do not have endpoint_id to check availiabililty status.
+    return status === 'connected' && executor_type !== 'RHC'
       ? availability
         ? availability.availability_status
         : 'loading'
       : status;
+  };
 
   useEffect(() => {
     const [con, dis] = data.reduce(
@@ -78,17 +80,24 @@ export const ExecuteModal = ({
   }, [data]);
 
   useEffect(() => {
-    const isAvailable = (connectionStatus, sourcesStatus, data) =>
+    const isAvailable = (
+      connectionStatus,
+      sourcesStatus,
+      data,
+      executor_type
+    ) =>
       combineStatuses(
         connectionStatus,
-        sourcesStatus === 'fulfilled' && data
+        sourcesStatus === 'fulfilled' && data,
+        executor_type
       ) === 'available';
 
     const updatedData = data.map((e) => ({
       ...e,
       connection_status: combineStatuses(
         e.connection_status,
-        sources.status === 'fulfilled' && sources.data[`${e.endpoint_id}`]
+        sources.status === 'fulfilled' && sources.data[`${e.endpoint_id}`],
+        e.executor_type
       ),
     }));
 
@@ -98,7 +107,8 @@ export const ExecuteModal = ({
           isAvailable(
             e.connection_status,
             sources.status,
-            sources.data[`${e.endpoint_id}`]
+            sources.data[`${e.endpoint_id}`],
+            e.executor_type
           )
             ? [[...pass, { ...e }], fail]
             : [pass, [...fail, { ...e }]],

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -39,8 +39,6 @@ export const ExecuteModal = ({
   issueCount,
   runRemediation,
   etag,
-  getEndpoint,
-  sources,
   setEtag,
   setActiveAlert,
 }) => {
@@ -57,15 +55,6 @@ export const ExecuteModal = ({
       );
   }, []);
 
-  const combineStatuses = (status, availability, executor_type) => {
-    //RHC hosts do not have endpoint_id to check availiabililty status.
-    return status === 'connected' && executor_type !== 'RHC'
-      ? availability
-        ? availability.availability_status
-        : 'loading'
-      : status;
-  };
-
   useEffect(() => {
     const [con, dis] = data.reduce(
       ([pass, fail], e) =>
@@ -76,56 +65,10 @@ export const ExecuteModal = ({
     );
     setConnected(con);
     setDisconnected(dis);
-    con.map((c) => c.endpoint_id && getEndpoint(c.endpoint_id));
   }, [data]);
 
-  useEffect(() => {
-    const isAvailable = (
-      connectionStatus,
-      sourcesStatus,
-      data,
-      executor_type
-    ) =>
-      combineStatuses(
-        connectionStatus,
-        sourcesStatus === 'fulfilled' && data,
-        executor_type
-      ) === 'available';
-
-    const updatedData = data.map((e) => ({
-      ...e,
-      connection_status: combineStatuses(
-        e.connection_status,
-        sources.status === 'fulfilled' && sources.data[`${e.endpoint_id}`],
-        e.executor_type
-      ),
-    }));
-
-    if (sources.status === 'fulfilled') {
-      const [con, dis] = updatedData.reduce(
-        ([pass, fail], e) =>
-          isAvailable(
-            e.connection_status,
-            sources.status,
-            sources.data[`${e.endpoint_id}`],
-            e.executor_type
-          )
-            ? [[...pass, { ...e }], fail]
-            : [pass, [...fail, { ...e }]],
-        [[], []]
-      );
-      setConnected(con);
-      setDisconnected(dis);
-    }
-  }, [sources]);
-
   const generateRowsStatus = (con) => {
-    return styledConnectionStatus(
-      con.connection_status,
-      sources.status === 'fulfilled' &&
-        sources.data[`${con.endpoint_id}`] &&
-        sources.data[`${con.endpoint_id}`].availability_status_error
-    );
+    return styledConnectionStatus(con.connection_status);
   };
 
   const rows = [...connected, ...disconnected].map((con) => ({
@@ -365,7 +308,5 @@ ExecuteModal.propTypes = {
   runRemediation: PropTypes.func,
   etag: PropTypes.string,
   setEtag: PropTypes.func,
-  getEndpoint: PropTypes.func,
-  sources: PropTypes.object,
   setActiveAlert: PropTypes.func,
 };

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -11,7 +11,6 @@ import {
   setEtag,
   getPlaybookRuns,
   loadRemediation,
-  getEndpoint,
 } from '../actions';
 import { PermissionContext } from '../App';
 import { ExecuteModal } from './Modals/ExecuteModal';
@@ -68,7 +67,6 @@ function RemediationTable({
   );
   const connectionStatus = reduxSelector((state) => state.connectionStatus);
   const runningRemediation = reduxSelector((state) => state.runRemediation);
-  const sources = reduxSelector((state) => state.sources);
   const dispatch = useDispatch();
 
   function load() {
@@ -171,10 +169,6 @@ function RemediationTable({
               setEtag={(etag) => {
                 dispatch(setEtag(etag));
               }}
-              getEndpoint={(id) => {
-                dispatch(getEndpoint(id));
-              }}
-              sources={sources}
               activeAlert={activeToastAlert}
               setActiveAlert={setActiveToastAlert}
             />

--- a/src/components/__tests__/ExecuteButton.test.js
+++ b/src/components/__tests__/ExecuteButton.test.js
@@ -45,8 +45,6 @@ describe('Execute button', () => {
         issueCount={1}
         remediationId="id"
         isDisabled={false}
-        getEndpoint={() => null}
-        sources={{ data: {} }}
         getConnectionStatus={() => null}
       />
     );
@@ -62,7 +60,6 @@ describe('Execute button', () => {
         issueCount={1}
         remediationId="id"
         isDisabled={false}
-        sources={{ data: {} }}
         getConnectionStatus={() => null}
       />
     );

--- a/src/components/__tests__/__snapshots__/ExecuteButton.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ExecuteButton.test.js.snap
@@ -21,16 +21,10 @@ exports[`Execute button fullfiled request 1`] = `
     ]
   }
   getConnectionStatus={[Function]}
-  getEndpoint={[Function]}
   isDisabled={false}
   isLoading={true}
   issueCount={1}
   remediationId="id"
-  sources={
-    Object {
-      "data": Object {},
-    }
-  }
   status="fullfiled"
 >
   <Button
@@ -67,11 +61,6 @@ exports[`Execute button pending request 1`] = `
   isLoading={true}
   issueCount={1}
   remediationId="id"
-  sources={
-    Object {
-      "data": Object {},
-    }
-  }
   status="pending"
 >
   <Button

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -194,21 +194,9 @@ export const StatusSummary = ({
   return statusBar;
 };
 
-export const styledConnectionStatus = (status, err) =>
+export const styledConnectionStatus = (status) =>
   ({
     connected: (
-      <TextContent>
-        <Text component={TextVariants.p}>
-          <CheckCircleIcon
-            className="rem-c-reboot-check-circle rem-c-connection-status"
-            aria-label="connection status"
-          />
-          Ready
-        </Text>
-      </TextContent>
-    ),
-    // TODO: delete?
-    available: (
       <TextContent>
         <Text component={TextVariants.p}>
           <CheckCircleIcon
@@ -233,30 +221,6 @@ export const styledConnectionStatus = (status, err) =>
                     variant='link' onClick={ () => console.log('TODO: add link') }>
                     Troubleshoot
                 </Button> */}
-        </Text>
-      </TextContent>
-    ),
-    // TODO: delete?
-    unavailable: (
-      <TextContent>
-        <Text component={TextVariants.p}>
-          <ExclamationCircleIcon
-            className="rem-c-failure rem-c-connection-status"
-            aria-label="connection status"
-          />
-          Connection issue
-          <Text component={TextVariants.small} style={{ margin: '0px' }}>
-            {err ? err : 'Cloud Connector not responding'}
-          </Text>
-          <Button
-            className="pf-u-p-0"
-            key="troubleshoot"
-            // eslint-disable-next-line no-console
-            variant="link"
-            onClick={() => console.log('TODO: add link')}
-          >
-            Troubleshoot
-          </Button>
         </Text>
       </TextContent>
     ),


### PR DESCRIPTION
This PR [resolves](https://issues.redhat.com/browse/ESSNTL-1482) the connection status column on ExecuteModal.

It needs to be checked against side effects as I do not have full understanding of connection status use-cases. BUT, I have indentified that RHC hosts do not have availability info and this is breaking `combineStatuses` function result. Thus, I have introduced a single condition to prevent availability checking for RHC hosts only.

These hosts can be used to reproduce the issue, one of them is satellite and another is RHC:

1. ci-vm-10-0-147-6.hosted.upshift.rdu2.redhat.com 
2. ci-vm-10-0-152-181.hosted.upshift.rdu2.redhat.com

Also thre are three remediations for those hosts. To view them, log in to console.redhat.com as the insights-qa user, and search for the following remediations:

jaudet-muslimjon-sat
jaudet-muslimjon-rhc
jaudet-muslimjon-both
The names are indicative of which host(s) the remediations target.