### PR TITLE
fix(REMEDY-122): Broken "Download playbook" on remedation card

### DIFF
--- a/src/components/PlaybookCard.js
+++ b/src/components/PlaybookCard.js
@@ -100,7 +100,7 @@ const PlaybookCardHeader = ({
     <DropdownItem
       key="download"
       onClick={() => {
-        downloadPlaybook(remediation.id);
+        downloadPlaybook([remediation.id]);
         setIsOpen(false);
         dispatchNotification({
           title: `Preparing playbook for download`,


### PR DESCRIPTION
Steps to Reproduce:

1. Go to remediations
2. Click the three dots on a specific playbook card
3. Click "Download playbook" and you get the download zipped although it's a single playbook

If you check the checkbox of a single playbook then click the large Download button above. You get it unzipped. This is the anticipated action when downloading a single playbook. This PR fixes this interaction.

See the card comments for additional information.

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
