### PR TITLE
fix(RHINENG-14395): Playbook output is visible while executing

### DIFF
--- a/src/components/ExecutorDetails/ExecutorDetails.js
+++ b/src/components/ExecutorDetails/ExecutorDetails.js
@@ -164,8 +164,7 @@ const ExecutorDetails = () => {
                           setOpenId(undefined);
                           clearInterval(refreshInterval);
                         }
-
-                        dispatch(expandInventoryTable(isOpen, id));
+                        dispatch(expandInventoryTable(id, isOpen));
                       }
                     : (_e, _i, isOpen, { id }) => {
                         setFirstExpand(true);


### PR DESCRIPTION
If you run a remediation, ( I recommend hitting jaudet-test:pause5m for testing), and try to view its output while running, it would fail and the user could never open up the output. 

With this fix it allows you to open the table and view the output. 
To test: 

Automation Toolkit > Remediations > A playbook ( jaudet-test:pause5m) > Execute it > Activity > Click the latest one > click 'Direct connected' > observe the Run Status is running in the page header, and then expand one of the systems. (or both).

With this one specifically you may notice for the first few seconds there is no output, but thats because its still booting up and there is legitimately no output.