### PR TITLE
feat(RHINENG-7065): Add popover to explain disabled statuses

### DIFF
--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -27,7 +27,7 @@ export const useConnectionStatus = (remediation) => {
         setAreDetailsLoading(false);
       } catch (error) {
         console.error(error);
-        setDetailsError(error);
+        setDetailsError(error.errors[0].status);
       }
     };
 

--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -5,6 +5,9 @@ import { useState, useEffect, useRef } from 'react';
 export const useConnectionStatus = (remediation) => {
   const axios = useAxiosWithPlatformInterceptors();
   const [isConnected, setisConnected] = useState();
+  const [areDetailsLoading, setAreDetailsLoading] = useState(true);
+  const [connectionDetails, setConnectionDetails] = useState();
+  const [detailsError, setDetailsError] = useState();
   const mounted = useRef(false);
 
   useEffect(() => {
@@ -20,8 +23,11 @@ export const useConnectionStatus = (remediation) => {
           setisConnected(
             connection_status.data?.[0].connection_status === 'connected'
           );
+        setConnectionDetails(connection_status.data[0]);
+        setAreDetailsLoading(false);
       } catch (error) {
         console.error(error);
+        setDetailsError(error);
       }
     };
 
@@ -31,5 +37,5 @@ export const useConnectionStatus = (remediation) => {
     };
   }, [remediation]);
 
-  return isConnected;
+  return [isConnected, connectionDetails, areDetailsLoading, detailsError];
 };

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -67,7 +67,7 @@ const ExecuteButton = ({
               </span>
 
               <span className="pf-v5-u-font-size-sm">
-                {detailsError ? (
+                {detailsError === 403 ? (
                   <TimesIcon className="pf-v5-u-mr-sm" />
                 ) : (
                   <CheckIcon className="pf-v5-u-mr-sm" />
@@ -78,7 +78,7 @@ const ExecuteButton = ({
                 >
                   RHC manager
                 </a>
-                is {detailsError ? 'disabled' : 'enabled'}.
+                is {detailsError === 403 ? 'disabled' : 'enabled'}.
               </span>
 
               <span className="pf-v5-u-font-size-sm pf-v5-u-mb-sm">

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useMemo } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import Link from '@redhat-cloud-services/frontend-components/InsightsLink';
 import useNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate';
 import { useSearchParams, useParams } from 'react-router-dom';
@@ -67,7 +67,7 @@ const RemediationDetails = ({
   const { id } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { isFedramp, isBeta, isOrgAdmin = () => false } = chrome;
+  const { isFedramp, isBeta } = chrome;
   const context = useContext(PermissionContext);
 
   const [upsellBannerVisible, setUpsellBannerVisible] = useState(
@@ -92,26 +92,6 @@ const RemediationDetails = ({
       ...Object.fromEntries(searchParams),
       activeTab: tabName,
     });
-
-  const disabledStateText = useMemo(() => {
-    if (!context.permissions.execute) {
-      if (isOrgAdmin()) {
-        return (
-          'Executing the playbook requires having the remediations:remediation:execute permission' +
-          ' which is included in the Remediations administrator role. Manage your roles in User access.'
-        );
-      } else {
-        return (
-          'Executing the playbook requires having the remediations:remediation:execute permission' +
-          ' which is included in the Remediations administrator role. Contact your Organization Administrator for access.'
-        );
-      }
-    } else if (!executable) {
-      return 'Your account must be entitled to Satellite to execute playbooks.';
-    }
-
-    return 'Unable to execute playbook.';
-  }, [chrome]);
 
   useEffect(() => {
     loadRemediation(id).catch((e) => {
@@ -170,7 +150,8 @@ const RemediationDetails = ({
 
   const { status, remediation } = selectedRemediation;
 
-  const isConnected = useConnectionStatus(remediation);
+  const [isConnected, connectionDetails, areDetailsLoading, detailsError] =
+    useConnectionStatus(remediation);
 
   useEffect(() => {
     remediation &&
@@ -213,9 +194,12 @@ const RemediationDetails = ({
                       !executable ||
                       isFedramp
                     }
-                    disabledStateText={disabledStateText}
                     remediationId={remediation.id}
                     remediationName={remediation.name}
+                    connectionDetails={connectionDetails}
+                    areDetailsLoading={areDetailsLoading}
+                    detailsError={detailsError}
+                    permissions={context.permissions.execute}
                   ></ExecutePlaybookButton>
                 </SplitItem>
                 <SplitItem>

--- a/src/routes/RemediationDetails.test.js
+++ b/src/routes/RemediationDetails.test.js
@@ -1,5 +1,6 @@
+/* eslint-disable testing-library/no-unnecessary-act */
 import { useConnectionStatus } from '../Utilities/useConnectionStatus';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 
 jest.mock(
@@ -20,12 +21,13 @@ describe('useConnectionStatus', () => {
         return res;
       },
     }));
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useConnectionStatus(remediation)
-    );
+    let hook;
+    await act(async () => {
+      hook = renderHook(() => useConnectionStatus(remediation));
+    });
+    const { result } = hook;
 
-    await waitForNextUpdate();
-    expect(result.current).toBe(true);
+    expect(result.current[0]).toBe(true);
   });
   test('fires off a request and returns FALSE', async () => {
     useAxiosWithPlatformInterceptors.mockImplementation(() => ({
@@ -34,11 +36,11 @@ describe('useConnectionStatus', () => {
         return res;
       },
     }));
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useConnectionStatus(remediation)
-    );
-
-    await waitForNextUpdate();
-    expect(result.current).toBe(false);
+    let hook;
+    await act(async () => {
+      hook = renderHook(() => useConnectionStatus(remediation));
+    });
+    const { result } = hook;
+    expect(result.current[0]).toBe(false);
   });
 });


### PR DESCRIPTION
# Description
Adds a popover to explain why your remediation cant be executed if its disabled.

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-7065))

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR
Select a Remediation to go to details
hover over the disabled executable button (needs to be disabled to see popover)
Popover should match mocks:  https://www.figma.com/proto/4SzBpdiqHzLDtItBG3aisz/Remediations?page-id=0%3A1&type=design&node-id=243-6441&viewport=358%2C-1266%2C0.16&t=qCljog3Q1nHLY3d1-1&scaling=min-zoom&starting-point-node-id=133%3A8687



# Before the change
Popover says 'Unable to execute'


# After the change
<img width="559" alt="Screenshot 2024-04-10 at 11 52 47 AM" src="https://github.com/RedHatInsights/insights-remediations-frontend/assets/60629070/b98f58f1-99d3-4ccd-94c8-a5baa081d88b">


With the addition of the 403 error, the structure of the data coming back on a 403 is (removed unrelated key/value pairs )
{
  "errors": [
    {
      "status": 403,
    }
  ]
}


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
