### PR TITLE
fix(detailsTable): bulk select fix

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -29,7 +29,7 @@ const insightsProxy = {
 const webpackProxy = {
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   useProxy: true,
-  env: 'prod-stable', //process.env.CHROME_ENV ? process.env.CHROME_ENV : 'stage-stable',
+  env: process.env.CHROME_ENV ? process.env.CHROME_ENV : 'stage-stable',
   appUrl: process.env.BETA
     ? ['/beta/insights/remediations']
     : ['/insights/remediations'],

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -223,22 +223,22 @@ function RemediationDetailsTable(props) {
             },
             rows.length > 0
               ? {
-                  title: `Select page (${rows.length})`,
+                  title: `Select page (${rows?.length})`,
                   onClick: () => {
                     bulkSelectCheck(rows).length === 0
                       ? selector.props.onSelect('page', true, 0)
                       : rows.length === bulkSelectCheck(rows).length
                       ? selector.props.onSelect('page', false, 0)
-                      : selector.props.onSelect('page', false, 0);
+                      : selector.props.onSelect('page', true, 0);
                   },
                 }
               : {},
             rows.length > 0
               ? {
-                  title: `Select all (${props.remediation.issues.length})`,
+                  title: `Select all (${props?.remediation?.issues.length})`,
                   onClick: () => {
-                    selector.register(props.remediation.issues);
-                    selectedIds.length < props.remediation.issues.length
+                    selector.register(props?.remediation.issues);
+                    selectedIds?.length < props?.remediation?.issues.length
                       ? selector.props.onSelect('page', true, 0)
                       : selector.props.onSelect('page', false, 0);
                   },
@@ -253,7 +253,7 @@ function RemediationDetailsTable(props) {
           onSelect: () => {
             bulkSelectCheck(rows).length === 0
               ? selector.props.onSelect('page', true, 0)
-              : selector.props.onSelect('none');
+              : selector.props.onSelect('page', false, 0);
           },
         }}
         actionsConfig={{

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -212,6 +212,13 @@ function RemediationDetailsTable(props) {
         }}
         bulkSelect={{
           items: [
+            {
+              title: 'Select none (0)',
+              onClick: () => {
+                bulkSelectChecked ? setBulkSelectChecked(false) : true;
+                selector.props.onSelect('none');
+              },
+            },
             rows.length > 0
               ? {
                   title: `Select page (${rows.length})`,
@@ -221,13 +228,6 @@ function RemediationDetailsTable(props) {
                   },
                 }
               : {},
-            {
-              title: 'Select none (0)',
-              onClick: () => {
-                setBulkSelectChecked((prev) => !prev);
-                selector.props.onSelect('none');
-              },
-            },
           ],
           checked: bulkSelectChecked,
           count: selectedIds.length,

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -152,6 +152,7 @@ function RemediationDetailsTable(props) {
   const { setActiveAlert } = props;
   const permission = useContext(PermissionContext);
   const [filterText, setFilterText] = useState('');
+  const [bulkSelectChecked, setBulkSelectChecked] = useState(false);
   const [prevRemediationsCount, setPrevRemediationsCount] = useState(0); // eslint-disable-line
 
   useEffect(() => {
@@ -211,22 +212,31 @@ function RemediationDetailsTable(props) {
         }}
         bulkSelect={{
           items: [
+            rows.length > 0
+              ? {
+                  title: `Select page (${rows.length})`,
+                  onClick: () => {
+                    setBulkSelectChecked((prev) => !prev);
+                    selector.props.onSelect('page', true, 0);
+                  },
+                }
+              : {},
             {
-              title: 'Select all',
-              onClick: () => selector.props.onSelect('page', true, 0),
-            },
-            {
-              title: 'Select none',
-              onClick: () => selector.props.onSelect('none'),
+              title: 'Select none (0)',
+              onClick: () => {
+                setBulkSelectChecked((prev) => !prev);
+                selector.props.onSelect('none');
+              },
             },
           ],
-          checked:
-            selectedIds.length && filtered.length > selectedIds.length
-              ? null
-              : selectedIds.length,
+          checked: bulkSelectChecked,
           count: selectedIds.length,
-          onSelect: (isSelected, e) =>
-            selector.props.onSelect(e, isSelected, -1),
+          onSelect: () => {
+            setBulkSelectChecked((prev) => !prev);
+            !bulkSelectChecked
+              ? selector.props.onSelect('page', true, 0)
+              : selector.props.onSelect('none');
+          },
         }}
         actionsConfig={{
           actions: [

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -211,6 +211,7 @@ function RemediationDetailsTable(props) {
           ],
         }}
         bulkSelect={{
+          isDisabled: rows ? false : true,
           items: [
             {
               title: 'Select none (0)',
@@ -224,12 +225,29 @@ function RemediationDetailsTable(props) {
                   title: `Select page (${rows.length})`,
                   onClick: () => {
                     setBulkSelectChecked((prev) => !prev);
-                    selector.props.onSelect('page', true, 0);
+                    !bulkSelectChecked
+                      ? selector.props.onSelect('page', true, 0)
+                      : selector.props.onSelect('page', false, 0);
+                  },
+                }
+              : {},
+            rows.length > 0
+              ? {
+                  title: `Select all (${props.remediation.issues.length})`,
+                  onClick: () => {
+                    setBulkSelectChecked((prev) => !prev);
+                    selector.register(props.remediation.issues);
+                    !bulkSelectChecked
+                      ? selector.props.onSelect('page', true, 0)
+                      : selector.props.onSelect('page', false, 0);
                   },
                 }
               : {},
           ],
-          checked: bulkSelectChecked,
+          checked:
+            selectedIds.length && filtered.length > selectedIds.length
+              ? null
+              : selectedIds.length,
           count: selectedIds.length,
           onSelect: () => {
             setBulkSelectChecked((prev) => !prev);

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -152,9 +152,7 @@ function RemediationDetailsTable(props) {
   const { setActiveAlert } = props;
   const permission = useContext(PermissionContext);
   const [filterText, setFilterText] = useState('');
-  const [bulkSelectChecked, setBulkSelectChecked] = useState(false);
   const [prevRemediationsCount, setPrevRemediationsCount] = useState(0); // eslint-disable-line
-
   useEffect(() => {
     filter.setValue(filterText);
   }, [filterText]);
@@ -190,6 +188,10 @@ function RemediationDetailsTable(props) {
     },
   };
 
+  const bulkSelectCheck = (data) => {
+    return data?.filter((action) => action.selected === true);
+  };
+
   return (
     <div className="test">
       <PrimaryToolbar
@@ -216,7 +218,6 @@ function RemediationDetailsTable(props) {
             {
               title: 'Select none (0)',
               onClick: () => {
-                bulkSelectChecked ? setBulkSelectChecked(false) : true;
                 selector.props.onSelect('none');
               },
             },
@@ -224,9 +225,10 @@ function RemediationDetailsTable(props) {
               ? {
                   title: `Select page (${rows.length})`,
                   onClick: () => {
-                    setBulkSelectChecked((prev) => !prev);
-                    !bulkSelectChecked
+                    bulkSelectCheck(rows).length === 0
                       ? selector.props.onSelect('page', true, 0)
+                      : rows.length === bulkSelectCheck(rows).length
+                      ? selector.props.onSelect('page', false, 0)
                       : selector.props.onSelect('page', false, 0);
                   },
                 }
@@ -235,9 +237,8 @@ function RemediationDetailsTable(props) {
               ? {
                   title: `Select all (${props.remediation.issues.length})`,
                   onClick: () => {
-                    setBulkSelectChecked((prev) => !prev);
                     selector.register(props.remediation.issues);
-                    !bulkSelectChecked
+                    selectedIds.length < props.remediation.issues.length
                       ? selector.props.onSelect('page', true, 0)
                       : selector.props.onSelect('page', false, 0);
                   },
@@ -250,8 +251,7 @@ function RemediationDetailsTable(props) {
               : selectedIds.length,
           count: selectedIds.length,
           onSelect: () => {
-            setBulkSelectChecked((prev) => !prev);
-            !bulkSelectChecked
+            bulkSelectCheck(rows).length === 0
               ? selector.props.onSelect('page', true, 0)
               : selector.props.onSelect('none');
           },

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -10,7 +10,12 @@ import { deleteSystems, selectEntity, loadRemediation } from '../../actions';
 import './SystemsTable.scss';
 import RemoveSystemModal from './RemoveSystemModal';
 import { generateUniqueId } from '../Alerts/PlaybookToastAlerts';
-import { calculateSystems, fetchInventoryData, mergedColumns } from './helpers';
+import {
+  calculateSystems,
+  fetchInventoryData,
+  mergedColumns,
+  calculateChecked,
+} from './helpers';
 import systemsColumns from './Columns';
 
 const SystemsTableWrapper = ({
@@ -77,6 +82,7 @@ const SystemsTableWrapper = ({
         mergedColumns(defaultColumns, systemsColumns)
       }
       bulkSelect={{
+        isDisabled: rows ? false : true,
         count: selected ? selected.size : 0,
         items: [
           {
@@ -92,13 +98,32 @@ const SystemsTableWrapper = ({
                   title: `Select page (${rows.length})`,
                   onClick: () => {
                     setBulkSelectChecked((prev) => !prev);
-                    dispatch(selectEntity(0, true));
+                    !bulkSelectChecked
+                      ? dispatch(selectEntity(0, true))
+                      : dispatch(selectEntity(0, false));
+                  },
+                }
+              : {}),
+          },
+          {
+            ...(loaded && rows && rows.length > 0
+              ? {
+                  title: `Select all (${systemsRef.current.length})`,
+                  onClick: () => {
+                    setBulkSelectChecked((prev) => !prev);
+                    !bulkSelectChecked
+                      ? systemsRef.current.map((system) =>
+                          dispatch(selectEntity(system.id, true))
+                        )
+                      : systemsRef.current.map((system) =>
+                          dispatch(selectEntity(system.id, false))
+                        );
                   },
                 }
               : {}),
           },
         ],
-        checked: bulkSelectChecked,
+        checked: calculateChecked(systemsRef.current, selected),
         onSelect: (value) => {
           dispatch(selectEntity(0, value));
           setBulkSelectChecked((prev) => !prev);

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -75,7 +75,7 @@ const SystemsTableWrapper = ({
       case 'page':
         dispatch(selectEntity(0, true));
         break;
-      case 'unselect page':
+      case 'deselect page':
         rows.map(() => dispatch(selectEntity(0, false)));
         break;
       case 'all':
@@ -83,7 +83,7 @@ const SystemsTableWrapper = ({
           dispatch(selectEntity(system.id, true))
         );
         break;
-      case 'unselect all':
+      case 'deselect all':
         systemsRef.current.map((system) =>
           dispatch(selectEntity(system.id, false))
         );
@@ -124,11 +124,11 @@ const SystemsTableWrapper = ({
                   onClick: () => {
                     !selected //if nothing is selected - select the page
                       ? bulkSelectorSwitch('page')
-                      : bulkSelectCheck(rows).length === rows.length //it compares the selected rows to the total selected values so you can unselect the page
-                      ? bulkSelectorSwitch('unselect page')
+                      : bulkSelectCheck(rows).length === rows.length //it compares the selected rows to the total selected values so you can deselect the page
+                      ? bulkSelectorSwitch('deselect page')
                       : systemsRef.current.length > selected.size //it compares the total amount of rows to the selected values, so you can select additional page
                       ? bulkSelectorSwitch('page')
-                      : bulkSelectorSwitch('unselect page');
+                      : bulkSelectorSwitch('deselect page');
                   },
                 }
               : {}),
@@ -139,7 +139,7 @@ const SystemsTableWrapper = ({
                   title: `Select all (${systemsRef.current.length})`,
                   onClick: () => {
                     calculateChecked(systemsRef.current, selected)
-                      ? bulkSelectorSwitch('unselect all')
+                      ? bulkSelectorSwitch('deselect all')
                       : bulkSelectorSwitch('all');
                   },
                 }
@@ -149,7 +149,7 @@ const SystemsTableWrapper = ({
         checked: calculateChecked(systemsRef.current, selected),
         onSelect: () => {
           bulkSelectCheck(rows).length === rows.length
-            ? bulkSelectorSwitch('unselect page')
+            ? bulkSelectorSwitch('deselect page')
             : bulkSelectorSwitch('page');
         },
       }}

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -65,7 +65,7 @@ const SystemsTableWrapper = ({
   const bulkSelectCheck = (data) => {
     return data?.filter((system) => system.selected === true);
   };
-  const checkBoxValidator = (selection) => {
+  const bulkSelectorSwitch = (selection) => {
     switch (selection) {
       case 'none':
         systemsRef.current.map((system) =>
@@ -115,20 +115,20 @@ const SystemsTableWrapper = ({
         items: [
           {
             title: 'Select none (0)',
-            onClick: () => checkBoxValidator('none'),
+            onClick: () => bulkSelectorSwitch('none'),
           },
           {
             ...(loaded && rows && rows.length > 0
               ? {
                   title: `Select page (${rows.length})`,
                   onClick: () => {
-                    calculateChecked(systemsRef.current, selected) === false //if nothing is selected - selected the page
-                      ? checkBoxValidator('page')
+                    !selected //if nothing is selected - select the page
+                      ? bulkSelectorSwitch('page')
                       : bulkSelectCheck(rows).length === rows.length //it compares the selected rows to the total selected values so you can unselect the page
-                      ? checkBoxValidator('unselect page')
+                      ? bulkSelectorSwitch('unselect page')
                       : systemsRef.current.length > selected.size //it compares the total amount of rows to the selected values, so you can select additional page
-                      ? checkBoxValidator('page')
-                      : checkBoxValidator('unselect page');
+                      ? bulkSelectorSwitch('page')
+                      : bulkSelectorSwitch('unselect page');
                   },
                 }
               : {}),
@@ -139,16 +139,18 @@ const SystemsTableWrapper = ({
                   title: `Select all (${systemsRef.current.length})`,
                   onClick: () => {
                     calculateChecked(systemsRef.current, selected)
-                      ? checkBoxValidator('unselect all')
-                      : checkBoxValidator('all');
+                      ? bulkSelectorSwitch('unselect all')
+                      : bulkSelectorSwitch('all');
                   },
                 }
               : {}),
           },
         ],
         checked: calculateChecked(systemsRef.current, selected),
-        onSelect: (value) => {
-          dispatch(selectEntity(0, value));
+        onSelect: () => {
+          bulkSelectCheck(rows).length === rows.length
+            ? bulkSelectorSwitch('unselect page')
+            : bulkSelectorSwitch('page');
         },
       }}
       getEntities={async (_i, config) =>

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -10,12 +10,7 @@ import { deleteSystems, selectEntity, loadRemediation } from '../../actions';
 import './SystemsTable.scss';
 import RemoveSystemModal from './RemoveSystemModal';
 import { generateUniqueId } from '../Alerts/PlaybookToastAlerts';
-import {
-  calculateChecked,
-  calculateSystems,
-  fetchInventoryData,
-  mergedColumns,
-} from './helpers';
+import { calculateSystems, fetchInventoryData, mergedColumns } from './helpers';
 
 import columns, { defaultProps } from './Columns';
 
@@ -35,7 +30,7 @@ const SystemsTableWrapper = ({
   );
   const loaded = useSelector(({ entities }) => entities?.loaded);
   const rows = useSelector(({ entities }) => entities?.rows);
-
+  const [bulkSelectChecked, setBulkSelectChecked] = useState(false);
   const onConfirm = () => {
     (async () => {
       const selectedSystems =
@@ -100,9 +95,10 @@ const SystemsTableWrapper = ({
               : {}),
           },
         ],
-        checked: calculateChecked(rows, selected),
+        checked: bulkSelectChecked,
         onSelect: (value) => {
           dispatch(selectEntity(0, value));
+          setBulkSelectChecked((prev) => !prev);
         },
       }}
       getEntities={async (_i, config) =>

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -11,8 +11,7 @@ import './SystemsTable.scss';
 import RemoveSystemModal from './RemoveSystemModal';
 import { generateUniqueId } from '../Alerts/PlaybookToastAlerts';
 import { calculateSystems, fetchInventoryData, mergedColumns } from './helpers';
-
-import columns, { defaultProps } from './Columns';
+import systemsColumns from './Columns';
 
 const SystemsTableWrapper = ({
   remediation,
@@ -83,6 +82,7 @@ const SystemsTableWrapper = ({
           {
             title: 'Select none (0)',
             onClick: () => {
+              bulkSelectChecked ? setBulkSelectChecked(false) : true;
               dispatch(selectEntity(-1, false));
             },
           },
@@ -91,6 +91,7 @@ const SystemsTableWrapper = ({
               ? {
                   title: `Select page (${rows.length})`,
                   onClick: () => {
+                    setBulkSelectChecked((prev) => !prev);
                     dispatch(selectEntity(0, true));
                   },
                 }


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)
Fixing bulk select in Actions and Systems tab
https://issues.redhat.com/browse/REMEDY-283
https://issues.redhat.com/browse/REMEDY-145
https://issues.redhat.com/browse/REMEDY-90

Please include a summary of the change, what this fixes/creates/improves.
I added 2 buttons:
**Select page (number of rows)
Select all (number of values in the entire table)**
I improved the behavior of the select page buttons

**Behavior**: User has a list of things, 10 per page, 5 pages (50 items total):
First page - “Select page” --> 10 items selected
Nav to second page - “Select page” --> 20 items selected (adds to the selection)
Nav to third page - "Select page" --> 30 items selected (adds to the selection)
To unselect the third page -> "Select page" --> 20 items selected (takes out 10 - the page - from the selection)
Nav to the fourth page - “Select all” --> 50 items selected (all selected)
User chooses “Select none” --> Everything deselected, 0 items selected
User selects a single item --> 1 item selected
User goes back to page 2, chooses “Select page” --> page 2 is selected & that one item from page, 11 items total


This is a diagram for the select page button in Systems tab so you could understand it better
![image](https://user-images.githubusercontent.com/62722417/213154476-362d7f81-5f59-42ad-8956-653b76e0ad61.png)

This is a diagram for the select page button in Actions tab
![image](https://user-images.githubusercontent.com/62722417/213429985-afc05c08-f0f2-4a77-9ad6-ed3bf685d3af.png)

# How to test the PR
Find remediation with the name "voznesenskii test" to test systems tab.
Find remediation with the name "test-patch" to test actions tab.
Open the local dev environment, go to the /insights/remediations and find remediation with several systems
Open the table and check bulk select in the Actions tab and Activity tab.

What to check:
The dropdown should be disabled when there are no systems/actions to show. 
The dropdown should be enabled when there are systems/actions to show.
If you select the number of values < than the whole table the check mark should look like a - symbol
![image](https://user-images.githubusercontent.com/62722417/212057467-665175f7-eef0-4c2e-9419-96a7462f462c.png)

If you select the number of values = to the amount of values in the entire table the check mark should look like this 
![image](https://user-images.githubusercontent.com/62722417/212065791-6016a301-b9d2-4844-a1d5-d53bd021b6d9.png)

# Before the change
There were no select all button

# After the change
![image](https://user-images.githubusercontent.com/62722417/212066852-9e34c49e-f914-4166-b880-059df02021de.png)




# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
