### PR TITLE
fix(RHINENG-7065): Fix popover conditions

### DIFF
--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -14,24 +14,22 @@ export const useConnectionStatus = (remediation) => {
     mounted.current = true;
     const fetchData = async () => {
       try {
-        const connection_status =
-          remediation &&
-          (await axios.get(
-            `${API_BASE}/remediations/${remediation.id}/connection_status`
-          ));
+        const connection_status = await axios.get(
+          `${API_BASE}/remediations/${remediation.id}/connection_status`
+        );
         mounted.current &&
           setisConnected(
             connection_status.data?.[0].connection_status === 'connected'
           );
         setConnectionDetails(connection_status.data[0]);
-        setAreDetailsLoading(false);
       } catch (error) {
         console.error(error);
         setDetailsError(error.errors[0].status);
       }
+      setAreDetailsLoading(false);
     };
 
-    fetchData();
+    remediation && fetchData();
     return () => {
       mounted.current = false;
     };

--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -442,3 +442,13 @@ export const matchPermissions = (permissionA, permissionB) => {
       segmentsB[index] === '*'
   );
 };
+
+export const getResolvedSystems = (issue) => {
+  let count = 0;
+  issue.systems.map((system) => {
+    if (system.resolved) {
+      count++;
+    }
+  });
+  return count;
+};

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -7,14 +7,13 @@ import { ExecuteModal } from './Modals/ExecuteModal';
 import './ExecuteButton.scss';
 import './Status.scss';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { getResolvedSystems } from './RemediationDetailsTable';
 
 const ExecuteButton = ({
   isLoading,
   isDisabled,
   data,
   getConnectionStatus,
-  remediationId,
-  remediationName,
   issueCount,
   runRemediation,
   etag,
@@ -24,6 +23,7 @@ const ExecuteButton = ({
   areDetailsLoading,
   detailsError,
   permissions,
+  remediation,
 }) => {
   const [open, setOpen] = useState(false);
   const [showRefreshMessage, setShowRefreshMessage] = useState(false);
@@ -32,7 +32,7 @@ const ExecuteButton = ({
 
   useEffect(() => {
     if (remediationStatus === 'changed') {
-      getConnectionStatus(remediationId);
+      getConnectionStatus(remediation.id);
       setShowRefreshMessage(true);
     } else if (remediationStatus === 'fulfilled') {
       setOpen(false);
@@ -62,8 +62,13 @@ const ExecuteButton = ({
                 ) : (
                   <TimesIcon className="pf-v5-u-mr-sm" />
                 )}
-                Connected Systems ({connectionDetails?.system_count}/4). See
-                systems tab.
+                Connected Systems (
+                {`${
+                  getResolvedSystems(remediation.issues[0]) +
+                  '/' +
+                  remediation.issues[0].systems.length
+                }`}
+                ). See systems tab.
               </span>
 
               <span className="pf-v5-u-font-size-sm">
@@ -75,6 +80,7 @@ const ExecuteButton = ({
                 <a
                   href="https://console.redhat.com/insights/connector"
                   style={{ textDecoration: 'underline', color: 'white' }}
+                  className="pf-v5-u-mr-xs"
                 >
                   RHC manager
                 </a>
@@ -90,6 +96,7 @@ const ExecuteButton = ({
                 <a
                   href="https://console.redhat.com/iam/user-access/overview"
                   style={{ textDecoration: 'underline', color: 'white' }}
+                  className="pf-v5-u-mr-xs"
                 >
                   User access permissions
                 </a>
@@ -112,7 +119,7 @@ const ExecuteButton = ({
         data-testid="execute-button-enabled"
         onClick={() => {
           setOpen(true);
-          getConnectionStatus(remediationId);
+          getConnectionStatus(remediation.id);
         }}
       >
         Execute playbook
@@ -131,8 +138,8 @@ const ExecuteButton = ({
             setOpen(false);
           }}
           showRefresh={showRefreshMessage}
-          remediationId={remediationId}
-          remediationName={remediationName}
+          remediationId={remediation.id}
+          remediationName={remediation.name}
           data={data}
           etag={etag}
           isLoading={isLoading}
@@ -152,8 +159,7 @@ ExecuteButton.propTypes = {
   data: PropTypes.array,
   getConnectionStatus: PropTypes.func,
   runRemediation: PropTypes.func,
-  remediationId: PropTypes.string,
-  remediationName: PropTypes.string,
+  remediation: PropTypes.string,
   remediationStatus: PropTypes.string,
   issueCount: PropTypes.number,
   etag: PropTypes.string,

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -7,7 +7,7 @@ import { ExecuteModal } from './Modals/ExecuteModal';
 import './ExecuteButton.scss';
 import './Status.scss';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
-import { getResolvedSystems } from './RemediationDetailsTable';
+import { getResolvedSystems } from '../Utilities/utils';
 
 const ExecuteButton = ({
   isLoading,

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -36,6 +36,7 @@ import './RemediationDetailsTable.scss';
 import { PermissionContext } from '../App';
 import { EmptyActions } from './EmptyStates/EmptyActions';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { getResolvedSystems } from '../Utilities/utils';
 
 function resolutionDescriptionCell(remediation, issue) {
   const url = buildIssueUrl(issue.id);
@@ -86,16 +87,6 @@ function systemsForAction(issue, remediation, title) {
       title={title}
     />
   );
-}
-
-export function getResolvedSystems(issue) {
-  let count = 0;
-  issue.systems.map((system) => {
-    if (system.resolved) {
-      count++;
-    }
-  });
-  return count;
 }
 
 const SORTING_ITERATEES = [

--- a/src/components/RemediationDetailsTable.js
+++ b/src/components/RemediationDetailsTable.js
@@ -88,7 +88,7 @@ function systemsForAction(issue, remediation, title) {
   );
 }
 
-function getResolvedSystems(issue) {
+export function getResolvedSystems(issue) {
   let count = 0;
   issue.systems.map((system) => {
     if (system.resolved) {

--- a/src/components/__tests__/ExecuteButton.test.js
+++ b/src/components/__tests__/ExecuteButton.test.js
@@ -44,7 +44,21 @@ describe('Execute button', () => {
         isDisabled={true}
         remediationStatus={'pending'}
         issueCount={1}
-        remediationId="id"
+        remediation={{
+          id: 'id',
+          issues: [
+            {
+              systems: [
+                {
+                  display_name: 'test',
+                  hostname: 'test2',
+                  id: 'id',
+                  resolved: false,
+                },
+              ],
+            },
+          ],
+        }}
         getConnectionStatus={() => null}
       />
     );
@@ -61,7 +75,21 @@ describe('Execute button', () => {
         isLoading
         remediationStatus={'fullfiled'}
         issueCount={1}
-        remediationId="id"
+        remediation={{
+          id: 'id',
+          issues: [
+            {
+              systems: [
+                {
+                  display_name: 'test',
+                  hostname: 'test2',
+                  id: 'id',
+                  resolved: false,
+                },
+              ],
+            },
+          ],
+        }}
         isDisabled={false}
         getConnectionStatus={() => null}
       />
@@ -79,7 +107,21 @@ describe('Execute button', () => {
         isLoading
         remediationStatus={'fullfiled'}
         issueCount={1}
-        remediationId="id"
+        remediation={{
+          id: 'id',
+          issues: [
+            {
+              systems: [
+                {
+                  display_name: 'test',
+                  hostname: 'test2',
+                  id: 'id',
+                  resolved: false,
+                },
+              ],
+            },
+          ],
+        }}
         isDisabled={false}
         getConnectionStatus={() => null}
       />

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -194,12 +194,11 @@ const RemediationDetails = ({
                       !executable ||
                       isFedramp
                     }
-                    remediationId={remediation.id}
-                    remediationName={remediation.name}
                     connectionDetails={connectionDetails}
                     areDetailsLoading={areDetailsLoading}
                     detailsError={detailsError}
                     permissions={context.permissions.execute}
+                    remediation={remediation}
                   ></ExecutePlaybookButton>
                 </SplitItem>
                 <SplitItem>


### PR DESCRIPTION
# Description
Updates the conditionals in the popover in remediation details page. 
Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-7065))

Fixes three issues:
The tooltip incorrectly always states that there are 4 systems in a remediation plan (now updated)
-Spacing is incorrect (updated, added pf class)
-When RHC Manager (config-manager) is disabled, the execute button never loads at all (updated, i had placed setAreDetailsLoading(false) only in the try statement)

# How to test the PR
Open up a remediation detail, verify the the system count matches up and that the spacing looks fine.
If youre unaware of how to disable to rhc config, you can just comment out 'detailsError' prop and define it as a 403. 

Before: 
![Screenshot 2024-04-15 at 4 08 26 PM](https://github.com/RedHatInsights/insights-remediations-frontend/assets/60629070/9d674e22-741c-4f69-8399-00f9c7c7b317)

After: 
![Screenshot 2024-04-15 at 4 07 00 PM](https://github.com/RedHatInsights/insights-remediations-frontend/assets/60629070/b184b3e7-f5af-4f4b-9445-d147e92e85bf)

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
