### PR TITLE
Update <a> to <Link> when Executing playbook

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -4,6 +4,11 @@ import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  __esModule: true,
+  default: () => ({
+    getApp: () => 'remediations',
+    getBundle: () => 'insights',
+  }),
   useChrome: () => ({
     isBeta: jest.fn(),
     chrome: jest.fn(),

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -7,6 +7,8 @@ import { ExecuteModal } from './Modals/ExecuteModal';
 import './ExecuteButton.scss';
 import './Status.scss';
 import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { Link } from 'react-router-dom';
 
 const ExecuteButton = ({
   isLoading,
@@ -72,13 +74,14 @@ const ExecuteButton = ({
                 ) : (
                   <CheckIcon className="pf-v5-u-mr-sm" />
                 )}
-                <a
-                  href="https://console.redhat.com/insights/connector"
+                <InsightsLink
+                  app="connector"
+                  to="/"
                   style={{ textDecoration: 'underline', color: 'white' }}
                   className="pf-v5-u-mr-xs"
                 >
                   RHC manager
-                </a>
+                </InsightsLink>
                 is {detailsError === 403 ? 'disabled' : 'enabled'}.
               </span>
 
@@ -88,13 +91,13 @@ const ExecuteButton = ({
                 ) : (
                   <TimesIcon className="pf-v5-u-mr-sm" />
                 )}
-                <a
-                  href="https://console.redhat.com/iam/user-access/overview"
+                <Link
+                  to="/iam/user-access/overview"
                   style={{ textDecoration: 'underline', color: 'white' }}
                   className="pf-v5-u-mr-xs"
                 >
                   User access permissions
-                </a>
+                </Link>
                 are {permissions ? '' : 'not'} granted.
               </span>
             </Flex>

--- a/src/components/__tests__/ExecuteButton.test.js
+++ b/src/components/__tests__/ExecuteButton.test.js
@@ -5,6 +5,7 @@ import * as api from '../../api';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 // eslint-disable-next-line no-import-assign
 api.downloadPlaybook = jest.fn();
@@ -102,29 +103,31 @@ describe('Execute button', () => {
 
   test('Opens execute modal on execute button click', async () => {
     render(
-      <ExecuteButton
-        data={data}
-        isLoading
-        remediationStatus={'fullfiled'}
-        issueCount={1}
-        remediation={{
-          id: 'id',
-          issues: [
-            {
-              systems: [
-                {
-                  display_name: 'test',
-                  hostname: 'test2',
-                  id: 'id',
-                  resolved: false,
-                },
-              ],
-            },
-          ],
-        }}
-        isDisabled={false}
-        getConnectionStatus={() => null}
-      />
+      <Router>
+        <ExecuteButton
+          data={data}
+          isLoading
+          remediationStatus={'fullfiled'}
+          issueCount={1}
+          remediation={{
+            id: 'id',
+            issues: [
+              {
+                systems: [
+                  {
+                    display_name: 'test',
+                    hostname: 'test2',
+                    id: 'id',
+                    resolved: false,
+                  },
+                ],
+              },
+            ],
+          }}
+          isDisabled={false}
+          getConnectionStatus={() => null}
+        />
+      </Router>
     );
 
     expect(screen.queryByTestId('execute-button')).not.toBeInTheDocument();

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -21,11 +21,7 @@ import {
 import { CancelButton } from '../containers/CancelButton';
 
 import { capitalize } from '../Utilities/utils';
-
-const connectorUrl = (isBeta) =>
-  isBeta
-    ? `${window.location.origin}/preview/settings/connector`
-    : `${window.location.origin}/settings/connector`;
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 
 export const normalizeStatus = (status) =>
   ({
@@ -204,7 +200,7 @@ StatusSummary.propTypes = {
   playbookId: PropTypes.string,
 };
 
-export const styledConnectionStatus = (status, isBeta) =>
+export const styledConnectionStatus = (status) =>
   ({
     connected: (
       <TextContent>
@@ -307,16 +303,13 @@ export const styledConnectionStatus = (status, isBeta) =>
           <Text component={TextVariants.small} style={{ margin: '0px' }}>
             Remediation from Insights requires Cloud connector. Cloud connector
             can be enabled via Satelite, or through &nbsp;
-            <Button
-              className="pf-u-p-0"
-              key="configure"
-              variant="link"
-              component="a"
-              // eslint-disable-next-line max-len
-              href={connectorUrl(isBeta)}
+            <InsightsLink
+              app="connector"
+              to="/"
+              className="pf-v5-u-font-size-md pf-v5-u-display-inline-block"
             >
               RHC (Red Hat connector)
-            </Button>
+            </InsightsLink>
           </Text>
           <Button
             className="pf-u-p-0"
@@ -339,16 +332,13 @@ export const styledConnectionStatus = (status, isBeta) =>
           <Text component={TextVariants.small} style={{ margin: '0px' }}>
             Remediation from Insights requires Cloud connector. Cloud connector
             can be enabled via Satelite, or through &nbsp;
-            <Button
-              className="pf-u-p-0"
-              key="configure"
-              variant="link"
-              component="a"
-              // eslint-disable-next-line max-len
-              href={connectorUrl(isBeta)}
+            <InsightsLink
+              app="connector"
+              to="/"
+              className="pf-v5-u-font-size-md pf-v5-u-display-inline-block"
             >
               RHC (Red Hat connector)
-            </Button>
+            </InsightsLink>
           </Text>
           <Button
             className="pf-u-p-0"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-11983

How to test:
1. Go to detail of any playbook which can be executed
2. Hover over the "Execute playbook" button
3. The two links in the shown tooltip should take you to the corresponding app without having to reload the whole page
4. Click on the "Execute playbook" button
5. The "RHC (Red Hat connector)" link should take you to the corresponding app without having to reload the whole page