### PR TITLE
[REMEDY-219] Fix new loading issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,9 +57,7 @@ class App extends Component {
     );
     this.unregister = insights.chrome.on('APP_NAVIGATION', (event) => {
       if (typeof event?.domEvent?.href === 'string') {
-        this.props.history.push(
-          event.domEvent.href.replace(this.props.basename, '')
-        );
+        this.props.history.push('/');
       }
     });
     window.insights.chrome
@@ -123,7 +121,6 @@ class App extends Component {
 
 App.propTypes = {
   history: PropTypes.object,
-  basename: PropTypes.string.isRequired,
 };
 
 /**

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -13,7 +13,7 @@ pathName.shift();
 const Remediations = ({ logger }) => (
   <Provider store={init(logger).getStore()}>
     <Router basename={getBaseName(window.location.pathname)}>
-      <App basename={`${pathName[0]}/${pathName[1]}`} />
+      <App />
     </Router>
   </Provider>
 );


### PR DESCRIPTION
To reproduce the bug:
- Navigate to /insights
- Click Toolkit -> Remediations in the side nave
- After the page loads, click Remediations in the side nave again

It is an intermittent error, and sometimes I have to try it 6 or 7 times to get it to error, but it does eventually do it. This should be fixed.