### PR TITLE
[REMEDY-219] Fix remediations loading errors

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -4,19 +4,15 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { init } from './store';
 import App from './App';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 window.remReact = React;
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
-let release = '/';
-if (pathName[0] === 'beta') {
-  release = `/${pathName.shift()}/`;
-}
-
 const Remediations = ({ logger }) => (
   <Provider store={init(logger).getStore()}>
-    <Router basename={`${release}${pathName[0]}/${pathName[1]}`}>
+    <Router basename={getBaseName(window.location.pathname)}>
       <App basename={`${pathName[0]}/${pathName[1]}`} />
     </Router>
   </Provider>


### PR DESCRIPTION
To reproduce:
- Navigate to `/insights`
- Click on Remediations in the side nav (may have to do this multiple times)

This issue is intermittent. If the page loads properly, then you'll need to navigate back to `/insights` and reload the page and start the process all over again. Eventually, you'll get the errors.

You will also see this issue of you navigate to `/insights` and then click the "All apps and services" button in the header and choose "Remediations" from the "Ansible Automation Platform" section.

This PR fixes that issue.