### PR TITLE
fix(RHINENG-7065): Refactor popover to include enabled execute button + new api

### DIFF
--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -4,12 +4,13 @@ import { useState, useEffect, useRef } from 'react';
 
 export const useConnectionStatus = (remediation) => {
   const axios = useAxiosWithPlatformInterceptors();
-  const [isConnected, setisConnected] = useState();
+  const [connectedSystems, setConnectedSystems] = useState(0);
+  const [totalSystems, setTotalSystems] = useState(0);
   const [areDetailsLoading, setAreDetailsLoading] = useState(true);
-  const [connectionDetails, setConnectionDetails] = useState();
   const [detailsError, setDetailsError] = useState();
   const mounted = useRef(false);
-
+  let connectedSystemCount = 0;
+  let totalSystemsCount = 0;
   useEffect(() => {
     mounted.current = true;
     const fetchData = async () => {
@@ -18,10 +19,13 @@ export const useConnectionStatus = (remediation) => {
           `${API_BASE}/remediations/${remediation.id}/connection_status`
         );
         mounted.current &&
-          setisConnected(
-            connection_status.data?.[0].connection_status === 'connected'
-          );
-        setConnectionDetails(connection_status.data[0]);
+          (connection_status.data.forEach((connected_group) => {
+            (totalSystemsCount += connected_group.system_count),
+              connected_group.connection_status === 'connected' &&
+                (connectedSystemCount = connected_group.system_count);
+          }),
+          setConnectedSystems(connectedSystemCount)),
+          setTotalSystems(totalSystemsCount);
       } catch (error) {
         console.error(error);
         setDetailsError(error.errors[0].status);
@@ -35,5 +39,5 @@ export const useConnectionStatus = (remediation) => {
     };
   }, [remediation]);
 
-  return [isConnected, connectionDetails, areDetailsLoading, detailsError];
+  return [connectedSystems, totalSystems, areDetailsLoading, detailsError];
 };

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -7,7 +7,6 @@ import { ExecuteModal } from './Modals/ExecuteModal';
 import './ExecuteButton.scss';
 import './Status.scss';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
-import { getResolvedSystems } from '../Utilities/utils';
 
 const ExecuteButton = ({
   isLoading,
@@ -19,11 +18,12 @@ const ExecuteButton = ({
   etag,
   remediationStatus,
   setEtag,
-  connectionDetails,
   areDetailsLoading,
   detailsError,
   permissions,
   remediation,
+  connectedSystems,
+  totalSystems,
 }) => {
   const [open, setOpen] = useState(false);
   const [showRefreshMessage, setShowRefreshMessage] = useState(false);
@@ -39,7 +39,7 @@ const ExecuteButton = ({
     }
   }, [remediationStatus]);
 
-  const disabledButton = () => {
+  const buttonWithTooltip = () => {
     return (
       <Tooltip
         minWidth="400px"
@@ -57,17 +57,12 @@ const ExecuteButton = ({
               </Title>
 
               <span className="pf-v5-u-font-size-sm">
-                {connectionDetails?.system_count === 4 ? (
-                  <CheckIcon className="pf-v5-u-mr-sm" />
-                ) : (
+                {connectedSystems === 0 ? (
                   <TimesIcon className="pf-v5-u-mr-sm" />
+                ) : (
+                  <CheckIcon className="pf-v5-u-mr-sm" />
                 )}
-                Connected Systems (
-                {`${
-                  getResolvedSystems(remediation.issues[0]) +
-                  '/' +
-                  remediation.issues[0].systems.length
-                }`}
+                Connected Systems ({`${connectedSystems + '/' + totalSystems}`}
                 ). See systems tab.
               </span>
 
@@ -106,24 +101,17 @@ const ExecuteButton = ({
           </>
         }
       >
-        <Button isAriaDisabled>Execute playbook</Button>
+        <Button
+          isAriaDisabled={isDisabled}
+          data-testid="execute-button-enabled"
+          onClick={() => {
+            setOpen(true);
+            getConnectionStatus(remediation.id);
+          }}
+        >
+          Execute playbook
+        </Button>
       </Tooltip>
-    );
-  };
-
-  const buttonWithTooltip = () => {
-    return isDisabled ? (
-      disabledButton()
-    ) : (
-      <Button
-        data-testid="execute-button-enabled"
-        onClick={() => {
-          setOpen(true);
-          getConnectionStatus(remediation.id);
-        }}
-      >
-        Execute playbook
-      </Button>
     );
   };
 
@@ -166,10 +154,11 @@ ExecuteButton.propTypes = {
   setEtag: PropTypes.func,
   isDisabled: PropTypes.bool,
   disabledStateText: PropTypes.string,
-  connectionDetails: PropTypes.object,
+  connectedSystems: PropTypes.number,
   areDetailsLoading: PropTypes.bool,
   detailsError: PropTypes.any,
   permissions: PropTypes.bool,
+  totalSystems: PropTypes.number,
 };
 
 ExecuteButton.defaultProps = {

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -150,7 +150,7 @@ const RemediationDetails = ({
 
   const { status, remediation } = selectedRemediation;
 
-  const [isConnected, connectionDetails, areDetailsLoading, detailsError] =
+  const [connectedSystems, totalSystems, areDetailsLoading, detailsError] =
     useConnectionStatus(remediation);
 
   useEffect(() => {
@@ -189,12 +189,13 @@ const RemediationDetails = ({
                 <SplitItem>
                   <ExecutePlaybookButton
                     isDisabled={
-                      !isConnected ||
+                      connectedSystems === 0 ||
                       !context.permissions.execute ||
                       !executable ||
                       isFedramp
                     }
-                    connectionDetails={connectionDetails}
+                    connectedSystems={connectedSystems}
+                    totalSystems={totalSystems}
                     areDetailsLoading={areDetailsLoading}
                     detailsError={detailsError}
                     permissions={context.permissions.execute}

--- a/src/routes/RemediationDetails.test.js
+++ b/src/routes/RemediationDetails.test.js
@@ -14,10 +14,27 @@ jest.mock(
 describe('useConnectionStatus', () => {
   const remediation = { id: '12345' };
 
-  test('fires off a request and returns a true boolean if all values are true', async () => {
+  test('returns 1 connected system but 4 systems total', async () => {
     useAxiosWithPlatformInterceptors.mockImplementation(() => ({
       get: () => {
-        let res = { data: [{ connection_status: 'connected' }] };
+        let res = {
+          meta: {
+            count: 2,
+            total: 2,
+          },
+          data: [
+            {
+              system_count: 1,
+              system_ids: ['826473e9-a5b9-4db7-99d6-d9f271bd8f4d'],
+              connection_status: 'connected',
+            },
+            {
+              system_count: 3,
+              system_ids: ['cb2dd466-283d-4260-b97b-c433606961ab'],
+              connection_status: 'disconnected',
+            },
+          ],
+        };
         return res;
       },
     }));
@@ -27,12 +44,25 @@ describe('useConnectionStatus', () => {
     });
     const { result } = hook;
 
-    expect(result.current[0]).toBe(true);
+    expect(result.current[0]).toBe(1);
+    expect(result.current[1]).toBe(4);
   });
-  test('fires off a request and returns FALSE', async () => {
+  test('returns 0 connected systems and 1 system total', async () => {
     useAxiosWithPlatformInterceptors.mockImplementation(() => ({
       get: () => {
-        let res = { data: [{ connection_status: 'NOT CONNECTED' }] };
+        let res = {
+          meta: {
+            count: 1,
+            total: 1,
+          },
+          data: [
+            {
+              system_count: 1,
+              system_ids: ['826473e9-a5b9-4db7-99d6-d9f271bd8f4d'],
+              connection_status: 'not_connected',
+            },
+          ],
+        };
         return res;
       },
     }));
@@ -41,6 +71,7 @@ describe('useConnectionStatus', () => {
       hook = renderHook(() => useConnectionStatus(remediation));
     });
     const { result } = hook;
-    expect(result.current[0]).toBe(false);
+    expect(result.current[0]).toBe(0);
+    expect(result.current[1]).toBe(1);
   });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-7065))

The popover in remediations details should be enable regardless if the button is disabled or not.
'Connected systems' should only come from the connection_status endpoint where the object actually says 'connected'. if there are not connected systems, the execute button should be disabled. The total amount of systems should also come from this endpoint.