### PR TITLE
fix(RHINENG-4944): Display the username if last_name is missing

### DIFF
--- a/src/components/RemediationActivityTable.js
+++ b/src/components/RemediationActivityTable.js
@@ -36,7 +36,9 @@ const RemediationActivityTable = ({ remediation, playbookRuns }) => {
               ),
               cellFormatters: [expandable],
             },
-            `${playbooks.created_by.first_name} ${playbooks.created_by.last_name}`,
+            playbooks.created_by.last_name // for reasons unknown, last_name is not available sometimes
+              ? `${playbooks.created_by.first_name} ${playbooks.created_by.last_name}`
+              : `${playbooks.created_by.username}`,
             {
               title: (
                 <StatusSummary


### PR DESCRIPTION
# Description
It seems that occasionally and for reasons unknown, the last_name is not recorded with the remediation, so this PR has the frontend display the username if the last_name is missing, otherwise it displays the first_name and last_name as usual.  Perhaps not the best solution (finding out why the last_name isn't being recorded is the best solution), but displaying 'my-user-name' in the UI is slightly better than displaying 'Firstname undefined'.

Associated Jira ticket: # (issue)
https://issues.redhat.com/browse/RHINENG-4944

Before the change, last_name is displayed as 'undefined':
![data_missing_last_name](https://github.com/RedHatInsights/insights-remediations-frontend/assets/4008744/46603a83-38f5-4ad0-960d-1ff19755e930)

After the change, the user's username is displayed instead:
![Screenshot from 2024-01-15 17-53-16](https://github.com/RedHatInsights/insights-remediations-frontend/assets/4008744/bd123160-7a12-4cb9-a481-58351201674a)

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
