### PR TITLE
feat(RHINENG:8656): Playbook rename modal doesnt allow duplicate names

### DIFF
--- a/src/Utilities/useRemediationsList.js
+++ b/src/Utilities/useRemediationsList.js
@@ -12,7 +12,7 @@ export const useRemediationsList = (remediation) => {
     const fetchData = async () => {
       try {
         const nameList = await axios.get(
-          `${API_BASE}/remediations/?fields[data]=${remediation.name}`
+          `${API_BASE}/remediations/?fields[data]=name`
         );
         mounted.current && setRemediationsList(nameList.data);
       } catch (error) {

--- a/src/Utilities/useRemediationsList.js
+++ b/src/Utilities/useRemediationsList.js
@@ -1,0 +1,30 @@
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+const { API_BASE } = require('../config');
+import { useState, useEffect, useRef } from 'react';
+
+export const useRemediationsList = (remediation) => {
+  const axios = useAxiosWithPlatformInterceptors();
+  const [remediationsList, setRemediationsList] = useState();
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    const fetchData = async () => {
+      try {
+        const nameList = await axios.get(
+          `${API_BASE}/remediations/?fields[data]=${remediation.name}`
+        );
+        mounted.current && setRemediationsList(nameList.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    remediation && fetchData();
+    return () => {
+      mounted.current = false;
+    };
+  }, [remediation]);
+
+  return remediationsList;
+};

--- a/src/Utilities/useVerifyName.js
+++ b/src/Utilities/useVerifyName.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useVerifyName = (name, remediationsList) => {
+  const [isVerifyingName, setIsVerifyingName] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const mounted = useRef(false);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    mounted.current = true;
+    setIsVerifyingName(true);
+
+    //Run a timer 1 second after an input, if the user inputs again within
+    //that timer, clear and reset timer
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    const compareData = async () => {
+      const dataHashmap = {};
+      remediationsList &&
+        remediationsList.forEach((item) => {
+          dataHashmap[item.name] = true;
+        });
+
+      const foundExistingRemediation = (name) => {
+        return dataHashmap[name];
+      };
+      foundExistingRemediation(name)
+        ? setIsDisabled(true)
+        : setIsDisabled(false);
+    };
+
+    timerRef.current = setTimeout(() => {
+      mounted.current && compareData();
+      setIsVerifyingName(false);
+    }, 1000);
+
+    return () => {
+      mounted.current = false;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [name, remediationsList]);
+
+  return [isVerifyingName, isDisabled];
+};

--- a/src/components/Dialogs/TextInputDialog.js
+++ b/src/components/Dialogs/TextInputDialog.js
@@ -8,6 +8,7 @@ import {
   TextInput,
   ModalVariant,
   Spinner,
+  ValidatedOptions,
 } from '@patternfly/react-core';
 import { useVerifyName } from '../../Utilities/useVerifyName';
 
@@ -72,7 +73,18 @@ export default function TextInputDialog(props) {
           aria-label={ariaLabel || 'input text'}
           autoFocus
           isValid={valid}
+          validated={(isDisabled || !valid) && ValidatedOptions.error}
         />
+        {isDisabled && (
+          <p className="pf-v5-u-font-size-sm pf-v5-u-danger-color-100">
+            Playbook with the same name already exists.
+          </p>
+        )}
+        {!valid && (
+          <p className="pf-v5-u-font-size-sm pf-v5-u-danger-color-100">
+            Playbook name cannot be empty.
+          </p>
+        )}
       </FormGroup>
     </Modal>
   );

--- a/src/components/Dialogs/TextInputDialog.js
+++ b/src/components/Dialogs/TextInputDialog.js
@@ -7,7 +7,9 @@ import {
   Modal,
   TextInput,
   ModalVariant,
+  Spinner,
 } from '@patternfly/react-core';
+import { useVerifyName } from '../../Utilities/useVerifyName';
 
 export default function TextInputDialog(props) {
   const [value, setValue] = useState(props.value || '');
@@ -22,21 +24,30 @@ export default function TextInputDialog(props) {
     }
   }
 
+  const [isVerifyingName, isDisabled] = useVerifyName(
+    value,
+    props.remediationsList
+  );
+
   return (
     <Modal
       title={title}
       isOpen={true}
       onClose={(event) => onCancel(event)}
       actions={[
-        <Button
-          key="confirm"
-          variant="primary"
-          onClick={() => onSubmit(value)}
-          isDisabled={!valid}
-          ouiaId="save"
-        >
-          Save
-        </Button>,
+        isVerifyingName ? (
+          <Spinner size="lg" className="pf-u-mr-sm" />
+        ) : (
+          <Button
+            key="confirm"
+            variant="primary"
+            onClick={() => onSubmit(value)}
+            isDisabled={!valid || isVerifyingName || isDisabled}
+            ouiaId="save"
+          >
+            Save
+          </Button>
+        ),
         <Button
           key="cancel"
           variant="secondary"
@@ -75,4 +86,5 @@ TextInputDialog.propTypes = {
   value: PropTypes.string,
   className: PropTypes.string,
   pattern: PropTypes.instanceOf(RegExp),
+  remediationsList: PropTypes.array,
 };

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -16,7 +16,7 @@ import { dispatchNotification } from '../Utilities/dispatcher';
 
 import { PermissionContext } from '../App';
 
-const playbookNamePattern = /^$|^.*[\w\d]+.*$/;
+const playbookNamePattern = /^(?!$).*[\w\d]+.*$/;
 const EMPTY_NAME = 'Unnamed Playbook';
 
 function RemediationDetailsDropdown({

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -19,7 +19,12 @@ import { PermissionContext } from '../App';
 const playbookNamePattern = /^$|^.*[\w\d]+.*$/;
 const EMPTY_NAME = 'Unnamed Playbook';
 
-function RemediationDetailsDropdown({ remediation, onRename, onDelete }) {
+function RemediationDetailsDropdown({
+  remediation,
+  onRename,
+  onDelete,
+  remediationsList,
+}) {
   const [open, setOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -46,6 +51,7 @@ function RemediationDetailsDropdown({ remediation, onRename, onDelete }) {
             });
           }}
           pattern={playbookNamePattern}
+          remediationsList={remediationsList}
         />
       )}
 
@@ -98,6 +104,7 @@ RemediationDetailsDropdown.propTypes = {
   remediation: PropTypes.object.isRequired,
   onRename: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
+  remediationsList: PropTypes.array,
 };
 
 const connected = connect(null, (dispatch) => ({

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -50,6 +50,7 @@ import NoReceptorBanner from '../components/Alerts/NoReceptorBanner';
 import { RemediationSummary } from '../components/RemediationSummary';
 import { dispatchNotification } from '../Utilities/dispatcher';
 import { useConnectionStatus } from '../Utilities/useConnectionStatus';
+import { useRemediationsList } from '../Utilities/useRemediationsList';
 
 const RemediationDetails = ({
   selectedRemediation,
@@ -153,6 +154,8 @@ const RemediationDetails = ({
   const [connectedSystems, totalSystems, areDetailsLoading, detailsError] =
     useConnectionStatus(remediation);
 
+  const remediationsList = useRemediationsList(remediation);
+
   useEffect(() => {
     remediation &&
       chrome.updateDocumentTitle(
@@ -222,7 +225,10 @@ const RemediationDetails = ({
                   </Button>
                 </SplitItem>
                 <SplitItem>
-                  <RemediationDetailsDropdown remediation={remediation} />
+                  <RemediationDetailsDropdown
+                    remediation={remediation}
+                    remediationsList={remediationsList}
+                  />
                 </SplitItem>
               </Split>
             </LevelItem>


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(issue)](https://issues.redhat.com/browse/RHINENG-8656)

This removes the ability to name a remediation against one that already exist. No duplicates being possible moving forward. (Seperate PR for creation of remediation will be made)

# How to test the PR

grab any remediation name, copy it, and then go to the details of any other remediation.
Then try to rename the remediation with the copied string. The button should be disabled.

I added a timeout that is reset when the user types, so the logic shouldnt perform until the user is done typing (unless they type reaaaaallllly slowly).
While the logic is happening, a spinner takes the buttons place to indicate to the user that something is happening in the background as opposed to it just being disabled.
# Before the change
You could duplicate a remediation with any already-existing name

# After the change
you cannot name a remediation the same as another.

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
