### PR TITLE
fix(RHINENG-11503): Playbook log doesn't display properly

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TextEncoder } from 'util';
 import { enableFetchMocks } from 'jest-fetch-mock';
 
 enableFetchMocks();
@@ -18,6 +19,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 global.React = React;
 global.insights = {};
+global.TextEncoder = TextEncoder;
 
 window.HTMLElement.prototype.scrollTo = jest.fn();
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "!**/node_modules/**"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!@redhat-cloud-services)"
+      "/node_modules/(?!(uuid|@redhat-cloud-services|react-syntax-highlighter))"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"

--- a/src/actions.js
+++ b/src/actions.js
@@ -155,6 +155,10 @@ export const getPlaybookRunSystemDetails = (
   ),
 });
 
+export const clearPlaybookRunSystemDetails = () => ({
+  type: ACTION_TYPES.CLEAR_PLAYBOOK_RUN_SYSTEM_DETAILS,
+});
+
 export const expandInventoryTable = (id, isOpen) => ({
   type: ACTION_TYPES.EXPAND_INVENTORY_TABLE,
   payload: {

--- a/src/components/__fixtures__/remediations.fixtures.js
+++ b/src/components/__fixtures__/remediations.fixtures.js
@@ -22,3 +22,46 @@ export const remediationsMock = [
     },
   },
 ];
+
+export const playbookRunsMock = {
+  meta: {
+    count: 1,
+    total: 1,
+  },
+  data: {
+    created_at: '2024-10-04T10:26:24.015Z',
+    created_by: {
+      first_name: 'Ender',
+      last_name: 'Wiggin',
+      username: 'dragon',
+    },
+    executors: [
+      {
+        executor_id: 'be95812a-b98a-4dc3-bc2f-f93970f71bcf',
+        executor_name: 'Direct connected',
+        status: 'success',
+        system_count: 1,
+        counts: {
+          pending: 0,
+          failure: 0,
+          canceled: 0,
+          running: 0,
+          success: 1,
+        },
+      },
+    ],
+    id: '5678',
+    remediation_id: 'be95812a-b98a-4dc3-bc2f-f93970f71bcf',
+    status: 'success',
+    updated_at: '2024-10-04T10:26:24.015Z',
+  },
+};
+
+export const playbookRunSystemDetailsMock = {
+  console: '',
+  playbook_run_executor_id: '5678',
+  status: 'success',
+  system_id: 'efgh',
+  system_name: 'system1',
+  updated_at: '2024-10-04T10:28:10.301551Z',
+};

--- a/src/components/__tests__/ExecutorDetails.test.js
+++ b/src/components/__tests__/ExecutorDetails.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import ExecutorDetails from '../ExecutorDetails/ExecutorDetails';
+import configureStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import {
+  playbookRunsMock,
+  playbookRunSystemDetailsMock,
+  remediationsMock,
+} from '../__fixtures__/remediations.fixtures';
+import { Provider } from 'react-redux';
+import { clearPlaybookRunSystemDetails } from '../../actions';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    executor_id: 'be95812a-b98a-4dc3-bc2f-f93970f71bcf',
+    run_id: 'be95812a-b98a-4dc3-bc2f-f93970f71bcf',
+    id: '5678',
+  }),
+}));
+
+jest.mock('../../actions', () => ({
+  clearPlaybookRunSystemDetails: jest.fn(),
+  getPlaybookRun: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => jest.fn(),
+}));
+
+describe('Execute button', () => {
+  let mockStore;
+  let initialState;
+
+  beforeEach(() => {
+    mockStore = configureStore();
+    initialState = {
+      selectedRemediation: {
+        remediation: remediationsMock,
+      },
+      playbookRun: playbookRunsMock,
+      playbookRunSystemDetails: playbookRunSystemDetailsMock,
+    };
+  });
+
+  test('playbookRunSystemDetails is cleared in redux on initial load', async () => {
+    const store = mockStore(initialState);
+    render(
+      <Router>
+        <Provider store={store}>
+          <ExecutorDetails />
+        </Provider>
+      </Router>
+    );
+
+    expect(clearPlaybookRunSystemDetails).toHaveBeenCalled();
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,7 +29,12 @@ const asyncActions = flatMap(
   (a) => [a, `${a}_PENDING`, `${a}_FULFILLED`, `${a}_REJECTED`]
 );
 
-const actions = ['SET_ETAG', 'EXPAND_INVENTORY_TABLE', 'SELECT_ENTITY'];
+const actions = [
+  'SET_ETAG',
+  'EXPAND_INVENTORY_TABLE',
+  'SELECT_ENTITY',
+  'CLEAR_PLAYBOOK_RUN_SYSTEM_DETAILS',
+];
 export const ACTION_TYPES = keyBy([...asyncActions, ...actions], (k) => k);
 
 export const SEARCH_DEBOUNCE_DELAY = 500;

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -314,6 +314,7 @@ const reducers = {
     ) => ({
       ...action.payload,
     }),
+    [ACTION_TYPES.CLEAR_PLAYBOOK_RUN_SYSTEM_DETAILS]: () => ({}),
   }),
 
   runRemediation: applyReducerHash(


### PR DESCRIPTION
Playbook log doesn't display properly after inital load.

To repro:
- Automation Toolkit > Remediations > A playbook  > Activity > The data that the playbook ran successfully > Direct connected
- At this point the playbook log will flash on screen and disappear
- Click on the hostname

The issue was that playbookRunSystemDetails is a redux variable that remains after initial load. So when the playbook log is loaded again, the log viewer somehow only captures part of the string or none at all.

The best way to handle this issue is to clear the variable in redux on inital load to ensure there are no incorrect states.
