### PR TITLE
fix(RHINENG-4946): RemediationDetailsTable - Bulk Selector is not updated when an Action is deleted

### DIFF
--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -273,7 +273,7 @@ function RemediationDetailsTable(props) {
                   dismissable: true,
                   autoDismiss: true,
                 });
-                selector.reset;
+                selector.reset();
               }}
               isBeta={chrome?.isBeta?.()}
             />,


### PR DESCRIPTION
# Description

This PR addresses issue [#RHINENG-4946](https://issues.redhat.com/browse/RHINENG-4946)

With this PR's changes, we should be able to see that when deleting an Action, the Bulk Selector's number of selected items is being updated

# How to Reproduce the Bug? 
1. Navigate to a remediation that has several Actions
2. Select one or more Actions
3. Click the 'Remove Action' button at the top of the table
4. The Bulk Selector still counts it as selected, although it is no longer present