### PR TITLE
feat(RHINENG-9195): Block bootc systems

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -350,7 +350,16 @@ export const fetchSystemsInfo = async (
   );
   const data =
     sliced.length > 0
-      ? await getEntities(sliced, { ...config, hasItems: true, page: 1 }, true)
+      ? await getEntities(
+          sliced,
+          {
+            ...config,
+            fields: { system_profile: ['operating_system', 'bootc_status'] },
+            hasItems: true,
+            page: 1,
+          },
+          true
+        )
       : {};
   return {
     ...{


### PR DESCRIPTION
In this example, localhost is a bootc system.  You can see there is an error and the next button is greyed out. Advisor systems are an exception to this rule. They can remediate.
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/9499094/ca8c10c7-93fc-49f4-bb50-e0847a066a7a)


