### PR TITLE
RHCLOUD-24866

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -98,10 +98,10 @@ export function downloadPlaybook(selectedIds) {
       selectedIds.length > 1
         ? new RemediationsApiAxiosParamCreator()
             .downloadPlaybooks(selectedIds)
-            .then((value) => window.open(API_BASE + value.url))
+            .then((value) => window.location.assign(API_BASE + value.url))
         : new RemediationsApiAxiosParamCreator()
             .getRemediationPlaybook(selectedIds[0])
-            .then((value) => window.open(API_BASE + value.url));
+            .then((value) => window.location.assign(API_BASE + value.url));
 
     if (!tab) {
       return reject();


### PR DESCRIPTION

[RHCLOUD-24866](https://issues.redhat.com/browse/RHCLOUD-24866)

downloading playbook from remediations should not open a new window anymore
