### PR TITLE
Reset  filter after Playbook deletion

### DIFF
--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -339,6 +339,7 @@ const Home = () => {
                           await deleteRemediations(selectedIds);
 
                           loadRemediations();
+                          activeFiltersConfig.onDelete();
                           selector.reset();
                         }
                       }}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-4954

Before -- after deleting the playbook the filter did not reset, but the cards below were fetched as if the filter wasn't applied
After -- after deleting the playbook the filter is reset and cards are shown correctly
