### PR TITLE
fix(RHINENG-8088): refactor select playbook typeahead

### DIFF
--- a/src/modules/RemediationsModal/common/ExistingPlaybookTypeahead.js
+++ b/src/modules/RemediationsModal/common/ExistingPlaybookTypeahead.js
@@ -1,0 +1,204 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  MenuToggle,
+  TextInputGroup,
+  TextInputGroupMain,
+} from '@patternfly/react-core';
+import propTypes from 'prop-types';
+import { EXISTING_PLAYBOOK } from '../../../Utilities/utils';
+import * as api from '../../../api';
+
+const ExistingPlaybookTypeahead = ({
+  selectedPlaybook,
+  setIsLoadingRemediation,
+  setSelectedPlaybook,
+  existingPlaybookSelected,
+  existingRemediations,
+  input,
+  formOptions,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
+  const [selectOptions, setSelectOptions] = useState(existingRemediations);
+  const [focusedItemIndex, setFocusedItemIndex] = useState(null);
+  const [activeItem, setActiveItem] = useState(null);
+  const textInputRef = useRef();
+
+  useEffect(() => {
+    let newSelectOptions = existingRemediations;
+    if (filterValue) {
+      newSelectOptions = existingRemediations.filter((menuItem) =>
+        String(menuItem.name).toLowerCase().includes(filterValue.toLowerCase())
+      );
+
+      if (!newSelectOptions.length) {
+        newSelectOptions = [
+          {
+            name: `No results found for "${filterValue}"`,
+          },
+        ];
+      }
+
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+    }
+
+    setSelectOptions(newSelectOptions);
+    setActiveItem(null);
+    setFocusedItemIndex(null);
+  }, [filterValue]);
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (_event, value) => {
+    setIsLoadingRemediation(true);
+    api.getRemediation(value).then((remediation) => {
+      setSelectedPlaybook(remediation);
+      setIsLoadingRemediation(false);
+      existingPlaybookSelected && input.onChange(remediation.name);
+      existingPlaybookSelected &&
+        formOptions.change(EXISTING_PLAYBOOK, remediation);
+    });
+  };
+
+  const onTextInputChange = (_event, value) => {
+    setFilterValue(value);
+  };
+
+  const handleMenuArrowKeys = (key) => {
+    let indexToFocus;
+
+    if (isOpen) {
+      if (key === 'ArrowUp') {
+        if (focusedItemIndex === null || focusedItemIndex === 0) {
+          indexToFocus = selectOptions.length - 1;
+        } else {
+          indexToFocus = focusedItemIndex - 1;
+        }
+      }
+
+      if (key === 'ArrowDown') {
+        if (
+          focusedItemIndex === null ||
+          focusedItemIndex === selectOptions.length - 1
+        ) {
+          indexToFocus = 0;
+        } else {
+          indexToFocus = focusedItemIndex + 1;
+        }
+      }
+
+      setFocusedItemIndex(indexToFocus);
+      const focusedItem = selectOptions.filter((option) => !option.isDisabled)[
+        indexToFocus
+      ];
+
+      setActiveItem(`select-typeahead-${focusedItem.name.replace(' ', '-')}`);
+    }
+  };
+
+  const onInputKeyDown = (event) => {
+    const enabledMenuItems = selectOptions.filter(
+      (option) => !option.isDisabled
+    );
+    const [firstMenuItem] = enabledMenuItems;
+    const focusedItem = focusedItemIndex
+      ? enabledMenuItems[focusedItemIndex]
+      : firstMenuItem;
+    switch (event.key) {
+      case 'Enter':
+        if (isOpen && focusedItem.name !== 'no results') {
+          onSelect(null, focusedItem.id);
+        }
+        setIsOpen((prevIsOpen) => !prevIsOpen);
+        setFocusedItemIndex(null);
+        setActiveItem(null);
+        break;
+      case 'Escape':
+        setIsOpen(false);
+        setActiveItem(null);
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const toggle = (toggleRef) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      aria-label="Typeahead menu toggle"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={selectedPlaybook?.name || filterValue}
+          onClick={onToggleClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id="typeahead-select-input"
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder="Select playbook"
+          {...(activeItem && {
+            'aria-activedescendant': activeItem,
+          })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="select-typeahead-listbox"
+        />
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id="typeahead-select-existing-playbook"
+      isOpen={isOpen}
+      selected={selectedPlaybook?.name}
+      onSelect={onSelect}
+      onOpenChange={() => {
+        setIsOpen(false);
+      }}
+      toggle={toggle}
+      isScrollable
+    >
+      <SelectList id="select-typeahead-listbox">
+        {selectOptions.map((remediation, index) => {
+          return (
+            <SelectOption
+              key={remediation.id}
+              value={remediation.id}
+              isFocused={focusedItemIndex === index}
+              id={remediation.id}
+            >
+              {remediation.name}
+            </SelectOption>
+          );
+        })}
+      </SelectList>
+    </Select>
+  );
+};
+
+ExistingPlaybookTypeahead.propTypes = {
+  selectedPlaybook: propTypes.object,
+  setIsLoadingRemediation: propTypes.func,
+  setSelectedPlaybook: propTypes.func,
+  existingPlaybookSelected: propTypes.bool,
+  existingRemediations: propTypes.array,
+  input: propTypes.object,
+  formOptions: propTypes.object,
+};
+
+export default ExistingPlaybookTypeahead;

--- a/src/modules/RemediationsModal/steps/selectPlaybook.js
+++ b/src/modules/RemediationsModal/steps/selectPlaybook.js
@@ -10,13 +10,12 @@ import * as api from '../../../api';
 import { Fragment } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import FetchError from './fetchError';
+import ExistingPlaybookTypeahead from '../common/ExistingPlaybookTypeahead';
 import {
   FormGroup,
   Grid,
   GridItem,
   Radio,
-  FormSelect,
-  FormSelectOption,
   Text,
   TextContent,
   TextInput,
@@ -191,42 +190,15 @@ const SelectPlaybook = (props) => {
           </GridItem>
           <GridItem sm={12} md={6} lg={4}>
             {existingRemediations && !isLoadingRemediation ? (
-              <FormSelect
-                onChange={(_event, val) => {
-                  setIsLoadingRemediation(true);
-                  api.getRemediation(val).then((remediation) => {
-                    setSelectedPlaybook(remediation);
-                    setIsLoadingRemediation(false);
-                    existingPlaybookSelected &&
-                      input.onChange(remediation.name);
-                    existingPlaybookSelected &&
-                      formOptions.change(EXISTING_PLAYBOOK, remediation);
-                  });
-                }}
-                value={selectedPlaybook?.id || ''}
-                aria-label="Select an existing playbook"
-              >
-                {existingRemediations?.length ? (
-                  [
-                    <FormSelectOption
-                      key="select-playbook-placeholder"
-                      data-testid="select-playbook-placeholder"
-                      value=""
-                      label="Select playbook"
-                      isDisabled
-                    />,
-                    ...existingRemediations.map(({ id, name }) => (
-                      <FormSelectOption key={id} value={id} label={name} />
-                    )),
-                  ]
-                ) : (
-                  <FormSelectOption
-                    key="empty"
-                    value="empty"
-                    label="No existing playbooks"
-                  />
-                )}
-              </FormSelect>
+              <ExistingPlaybookTypeahead
+                selectedPlaybook={selectedPlaybook}
+                setIsLoadingRemediation={setIsLoadingRemediation}
+                setSelectedPlaybook={setSelectedPlaybook}
+                existingPlaybookSelected={existingPlaybookSelected}
+                existingRemediations={existingRemediations}
+                input={input}
+                formOptions={formOptions}
+              />
             ) : (
               <Skeleton size={SkeletonSize.lg} data-testid="skeleton-loader" />
             )}

--- a/src/modules/tests/steps/selectPlaybook.test.js
+++ b/src/modules/tests/steps/selectPlaybook.test.js
@@ -18,7 +18,12 @@ jest.mock('../../../api', () => ({
   getRemediations: jest.fn(
     () =>
       new Promise((resolve) =>
-        resolve({ data: [{ id: 'remediationId', name: 'test-remediation-1' }] })
+        resolve({
+          data: [
+            { id: 'remediationId', name: 'test-remediation-1' },
+            { id: '1234', name: 'bretheren' },
+          ],
+        })
       )
   ),
   getRemediation: jest.fn(
@@ -117,8 +122,60 @@ describe('SelectPlaybook', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('test-remediation-1')).toBeVisible();
+      expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
     });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('combobox', {
+          name: /type to filter/i,
+        })
+      ).toBeVisible();
+    });
+  });
+
+  it('should use type ahead on existing playbooks dropdown', async () => {
+    const store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <RendererWrapper schema={createSchema({})} {...initialProps} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
+    });
+
+    const typeaheadBox = screen.getByRole('combobox', {
+      name: /type to filter/i,
+    });
+    await userEvent.click(typeaheadBox);
+
+    expect(
+      screen.getByRole('option', {
+        name: /test-remediation-1/i,
+      })
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('option', {
+        name: /bretheren/i,
+      })
+    ).toBeVisible();
+
+    await userEvent.type(typeaheadBox, 'br');
+
+    expect(
+      screen.queryByRole('option', {
+        name: /test-remediation-1/i,
+      })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('option', {
+        name: /bretheren/i,
+      })
+    ).toBeVisible();
   });
 
   it('should be able to create new playbook', async () => {

--- a/src/modules/tests/steps/selectPlaybook.test.js
+++ b/src/modules/tests/steps/selectPlaybook.test.js
@@ -12,6 +12,7 @@ import { Provider } from 'react-redux';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { getRemediation } from '../../../api';
 
 jest.mock('../../../api', () => ({
   ...jest.requireActual('../../../api'),
@@ -176,6 +177,82 @@ describe('SelectPlaybook', () => {
         name: /bretheren/i,
       })
     ).toBeVisible();
+  });
+
+  it('should display no results found on typeahead', async () => {
+    const store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <RendererWrapper schema={createSchema({})} {...initialProps} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
+    });
+
+    const typeaheadBox = screen.getByRole('combobox', {
+      name: /type to filter/i,
+    });
+    await userEvent.click(typeaheadBox);
+
+    expect(
+      screen.getByRole('option', {
+        name: /test-remediation-1/i,
+      })
+    ).toBeVisible();
+
+    expect(
+      screen.getByRole('option', {
+        name: /bretheren/i,
+      })
+    ).toBeVisible();
+
+    await userEvent.type(typeaheadBox, 'tooted');
+
+    expect(
+      screen.queryByRole('option', {
+        name: /test-remediation-1/i,
+      })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('option', {
+        name: /bretheren/i,
+      })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('option', {
+        name: /no results found for "tooted"/i,
+      })
+    ).toBeVisible();
+  });
+
+  it('should call getRemediation on select', async () => {
+    const store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <RendererWrapper schema={createSchema({})} {...initialProps} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skeleton-loader')).not.toBeInTheDocument();
+    });
+
+    const typeaheadBox = screen.getByRole('combobox', {
+      name: /type to filter/i,
+    });
+    await userEvent.click(typeaheadBox);
+
+    await userEvent.click(
+      screen.queryByRole('option', {
+        name: /test-remediation-1/i,
+      })
+    );
+
+    expect(getRemediation).toHaveBeenCalled();
   });
 
   it('should be able to create new playbook', async () => {


### PR DESCRIPTION
# Description

Associated Jira ticket: # 8088

When you are creating playbook and choose from Existing playbooks (Add to existing playbook) select appears without search option. Seems it happened after Patternfly 5 migration. 

# How to test the PR

To repro:
- Choose and click a system in inventory
- From the system details page, click the Vulnerability tab Pick CVE(s) and click on Remediate button
- When modal opens - click in the "Select playbook" box

# Before the change
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/15373136/0fb53928-b514-4e9d-855d-21daca4c0ecb)

This box should allow typeahead, which filters the existing playbooks as you type. But this feature seems to have been removed from the PF component we were using and have been moved to the Select component.

# After the change
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/15373136/02ef426f-1ead-4bb3-8d1b-86ad59b1a86e)

This PR refactors this box to allow typeahead.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [x] README.md is updated if necessary
- [ ] Needs additional dependent work
