### PR TITLE
fix(RHINENG-4945): Fix bulk select on archive

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -4,7 +4,11 @@ import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
-  useChrome: () => null,
+  useChrome: () => ({
+    isBeta: jest.fn(),
+    chrome: jest.fn(),
+    updateDocumentTitle: jest.fn(),
+  }),
 }));
 
 global.React = React;

--- a/src/components/ExecutorDetails/ExecutorDetails.js
+++ b/src/components/ExecutorDetails/ExecutorDetails.js
@@ -99,7 +99,6 @@ const ExecutorDetails = ({
   }, [playbookRunSystemDetails.status]);
 
   const getEntites = useGetEntities({ id, run_id, executor_id, openId });
-  console.log(remediation, 'remediation');
   const renderInventorycard = (status) => (
     <Main>
       <Stack hasGutter>

--- a/src/components/PlaybookCard.js
+++ b/src/components/PlaybookCard.js
@@ -56,6 +56,7 @@ const PlaybookCardHeader = ({
   getConnectionStatus,
   downloadPlaybook,
   permission,
+  showArchived,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isArchived, setIsArchived] = useState(archived);
@@ -66,6 +67,12 @@ const PlaybookCardHeader = ({
     actionWrapper(
       [patchRemediation(remediation.id, { archived: !isArchived })],
       () => {
+        if (
+          selector.getSelectedIds().includes(remediation.id) &&
+          !showArchived
+        ) {
+          selector.props.onSelect(undefined, false, remediationIdx);
+        }
         setIsArchived(!isArchived);
         update(true);
       },
@@ -217,6 +224,7 @@ PlaybookCardHeader.propTypes = {
   getConnectionStatus: PropTypes.func.isRequired,
   downloadPlaybook: PropTypes.func.isRequired,
   permission: PropTypes.object.isRequired,
+  showArchived: PropTypes.bool.isRequired,
 };
 
 const renderActionStatus = (complete, total) => {
@@ -264,6 +272,7 @@ export const PlaybookCard = ({
   getConnectionStatus,
   downloadPlaybook,
   permission,
+  showArchived,
 }) => {
   // const [ poll, setPoll ] = useState(executeOpen => !executeOpen);
   // const [ curResolved, setCurResolved ] = useState(remediation.resolved_count);
@@ -313,6 +322,7 @@ export const PlaybookCard = ({
         getConnectionStatus={getConnectionStatus}
         downloadPlaybook={downloadPlaybook}
         permission={permission}
+        showArchived={showArchived}
       />
       <CardBody className="rem-c-playbook-card__body">
         <Split hasGutter className="rem-c-playbook-card__body--split">
@@ -356,10 +366,11 @@ PlaybookCard.propTypes = {
   archived: PropTypes.bool.isRequired,
   selector: PropTypes.object.isRequired,
   setExecuteOpen: PropTypes.func.isRequired,
-  executeOpen: PropTypes.bool.isRequired,
+  //executeOpen: PropTypes.bool.isRequired,
   update: PropTypes.func.isRequired,
   loadRemediation: PropTypes.func.isRequired,
   getConnectionStatus: PropTypes.func.isRequired,
   downloadPlaybook: PropTypes.func.isRequired,
   permission: PropTypes.object.isRequired,
+  showArchived: PropTypes.bool.isRequired,
 };

--- a/src/components/RemediationTable.js
+++ b/src/components/RemediationTable.js
@@ -182,6 +182,7 @@ function RemediationTable({
                     getConnectionStatus={getConnectionStatus}
                     downloadPlaybook={downloadPlaybook}
                     permission={permission}
+                    showArchived={showArchived}
                   />
                 </GridItem>
               );

--- a/src/components/__fixtures__/remediations.fixtures.js
+++ b/src/components/__fixtures__/remediations.fixtures.js
@@ -1,0 +1,24 @@
+export const remediationsMock = [
+  {
+    archived: false,
+    created_at: '2024-04-09T09:27:05.409Z',
+    created_by: {
+      first_name: 'Ender',
+      last_name: 'Wiggin',
+      username: 'dragon',
+    },
+    id: 'be95812a-b98a-4dc3-bc2f-f93970f71bcf',
+    issue_count: 1,
+    name: 'test-remediation-1',
+    needs_reboot: true,
+    resolved_count: 0,
+    selected: true,
+    system_count: 1,
+    updated_at: '2024-04-09T09:27:05.409Z',
+    updated_by: {
+      first_name: 'Ender',
+      last_name: 'Wiggin',
+      username: 'dragon',
+    },
+  },
+];

--- a/src/components/__tests__/PlaybookCard.test.js
+++ b/src/components/__tests__/PlaybookCard.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { PlaybookCard } from '../PlaybookCard';
+import * as api from '../../api';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { remediationsMock } from '../__fixtures__/remediations.fixtures';
+
+// eslint-disable-next-line no-import-assign
+api.downloadPlaybook = jest.fn();
+global.insights = {
+  chrome: {
+    auth: {
+      getUser: () =>
+        new Promise(() => ({
+          entitlements: { smart_management: { isEntitled: true } },
+        })),
+    },
+  },
+};
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => ({
+  __esModule: true,
+  default: (props) => {
+    return <div {...props}>{props.name}</div>;
+  },
+}));
+
+describe('PlaybookCard', () => {
+  let permission = {
+    isReceptorConfigured: true,
+    permissions: {
+      execute: true,
+    },
+  };
+
+  test('deselects playbook when archived and showArchived is false', async () => {
+    const selector = {
+      getSelectedIds() {
+        return ['be95812a-b98a-4dc3-bc2f-f93970f71bcf'];
+      },
+      register: () => undefined,
+      reset: () => jest.fn(),
+      props: { onSelect: jest.fn(() => {}) },
+      tbodyProps: {
+        onRowClick: () => jest.fn(),
+      },
+    };
+
+    render(
+      <PlaybookCard
+        remediation={remediationsMock[0]}
+        remediationIdx={0}
+        archived={false}
+        selector={selector}
+        setExecuteOpen={() => jest.fn()}
+        update={() => jest.fn()}
+        loadRemediation={() => jest.fn()}
+        getConnectionStatus={() => jest.fn()}
+        downloadPlaybook={() => jest.fn()}
+        permission={permission}
+        showArchived={false}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: /be95812a-b98a-4dc3-bc2f-f93970f71bcf-checkbox/i,
+      })
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /actions/i,
+      })
+    );
+
+    fireEvent.click(
+      screen.getByRole('menuitem', {
+        name: /archive playbook/i,
+      })
+    );
+
+    expect(selector.props.onSelect).toHaveBeenCalledWith(
+      expect.anything(),
+      false,
+      0
+    );
+  });
+});


### PR DESCRIPTION
# Description
Associated Jira ticket: # RHINENG-4953

When a selected playbook is archived, and archived playbooks are not visible, that selection remains in the bulk select.

# How to test the PR
- Navigate to Remediations
- Ensure only non-archived playbooks are being shown via toolbar action kebab
- Select checkbox of a playbook
- Archive playbook from card action kebab

# Before the change
The playbook remains selected (see Bulk Selector).

# After the change
With this PR, when only non-archived playbooks are being shown, and we archive a selected playbook, that selection should not remain.

On the other hand, if we are viewing all playbooks (archived and non-archived) and we archive a selected playbook, the selection should remain.

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
