### PR TITLE
fix(REMEDY-56): enable to deselect selected remediations

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,5 @@
 extends:
   - '@redhat-cloud-services/eslint-config-redhat-cloud-services'
+root: true
 globals:
   insights: readable

--- a/src/hooks/table.js
+++ b/src/hooks/table.js
@@ -167,7 +167,7 @@ function onSelectOne(selected, isSelected, id) {
   return result;
 }
 
-function onSelectAll(rows, value, isSelected, rowToId) {
+function onSelectPage(rows, value, isSelected, rowToId) {
   const rowIds = keyBy(
     filter(rows, (row) => rowToId(row)),
     rowToId
@@ -202,16 +202,24 @@ export function useSelector(rowToId = (row) => row.id) {
     },
     reset: () => setValue({}),
     props: {
-      onSelect: (unused, isSelected, index) => {
+      onSelect: (selectionType, isSelected, index) => {
         if (!rows) {
           throw new Error('register() not called on useSelector()');
         }
 
-        setValue((value) =>
-          index === -1
-            ? onSelectAll(rows, value, isSelected, rowToId)
-            : onSelectOne(value, isSelected, rowToId(rows[index]))
-        );
+        switch (selectionType) {
+          case 'none': {
+            setValue({});
+            break;
+          }
+          case 'page': {
+            setValue(onSelectPage(rows, value, isSelected, rowToId));
+            break;
+          }
+          default: {
+            setValue(onSelectOne(value, isSelected, rowToId(rows[index])));
+          }
+        }
       },
     },
     tbodyProps: {

--- a/src/hooks/table.test.js
+++ b/src/hooks/table.test.js
@@ -242,11 +242,11 @@ describe('table hooks', () => {
       const { result } = renderHook(() => useSelector());
       result.current.register(rows);
 
-      act(() => result.current.props.onSelect(undefined, true, -1));
+      act(() => result.current.props.onSelect('page', true));
       result.current.register(rows);
       expect(result.current.getSelectedIds()).toEqual(['5', '6', '7']);
 
-      act(() => result.current.props.onSelect(undefined, false, -1));
+      act(() => result.current.props.onSelect('none', false));
       result.current.register(rows);
       expect(result.current.getSelectedIds()).toEqual([]);
     });
@@ -255,7 +255,7 @@ describe('table hooks', () => {
       const { result } = renderHook(() => useSelector());
       result.current.register(rows);
 
-      act(() => result.current.props.onSelect(undefined, true, -1));
+      act(() => result.current.props.onSelect('page', true));
       result.current.register(rows);
       expect(result.current.getSelectedIds(['6'])).toEqual(['6']);
     });
@@ -264,7 +264,7 @@ describe('table hooks', () => {
       const { result } = renderHook(() => useSelector());
 
       expect(() =>
-        act(() => result.current.props.onSelect(undefined, true, 2))
+        act(() => result.current.props.onSelect('single', true, 2))
       ).toThrow('register() not called on useSelector()');
     });
   });

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -118,6 +118,7 @@ function Home() {
   const loadRemediations = (...args) =>
     dispatch(actions.loadRemediations(...args));
   const deleteRemediation = (id) => dispatch(actions.deleteRemediation(id));
+  const itemsCountInPage = remediations?.value?.data.length || 0;
 
   function load() {
     const column = SORTING_ITERATEES[sorter.sortBy];
@@ -224,8 +225,12 @@ function Home() {
                 bulkSelect={{
                   items: [
                     {
-                      title: 'Select all',
-                      onClick: (e) => selector.props.onSelect(e, true, -1),
+                      title: 'Select none',
+                      onClick: () => selector.props.onSelect('none', true),
+                    },
+                    {
+                      title: `Select page (${itemsCountInPage})`,
+                      onClick: () => selector.props.onSelect('page', true),
                     },
                   ],
                   checked:
@@ -233,8 +238,12 @@ function Home() {
                       ? null
                       : selectedIds.length,
                   count: selectedIds.length,
-                  onSelect: (isSelected, e) =>
-                    selector.props.onSelect(e, isSelected, -1),
+                  isDisabled: !itemsCountInPage,
+                  onSelect: (isSelected) =>
+                    selector.props.onSelect(
+                      selectedIds.length ? 'none' : 'page',
+                      isSelected
+                    ),
                 }}
                 actionsConfig={{
                   actions: [


### PR DESCRIPTION
This fixes: https://issues.redhat.com/browse/REMEDY-56.

Users should be able to:

1. Select page
2. Deselect all selected remediations

in remediations table. Selecting all existing remediations will be done later, when there is an API to fetch all IDs of those remediations.