### PR TITLE
fix(RHINENG-3750): Communicate in UI when remediations is disabled

### DIFF
--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -1,0 +1,45 @@
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+const { API_BASE } = require('../config');
+import { useState, useEffect } from 'react';
+
+export const useConnectionStatus = (
+  remediation,
+  context,
+  executable,
+  isFedramp
+) => {
+  const axios = useAxiosWithPlatformInterceptors();
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const connection_status =
+          remediation &&
+          (await axios.get(
+            `${API_BASE}/remediations/${remediation.id}/connection_status`
+          ));
+        let connected =
+          connection_status.data.length > 0
+            ? connection_status.data[0].connection_status !== 'connected'
+            : false;
+        if (!connected) {
+          setIsDisabled(true);
+        } else {
+          setIsDisabled(
+            !context.permissions.execute ||
+              !executable ||
+              isFedramp ||
+              connected
+          );
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData();
+  }, [remediation, context, executable, isFedramp]);
+
+  return isDisabled;
+};

--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -1,12 +1,14 @@
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 const { API_BASE } = require('../config');
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export const useConnectionStatus = (remediation) => {
   const axios = useAxiosWithPlatformInterceptors();
   const [isConnected, setisConnected] = useState();
+  const mounted = useRef(false);
 
   useEffect(() => {
+    mounted.current = true;
     const fetchData = async () => {
       try {
         const connection_status =
@@ -14,15 +16,19 @@ export const useConnectionStatus = (remediation) => {
           (await axios.get(
             `${API_BASE}/remediations/${remediation.id}/connection_status`
           ));
-        setisConnected(
-          connection_status.data?.[0].connection_status === 'connected'
-        );
+        mounted.current &&
+          setisConnected(
+            connection_status.data?.[0].connection_status === 'connected'
+          );
       } catch (error) {
         console.error(error);
       }
     };
 
     fetchData();
+    return () => {
+      mounted.current = false;
+    };
   }, [remediation]);
 
   return isConnected;

--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -2,14 +2,9 @@ import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/fronten
 const { API_BASE } = require('../config');
 import { useState, useEffect } from 'react';
 
-export const useConnectionStatus = (
-  remediation,
-  context,
-  executable,
-  isFedramp
-) => {
+export const useConnectionStatus = (remediation) => {
   const axios = useAxiosWithPlatformInterceptors();
-  const [isDisabled, setIsDisabled] = useState(true);
+  const [isConnected, setisConnected] = useState();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -19,27 +14,16 @@ export const useConnectionStatus = (
           (await axios.get(
             `${API_BASE}/remediations/${remediation.id}/connection_status`
           ));
-        let connected =
-          connection_status.data.length > 0
-            ? connection_status.data[0].connection_status !== 'connected'
-            : false;
-        if (!connected) {
-          setIsDisabled(true);
-        } else {
-          setIsDisabled(
-            !context.permissions.execute ||
-              !executable ||
-              isFedramp ||
-              connected
-          );
-        }
+        setisConnected(
+          connection_status.data?.[0].connection_status === 'connected'
+        );
       } catch (error) {
         console.error(error);
       }
     };
 
     fetchData();
-  }, [remediation, context, executable, isFedramp]);
+  }, [remediation]);
 
-  return isDisabled;
+  return isConnected;
 };

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -170,12 +170,7 @@ const RemediationDetails = ({
 
   const { status, remediation } = selectedRemediation;
 
-  const isDisabled = useConnectionStatus(
-    remediation,
-    context,
-    executable,
-    isFedramp
-  );
+  const isConnected = useConnectionStatus(remediation);
 
   useEffect(() => {
     remediation &&
@@ -212,7 +207,12 @@ const RemediationDetails = ({
               <Split hasGutter>
                 <SplitItem>
                   <ExecutePlaybookButton
-                    isDisabled={isDisabled}
+                    isDisabled={
+                      !isConnected ||
+                      !context.permissions.execute ||
+                      !executable ||
+                      isFedramp
+                    }
                     disabledStateText={disabledStateText}
                     remediationId={remediation.id}
                     remediationName={remediation.name}

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useContext,
-  useMemo,
-  useCallback,
-} from 'react';
+import React, { useEffect, useState, useContext, useMemo } from 'react';
 import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { useSearchParams, useParams } from 'react-router-dom';
@@ -25,8 +19,6 @@ import ActivityTabUpsell from '../components/EmptyStates/ActivityTabUpsell';
 import DeniedState from '../components/DeniedState';
 import SkeletonTable from '../skeletons/SkeletonTable';
 import '../components/Status.scss';
-import instance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
-
 import {
   PageHeader,
   PageHeaderTitle,
@@ -57,7 +49,7 @@ import './RemediationDetails.scss';
 import NoReceptorBanner from '../components/Alerts/NoReceptorBanner';
 import { RemediationSummary } from '../components/RemediationSummary';
 import { dispatchNotification } from '../Utilities/dispatcher';
-import { API_BASE } from '../config';
+import { useConnectionStatus } from '../Utilities/useConnectionStatus';
 
 const RemediationDetails = ({
   selectedRemediation,
@@ -74,7 +66,6 @@ const RemediationDetails = ({
   const navigate = useNavigate();
   const { id } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [isDisabled, setIsDisabled] = useState(true);
 
   const { isFedramp, isBeta, isOrgAdmin = () => false } = chrome;
   const context = useContext(PermissionContext);
@@ -179,26 +170,12 @@ const RemediationDetails = ({
 
   const { status, remediation } = selectedRemediation;
 
-  const fetchDisabledValue = useCallback(async () => {
-    return Promise.resolve(
-      instance.get(
-        `${API_BASE}/remediations/${remediation.id}/connection_status`
-      )
-    ).then(({ data }) => {
-      setIsDisabled(
-        !context.permissions.execute ||
-          !executable ||
-          isFedramp ||
-          data[0].connection_status !== 'connected'
-      );
-    });
-  });
-
-  useEffect(() => {
-    if (remediation) {
-      fetchDisabledValue();
-    }
-  }, [fetchDisabledValue]);
+  const isDisabled = useConnectionStatus(
+    remediation,
+    context,
+    executable,
+    isFedramp
+  );
 
   useEffect(() => {
     remediation &&

--- a/src/routes/RemediationDetails.test.js
+++ b/src/routes/RemediationDetails.test.js
@@ -41,16 +41,4 @@ describe('useConnectionStatus', () => {
     await waitForNextUpdate();
     expect(result.current).toBe(false);
   });
-
-  //   test('returns false if connection is false', async () => {
-  //     useAxiosWithPlatformInterceptors.mockImplementation(() => ({
-  //       get: () => {
-  //         let res = { data: [{ connection_status: 'dsadsaad' }] };
-  //         return res;
-  //       },
-  //     }));
-  //     const { result } = renderHook(() => useConnectionStatus(remediation));
-
-  //     expect(result.current).toBe(false);
-  //   });
 });

--- a/src/routes/RemediationDetails.test.js
+++ b/src/routes/RemediationDetails.test.js
@@ -1,0 +1,56 @@
+import { useConnectionStatus } from '../Utilities/useConnectionStatus';
+import { renderHook } from '@testing-library/react-hooks';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/interceptors',
+  () => ({
+    __esModule: true,
+    useAxiosWithPlatformInterceptors: jest.fn(),
+  })
+);
+
+describe('useConnectionStatus', () => {
+  const remediation = { id: '12345' };
+
+  test('fires off a request and returns a true boolean if all values are true', async () => {
+    useAxiosWithPlatformInterceptors.mockImplementation(() => ({
+      get: () => {
+        let res = { data: [{ connection_status: 'connected' }] };
+        return res;
+      },
+    }));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useConnectionStatus(remediation)
+    );
+
+    await waitForNextUpdate();
+    expect(result.current).toBe(true);
+  });
+  test('fires off a request and returns FALSE', async () => {
+    useAxiosWithPlatformInterceptors.mockImplementation(() => ({
+      get: () => {
+        let res = { data: [{ connection_status: 'NOT CONNECTED' }] };
+        return res;
+      },
+    }));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useConnectionStatus(remediation)
+    );
+
+    await waitForNextUpdate();
+    expect(result.current).toBe(false);
+  });
+
+  //   test('returns false if connection is false', async () => {
+  //     useAxiosWithPlatformInterceptors.mockImplementation(() => ({
+  //       get: () => {
+  //         let res = { data: [{ connection_status: 'dsadsaad' }] };
+  //         return res;
+  //       },
+  //     }));
+  //     const { result } = renderHook(() => useConnectionStatus(remediation));
+
+  //     expect(result.current).toBe(false);
+  //   });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-3750))

This adds a new endpoint and checks the connection status of the remediation. if the connection status is anything but 'connected', it should be disabled

# How to test the PR

- Open the network tab : Bring down the PR and select a remediation
- in the network tab, filter the results with connection_status
- Open the data and look through the data object for a connection_status key/value pair. If the value is connected (and other conditionals are met) the execute button should be enabled,
- Select multiple remediations, if any of them have a status other than 'connected' and the button is available, then this PR needs more work.
# Before the change
- You could remediate when the connection_status was not 'connected'

# After the change
- You can only execute with this new conditional


- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
