### PR TITLE
fix(ADVISOR-3053): remove obsole onRefresh prop

### DIFF
--- a/src/modules/RemediationsModal/common/SystemsTable.js
+++ b/src/modules/RemediationsModal/common/SystemsTable.js
@@ -52,7 +52,6 @@ const SystemsTable = ({
       hasCheckbox={hasCheckbox}
       showTags
       bulkSelect={bulkSelect}
-      onRefresh={(options) => inventory.current.onRefreshData(options)}
       ref={inventory}
       getEntities={(_i, config, showTags, defaultGetEntities) =>
         fetchSystemsInfo(


### PR DESCRIPTION
# Description

Associated Jira ticket: # https://issues.redhat.com/browse/ADVISOR-3053

After Inventory onRefresh caches the options passed and prevents successive function triggers
 with the same options, we need to remove this obsolete prop.

# How to test the PR

Run the remediation app with any app that you are comfortable with and open the remediation modal. When you go to the 'Review systems' step, observe that the table loads as expected.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
