### PR TITLE
feat(RHINENG-4974): Change autoreboot link to a switch

### DIFF
--- a/src/modules/RemediationsModal/steps/review.js
+++ b/src/modules/RemediationsModal/steps/review.js
@@ -10,11 +10,11 @@ import {
 } from '@patternfly/react-table/deprecated';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import {
-  Button,
   Text,
   TextContent,
   Stack,
   StackItem,
+  Switch,
 } from '@patternfly/react-core';
 import {
   buildRows,
@@ -125,14 +125,13 @@ const Review = (props) => {
         </TextContent>
       </StackItem>
       <StackItem>
-        <Button
-          data-testid="autoreboot-button"
-          variant="link"
-          isInline
-          onClick={() => input.onChange(!input.value)}
-        >
-          Turn {input.value ? 'off' : 'on'} autoreboot
-        </Button>
+        <Switch
+          data-testid="autoreboot-switch"
+          label="Turn off autoreboot"
+          labelOff="Turn on autoreboot"
+          isChecked={input.value}
+          onChange={() => input.onChange(!input.value)}
+        />
       </StackItem>
       <Table
         aria-label="Actions"

--- a/src/modules/tests/steps/review.test.js
+++ b/src/modules/tests/steps/review.test.js
@@ -104,13 +104,12 @@ describe('Review', () => {
       </Provider>
     );
 
-    expect(screen.getByTestId('autoreboot-button')).toHaveTextContent(
-      'Turn off autoreboot'
-    );
-    await userEvent.click(screen.getByTestId('autoreboot-button'));
-    expect(screen.getByTestId('autoreboot-button')).toHaveTextContent(
-      'Turn on autoreboot'
-    );
+    const autoreboot_switch = screen.getByTestId('autoreboot-switch');
+    expect(autoreboot_switch).toBeChecked();
+    expect(autoreboot_switch).toHaveAccessibleName('Turn off autoreboot');
+    await userEvent.click(autoreboot_switch);
+    expect(autoreboot_switch).not.toBeChecked();
+    expect(autoreboot_switch).toHaveAccessibleName('Turn on autoreboot');
   });
 
   it('should sort records correctly', async () => {


### PR DESCRIPTION
Associated Jira ticket: [RHINENG-4974](https://issues.redhat.com/browse/RHINENG-4974)

Description of changes: Changes the 'Turn on/off autoreboot' from a hyperlink to a switch.

Screenshot before the change:
![Screenshot from 2024-04-06 15-25-42](https://github.com/RedHatInsights/insights-remediations-frontend/assets/4008744/20b1a7e2-e461-4f62-94ef-e7faad574e1e)


Screenshot after the change:
![Screenshot from 2024-04-06 15-19-31](https://github.com/RedHatInsights/insights-remediations-frontend/assets/4008744/12bb350d-6c03-4fc0-9932-d2f5a4d93953)


# Checklist:

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [X] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
