### PR TITLE
feat(RHINENG-8657): Creation modal cannot duplicate names + refinement

### DIFF
--- a/src/Utilities/useRemediationsList.js
+++ b/src/Utilities/useRemediationsList.js
@@ -20,7 +20,7 @@ export const useRemediationsList = (remediation) => {
       }
     };
 
-    remediation && fetchData();
+    fetchData();
     return () => {
       mounted.current = false;
     };

--- a/src/Utilities/useVerifyName.js
+++ b/src/Utilities/useVerifyName.js
@@ -5,6 +5,7 @@ export const useVerifyName = (name, remediationsList) => {
   const [isDisabled, setIsDisabled] = useState(false);
   const mounted = useRef(false);
   const timerRef = useRef(null);
+  const playbookNamePattern = /^(?!$).*[\w\d]+.*$/;
 
   useEffect(() => {
     mounted.current = true;
@@ -17,18 +18,19 @@ export const useVerifyName = (name, remediationsList) => {
     }
 
     const compareData = async () => {
+      const trimmedVal = name.trim();
+
       const dataHashmap = {};
       remediationsList &&
         remediationsList.forEach((item) => {
           dataHashmap[item.name] = true;
         });
 
-      const foundExistingRemediation = (name) => {
-        return dataHashmap[name];
-      };
-      foundExistingRemediation(name)
-        ? setIsDisabled(true)
-        : setIsDisabled(false);
+      if (dataHashmap[trimmedVal] && playbookNamePattern.test(trimmedVal)) {
+        setIsDisabled(true);
+      } else {
+        setIsDisabled(false);
+      }
     };
 
     timerRef.current = setTimeout(() => {

--- a/src/components/Dialogs/TextInputDialog.js
+++ b/src/components/Dialogs/TextInputDialog.js
@@ -14,16 +14,7 @@ import { useVerifyName } from '../../Utilities/useVerifyName';
 
 export default function TextInputDialog(props) {
   const [value, setValue] = useState(props.value || '');
-  const [valid, setValid] = useState(true);
   const { title, onCancel, onSubmit, ariaLabel, className } = props;
-
-  function onChange(value) {
-    setValue(value);
-
-    if (props.pattern) {
-      setValid(props.pattern.test(value));
-    }
-  }
 
   const [isVerifyingName, isDisabled] = useVerifyName(
     value,
@@ -43,7 +34,7 @@ export default function TextInputDialog(props) {
             key="confirm"
             variant="primary"
             onClick={() => onSubmit(value)}
-            isDisabled={!valid || isVerifyingName || isDisabled}
+            isDisabled={isDisabled || value.trim() === ''}
             ouiaId="save"
           >
             Save
@@ -64,23 +55,29 @@ export default function TextInputDialog(props) {
       <FormGroup
         fieldId="remediation-name"
         helperTextInvalid="Playbook name has to contain alphanumeric characters"
-        isValid={valid}
+        isValid={isDisabled}
       >
         <TextInput
           value={value}
           type="text"
-          onChange={(_event, value) => onChange(value)}
+          onChange={(_event, value) => setValue(value)}
           aria-label={ariaLabel || 'input text'}
           autoFocus
-          isValid={valid}
-          validated={(isDisabled || !valid) && ValidatedOptions.error}
+          isValid={!isDisabled}
+          validated={
+            //isDisabled check if item exist in current remList,
+            //if exist and is current rem, dont show error message
+            value === props.value && isDisabled
+              ? ValidatedOptions.default
+              : (value.trim() === '' || isDisabled) && ValidatedOptions.error
+          }
         />
-        {isDisabled && (
+        {isDisabled && value !== props.value && (
           <p className="pf-v5-u-font-size-sm pf-v5-u-danger-color-100">
             Playbook with the same name already exists.
           </p>
         )}
-        {!valid && (
+        {value.trim() === '' && (
           <p className="pf-v5-u-font-size-sm pf-v5-u-danger-color-100">
             Playbook name cannot be empty.
           </p>

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -16,7 +16,6 @@ import { dispatchNotification } from '../Utilities/dispatcher';
 
 import { PermissionContext } from '../App';
 
-const playbookNamePattern = /^(?!$).*[\w\d]+.*$/;
 const EMPTY_NAME = 'Unnamed Playbook';
 
 function RemediationDetailsDropdown({
@@ -50,7 +49,6 @@ function RemediationDetailsDropdown({
               autoDismiss: true,
             });
           }}
-          pattern={playbookNamePattern}
           remediationsList={remediationsList}
         />
       )}

--- a/src/modules/RemediationsModal/RemediationsWizard.js
+++ b/src/modules/RemediationsModal/RemediationsWizard.js
@@ -45,6 +45,7 @@ import {
 } from '../../Utilities/utils';
 import Progress from './steps/progress';
 import { ModalVariant } from '@patternfly/react-core';
+import { useRemediationsList } from '../../Utilities/useRemediationsList';
 
 const initialState = {
   submitted: false,
@@ -74,6 +75,7 @@ export const RemediationWizard = ({ setOpen, data, basePath, registry }) => {
       )
     )
   );
+  const remediationsList = useRemediationsList();
 
   const dispatch = useDispatch();
 
@@ -90,7 +92,11 @@ export const RemediationWizard = ({ setOpen, data, basePath, registry }) => {
   };
 
   useEffect(() => {
-    setState({ type: 'schema', payload: schemaBuilder(data.issues) });
+    remediationsList &&
+      setState({
+        type: 'schema',
+        payload: schemaBuilder(data.issues, remediationsList),
+      });
     registry.register({
       hostReducer: applyReducerHash(hostReducer, hostsInitialState),
       resolutionsReducer: applyReducerHash(
@@ -100,7 +106,7 @@ export const RemediationWizard = ({ setOpen, data, basePath, registry }) => {
     });
     dispatch(fetchResolutions(data.issues));
     fetchHostNames(allSystems.current);
-  }, []);
+  }, [remediationsList]);
 
   const mapperExtension = {
     'select-playbook': {
@@ -108,6 +114,7 @@ export const RemediationWizard = ({ setOpen, data, basePath, registry }) => {
       issues: data.issues,
       systems: data.systems,
       allSystems: allSystems.current,
+      remediationsList: remediationsList,
     },
     'review-systems': {
       component: ReviewSystems,
@@ -263,6 +270,7 @@ RemediationWizard.propTypes = {
   registry: propTypes.shape({
     register: propTypes.func,
   }).isRequired,
+  remediationsList: propTypes.array,
 };
 
 const RemediationWizardWithContext = (props) => {

--- a/src/modules/RemediationsModal/common/helpers.js
+++ b/src/modules/RemediationsModal/common/helpers.js
@@ -1,0 +1,18 @@
+export const verifyName = (val, remediationsList) => {
+  const compareData = () => {
+    const trimmedVal = val.trim();
+    const dataHashmap = {};
+    remediationsList &&
+      remediationsList.forEach((item) => {
+        dataHashmap[item.name] = true;
+      });
+
+    if (dataHashmap[trimmedVal]) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  return compareData();
+};

--- a/src/modules/RemediationsModal/schema.js
+++ b/src/modules/RemediationsModal/schema.js
@@ -12,8 +12,9 @@ import {
   RESOLUTIONS,
   shortenIssueId,
 } from '../../Utilities/utils';
+import { verifyName } from './common/helpers';
 
-export const selectPlaybookFields = [
+export const selectPlaybookFields = (remediationsList) => [
   {
     name: SELECT_PLAYBOOK,
     component: 'select-playbook',
@@ -25,6 +26,10 @@ export const selectPlaybookFields = [
       {
         type: validatorTypes.REQUIRED,
       },
+      (value) =>
+        verifyName(value, remediationsList)
+          ? 'Duplicate names are not allowed'
+          : undefined,
     ],
   },
   {
@@ -101,7 +106,7 @@ export const reviewSystemsNextStep = (values) => {
   return filteredIssues.length > 0 ? 'actions' : 'review';
 };
 
-export default (issues) => ({
+export default (issues, remediationsList) => ({
   fields: [
     {
       component: componentTypes.WIZARD,
@@ -115,7 +120,7 @@ export default (issues) => ({
         {
           name: 'playbook',
           title: 'Select playbook',
-          fields: selectPlaybookFields,
+          fields: selectPlaybookFields(remediationsList),
           nextStep: 'systems',
         },
         {


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-8657))
This PR eliminates the ability to have duplicate names in the creation modal. 
To test run the PR and run apps that consume remediationsButton. For this example ill use advisor.

Advisor -> Recommendations ->Rec Details -> system details ->  select a system and remediate it.
When creating the remediation, you should NOT be allowed to move forward, and be greeted with an error message if
- Remediaton name exist
- Remediation name exist and you add trailing spaces 

Theres no error for an empty remediation but the modal already doesnt allow for this 
# How to test the PR

Refinement work
When editing a remediation name, there should also be errors for the same reasons, and it the remediation name is empty. 
# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description

