### PR TITLE
fix(Progress): REMEDY-83 - Fix beta wizard links

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -37,8 +37,11 @@ export const getEnvUrl = () => {
   return pathName[1] === 'beta' ? 'beta/' : '';
 };
 
+export const getBaseUri = () =>
+  `${document.baseURI.replace('beta/', '')}${getEnvUrl()}`;
+
 export const remediationUrl = (id) =>
-  `${document.baseURI}${getGroup()}/remediations${id ? `/${id}` : ''}`;
+  `${getBaseUri()}${getGroup()}/remediations${id ? `/${id}` : ''}`;
 
 export const dedupeArray = (array) => [...new Set(array)];
 


### PR DESCRIPTION
resolves https://issues.redhat.com/browse/REMEDY-83

Actually, redirect to stable happened only after second remediation. I suspect that `href` to playbook caused `document.baseURI` to change from `https://stage.foo.redhat.com:1337/beta/` to `https://stage.foo.redhat.com:1337/`. Therefore we have to check and remove `beta/` from `document.baseURI`