### PR TITLE
fix(RHINENG-9877): Update Validation for Remediations modal

### DIFF
--- a/src/modules/RemediationsModal/schema.js
+++ b/src/modules/RemediationsModal/schema.js
@@ -26,10 +26,15 @@ export const selectPlaybookFields = (remediationsList) => [
       {
         type: validatorTypes.REQUIRED,
       },
-      (value) =>
-        verifyName(value, remediationsList)
-          ? 'Duplicate names are not allowed'
-          : undefined,
+      (value, formValues) => {
+        const isPlaybookSelected = formValues[EXISTING_PLAYBOOK_SELECTED];
+        if (!isPlaybookSelected && value) {
+          return verifyName(value, remediationsList)
+            ? 'Duplicate names are not allowed'
+            : undefined;
+        }
+        return undefined;
+      },
     ],
   },
   {


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([issue](https://issues.redhat.com/browse/RHINENG-9877))

In the remediation modal, when creating a playbook, selecting an existing playbook resulted in not being able to move forward. This updates the validation so that you can click an existing playbook, and so error messaging still works on the text field


# How to test the PR
You can check via anywhere the button is available but for ex.
Advisor - recommendations -> rec details -> System details and remediate button.
- Select an existing remediation and see that you can proceed to the next step.
- Select create a playbook and verify that you still cant move forward when you have a duplicate name.

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
