### PR TITLE
fix(REMEDY-360): Use correct status icon in review Actions

### DIFF
--- a/src/components/SystemsTable/Columns.js
+++ b/src/components/SystemsTable/Columns.js
@@ -16,8 +16,8 @@ export default [
     key: 'issues',
     title: 'Issues',
     // eslint-disable-next-line react/display-name
-    renderFunc: (issues, id, { display_name }) => (
-      <IssuesColumn issues={issues} id={id} display_name={display_name} />
+    renderFunc: (issues, _, { display_name }) => (
+      <IssuesColumn issues={issues} display_name={display_name} />
     ),
     props: {
       width: 15,

--- a/src/components/SystemsTable/IssuesColumn.js
+++ b/src/components/SystemsTable/IssuesColumn.js
@@ -26,13 +26,12 @@ const sortByIndex = (issue) => [
   issue.resolved,
 ];
 
-const IssuesColumn = ({ issues, status, display_name }) => {
+const IssuesColumn = ({ issues, display_name }) => {
   const [sortByConfig, setSortByConfig] = useState({
     index: 0,
     direction: 'asc',
   });
   const [isOpen, setIsOpen] = useState();
-  const StatusIcon = status ? CheckIcon : TimesIcon;
   const sortedIssues = sortBy(
     issues,
     (sortIssue) => sortByIndex(sortIssue)[sortByConfig.index]
@@ -80,7 +79,7 @@ const IssuesColumn = ({ issues, status, display_name }) => {
             {
               title: (
                 <Fragment>
-                  <StatusIcon />{' '}
+                  {issue.resolved ? <CheckIcon /> : <TimesIcon />}{' '}
                   {issue.resolved ? 'Remediated' : 'Not remediated'}
                 </Fragment>
               ),
@@ -119,8 +118,6 @@ const IssuesColumn = ({ issues, status, display_name }) => {
 
 IssuesColumn.propTypes = {
   issues: PropTypes.arrayOf(PropTypes.shape()),
-  rebootRequired: PropTypes.bool,
-  status: PropTypes.bool,
   display_name: PropTypes.string,
 };
 


### PR DESCRIPTION
To test:

Go to remediations and choose a remediations playbook that has systems with actions that have been remediated. Click that playbook -> click the "Systems" tab -> click the "Issues" column links until you find a system with a "Status" that reads, "Remediated". You'll notice that the bug shows a `TimesIcon` instead of a `CheckIcon`. This PR fixes that.

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
