### PR TITLE
fix(InventoryColumns): use one custom columns array to merge with inventory default columns

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -29,7 +29,7 @@ const insightsProxy = {
 const webpackProxy = {
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   useProxy: true,
-  env: process.env.CHROME_ENV ? process.env.CHROME_ENV : 'stage-stable',
+  env: 'prod-stable', //process.env.CHROME_ENV ? process.env.CHROME_ENV : 'stage-stable',
   appUrl: process.env.BETA
     ? ['/beta/insights/remediations']
     : ['/insights/remediations'],

--- a/src/components/ExecutorDetails/Columns.js
+++ b/src/components/ExecutorDetails/Columns.js
@@ -11,7 +11,9 @@ export default [
     // eslint-disable-next-line
     renderFunc: (name, id, { fqdn }) => <div><a href={urlBuilder(id)}>{fqdn || name || id}</a></div>
   },
-  'tags',
+  {
+    key: 'tags',
+  },
   {
     key: 'status',
     title: 'Status',

--- a/src/components/ExecutorDetails/ExecutorDetails.js
+++ b/src/components/ExecutorDetails/ExecutorDetails.js
@@ -160,7 +160,9 @@ const ExecutorDetails = ({
           <CardBody>
             <InventoryTable
               ref={inventory}
-              columns={mergedColumns(columns)}
+              columns={(defaultColumns) =>
+                mergedColumns(defaultColumns, columns)
+              }
               onLoad={({ INVENTORY_ACTION_TYPES, mergeWithEntities }) =>
                 register({
                   ...mergeWithEntities(

--- a/src/components/SystemsTable/Columns.js
+++ b/src/components/SystemsTable/Columns.js
@@ -2,31 +2,38 @@ import React from 'react';
 import IssuesColumn from './IssuesColumn';
 import RebootColumn from './RebootColumn';
 
-const Issues = {
-  key: 'issues',
-  title: 'Issues',
-  // eslint-disable-next-line react/display-name
-  renderFunc: (issues, id, { display_name }) => (
-    <IssuesColumn issues={issues} id={id} display_name={display_name} />
-  ),
-  props: {
-    width: 15,
-    isStatic: true,
+export default [
+  {
+    key: 'display_name',
   },
-};
-
-const RebootRequired = {
-  key: 'rebootRequired',
-  title: 'Reboot required',
-  // eslint-disable-next-line react/display-name
-  renderFunc: (rebootRequired) => (
-    <RebootColumn rebootRequired={rebootRequired} />
-  ),
-  props: {
-    width: 15,
-    isStatic: true,
+  {
+    key: 'tags',
   },
-};
-
-export const inventoryColumns = ['display_name', 'tags', 'system_profile'];
-export default [Issues, RebootRequired];
+  {
+    key: 'system_profile',
+  },
+  {
+    key: 'issues',
+    title: 'Issues',
+    // eslint-disable-next-line react/display-name
+    renderFunc: (issues, id, { display_name }) => (
+      <IssuesColumn issues={issues} id={id} display_name={display_name} />
+    ),
+    props: {
+      width: 15,
+      isStatic: true,
+    },
+  },
+  {
+    key: 'rebootRequired',
+    title: 'Reboot required',
+    // eslint-disable-next-line react/display-name
+    renderFunc: (rebootRequired) => (
+      <RebootColumn rebootRequired={rebootRequired} />
+    ),
+    props: {
+      width: 15,
+      isStatic: true,
+    },
+  },
+];

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -16,6 +16,7 @@ import {
   fetchInventoryData,
   mergedColumns,
 } from './helpers';
+import systemsColumns from './Columns';
 
 const SystemsTableWrapper = ({
   remediation,
@@ -77,7 +78,9 @@ const SystemsTableWrapper = ({
       tableProps={{
         canSelectAll: false,
       }}
-      columns={(defaultColumns) => mergedColumns(defaultColumns)}
+      columns={(defaultColumns) =>
+        mergedColumns(defaultColumns, systemsColumns)
+      }
       bulkSelect={{
         count: selected ? selected.size : 0,
         items: [

--- a/src/components/SystemsTable/helpers.js
+++ b/src/components/SystemsTable/helpers.js
@@ -1,5 +1,3 @@
-import remediationColumns, { inventoryColumns } from './Columns';
-
 export const calculateChecked = (rows = [], selected) =>
   rows.every(({ id }) => selected?.has(id))
     ? rows.length > 0
@@ -63,9 +61,12 @@ export const fetchInventoryData = async (
   };
 };
 
-export const mergedColumns = (defaultColumns) => {
-  return [
-    ...defaultColumns.filter((column) => inventoryColumns.includes(column.key)),
-    ...remediationColumns,
-  ];
+export const mergedColumns = (defaultColumns = [], customColumns = []) => {
+  return customColumns.map((column) => {
+    const inventoryColumn = defaultColumns.find(
+      (invColumn) => invColumn.key === column.key
+    );
+
+    return inventoryColumn || column;
+  });
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

This resolves the regression on the Executor details page. The regression was caused while resolving REMEDY-277. It appears that Executor details page also uses the mergedColumns function with the obsolete column merging logic. This PR updates the usage of the mergedColumn function to be compatible for both pages. The regression is only on stage env.

# How to test the PR
1. Run the PR against prod env. The dev-webpack.config is prepared for running the PR agains PROD, once approved I will remove this.
2. search for playbook 'mkholjur-test-search'
3. click on the activities tab
4. open one activity detail
5. Observe that the inventory module does not fail to load.


# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
