### PR TITLE
fix(RHINENG-5917): Use default name instead of empty playbook name

### DIFF
--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -100,7 +100,12 @@ RemediationDetailsDropdown.propTypes = {
 };
 
 const connected = connect(null, (dispatch) => ({
-  onRename: (id, name = EMPTY_NAME) => dispatch(patchRemediation(id, { name })),
+  onRename: (id, name) => {
+    if (!name) {
+      name = EMPTY_NAME;
+    }
+    dispatch(patchRemediation(id, { name }));
+  },
   onDelete: (id) => dispatch(deleteRemediation(id)),
 }))(RemediationDetailsDropdown);
 


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-5917](https://issues.redhat.com/browse/RHINENG-5917)

Returned playbook renaming behavior as it was designed initially


# How to test the PR

1. Create a playbook with some name
2. Try to rename it and use empty value
3. Playbook should be named "Unnamed Playbook"

# Before the change

Before the change you had playbook without name at all that looked ugly

# After the change

[Screencast from 2024-01-15 15-46-27.webm](https://github.com/RedHatInsights/insights-remediations-frontend/assets/33912805/b3ce905c-36e9-4d23-8ff2-71d7f69c81ba)


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
