### PR TITLE
change(NoDataModal):RHINENG-3123 change text for no advisory systems

### DIFF
--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -15,6 +15,7 @@ const RemediationButton = ({
   dataProvider,
   onRemediationCreated,
   buttonProps,
+  patchNoAdvisoryText,
 }) => {
   const [hasPermissions, setHasPermissions] = useState(false);
   const [remediationsData, setRemediationsData] = useState();
@@ -67,7 +68,11 @@ const RemediationButton = ({
       >
         {children}
       </Button>
-      <NoDataModal isOpen={isNoDataModalOpen} setOpen={setNoDataModalOpen} />
+      <NoDataModal
+        isOpen={isNoDataModalOpen}
+        setOpen={setNoDataModalOpen}
+        patchNoAdvisoryText={patchNoAdvisoryText}
+      />
       {remediationsData && (
         <RemediationWizard
           setOpen={(isOpen) =>
@@ -93,6 +98,7 @@ RemediationButton.propTypes = {
   buttonProps: propTypes.shape({
     [propTypes.string]: propTypes.any,
   }),
+  patchNoAdvisoryText: propTypes.string,
 };
 
 RemediationButton.defaultProps = {

--- a/src/modules/RemediationsModal/NoDataModal.js
+++ b/src/modules/RemediationsModal/NoDataModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 
-export const NoDataModal = ({ isOpen, setOpen }) => {
+export const NoDataModal = ({ isOpen, setOpen, patchNoAdvisoryText }) => {
   return (
     <Modal
       variant={ModalVariant.small}
@@ -15,11 +15,17 @@ export const NoDataModal = ({ isOpen, setOpen }) => {
         </Button>,
       ]}
     >
-      None of the selected issues can be remediated with Ansible.
-      <br />
-      <br />
-      To remediate these issues, review the manual remediation steps associated
-      with each.
+      {patchNoAdvisoryText ? (
+        patchNoAdvisoryText
+      ) : (
+        <>
+          None of the selected issues can be remediated with Ansible.
+          <br />
+          <br />
+          To remediate these issues, review the manual remediation steps
+          associated with each.
+        </>
+      )}
     </Modal>
   );
 };
@@ -27,6 +33,7 @@ export const NoDataModal = ({ isOpen, setOpen }) => {
 NoDataModal.propTypes = {
   isOpen: propTypes.bool,
   setOpen: propTypes.func,
+  patchNoAdvisoryText: propTypes.string,
 };
 
 export default NoDataModal;


### PR DESCRIPTION
Change wording in NoDataModal when a system with no advisories is remediated

Associated Jira ticket: RHINENG-3123

# How to test 

1. Run this PR with https://github.com/RedHatInsights/patchman-ui/pull/1174
2. Go to Patch systems page
3. Select system with no advisories available
4. The modal should have changed wording

# Before the change
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/62351699/3c5b4fcc-992e-43bf-931a-476e1f9777e6)

# After the change
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/62351699/d5bf6232-5b89-4b50-a95d-4e8985717c47)

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
