### PR TITLE
fix(SystemsTable): REMEDY-265 - Don't set columns via redux store

### DIFF
--- a/src/components/SystemsTable/Columns.js
+++ b/src/components/SystemsTable/Columns.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import IssuesColumn from './IssuesColumn';
+import RebootColumn from './RebootColumn';
+
+export const defaultProps = {
+  isStatic: true,
+};
+
+const Issues = {
+  key: 'issues',
+  title: 'Issues',
+  // eslint-disable-next-line react/display-name
+  renderFunc: (issues, id, { display_name }) => (
+    <IssuesColumn issues={issues} id={id} display_name={display_name} />
+  ),
+  props: { width: 15 },
+};
+
+const RebootRequired = {
+  key: 'rebootRequired',
+  title: 'Reboot required',
+  // eslint-disable-next-line react/display-name
+  renderFunc: (rebootRequired) => (
+    <RebootColumn rebootRequired={rebootRequired} />
+  ),
+  props: {
+    width: 15,
+  },
+};
+
+export default ['display_name', 'tags', Issues, RebootRequired];

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -14,7 +14,10 @@ import {
   calculateChecked,
   calculateSystems,
   fetchInventoryData,
+  mergedColumns,
 } from './helpers';
+
+import columns, { defaultProps } from './Columns';
 
 const SystemsTableWrapper = ({
   remediation,
@@ -76,6 +79,7 @@ const SystemsTableWrapper = ({
       tableProps={{
         canSelectAll: false,
       }}
+      columns={mergedColumns(columns, defaultProps)}
       bulkSelect={{
         count: selected ? selected.size : 0,
         items: [

--- a/src/components/SystemsTable/helpers.js
+++ b/src/components/SystemsTable/helpers.js
@@ -58,3 +58,23 @@ export const fetchInventoryData = async (
     total: currSystems.length,
   };
 };
+
+export const mergedColumns =
+  (columns, defaultProps = {}) =>
+  (defaultColumns) =>
+    columns.map((column) => {
+      const isStringCol = typeof column === 'string';
+      const key = isStringCol ? column : column.key;
+      const defaultColumn = defaultColumns.find(
+        (defaultCol) => defaultCol.key === key
+      );
+      return {
+        ...defaultColumn,
+        ...(isStringCol ? { key: column } : column),
+        props: {
+          ...defaultColumn?.props,
+          ...column?.props,
+          ...defaultProps,
+        },
+      };
+    });

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -4,7 +4,6 @@ import { ACTION_TYPES } from '../constants';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
-import { RebootColumn, IssuesColumn } from '../components/SystemsTable';
 
 function issuesToSystemsIds(issues) {
   return uniq(
@@ -62,39 +61,6 @@ export const remediationSystems = ({ LOAD_ENTITIES_FULFILLED }) =>
           id,
           ...row,
           selected: !!state.selected?.get(id),
-        })),
-        columns: [
-          ...state.columns.filter(({ key }) =>
-            ['display_name', 'tags'].includes(key)
-          ),
-          {
-            key: 'issues',
-            title: 'Issues',
-            // eslint-disable-next-line react/display-name
-            renderFunc: (issues, id, { display_name }) => (
-              <IssuesColumn
-                issues={issues}
-                id={id}
-                display_name={display_name}
-              />
-            ),
-            props: { width: 15 },
-          },
-          {
-            key: 'rebootRequired',
-            title: 'Reboot required',
-            // eslint-disable-next-line react/display-name
-            renderFunc: (rebootRequired) => (
-              <RebootColumn rebootRequired={rebootRequired} />
-            ),
-            props: { width: 15 },
-          },
-        ].map((cell) => ({
-          ...cell,
-          props: {
-            ...(cell.props || {}),
-            isStatic: true,
-          },
         })),
       };
     },


### PR DESCRIPTION
When opening the Remediations app, and navigate to the "Systems" tab the loading of the Inventory Table will fail without this fix, as it tried to use the columns in the Inventory redux store that have been removed.