### PR TITLE
fix: RHINENG-4956 Move action below title in Systems for action modal

### DIFF
--- a/src/components/Modals/SystemsStatusModal.js
+++ b/src/components/Modals/SystemsStatusModal.js
@@ -81,13 +81,12 @@ export const SystemsStatusModal = ({
       <Modal
         className="remediations"
         variant={ModalVariant.large}
-        title={`System${issue.systems.length > 1 ? 's' : ''} for action ${
-          issue.description
-        }`}
+        title={`System${issue.systems.length > 1 ? 's' : ''} for action`}
         isOpen={isOpen}
         onClose={onClose}
         isFooterLeftAligned
       >
+        <b>Action:</b> {issue.description}
         <div className="rem-c-toolbar__filter">
           <InventoryTable
             onLoad={({ mergeWithEntities, INVENTORY_ACTION_TYPES }) =>


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-4956](https://issues.redhat.com/browse/RHINENG-4956)

Move action below title in Systems for action modal. If the action string were too long it would overflow the modal title.

# How to test the PR

Very long action string should no longer overflow the modal.

# Before the change
![Screenshot from 2024-03-04 20-33-38](https://github.com/RedHatInsights/insights-remediations-frontend/assets/8426204/671b5d65-5123-4a86-b68e-5ed09c77905a)

# After the change
![Screenshot from 2024-03-04 20-23-47](https://github.com/RedHatInsights/insights-remediations-frontend/assets/8426204/2b1f6f8e-d450-4c87-8fc8-ec66d3a385bf)
