### PR TITLE
fix(RHINENG-13431): Re-add color to Status Summary

### DIFF
--- a/src/components/RemediationSummary.js
+++ b/src/components/RemediationSummary.js
@@ -4,6 +4,7 @@ import {
   Button,
   Flex,
   FlexItem,
+  Icon,
   Split,
   SplitItem,
   Stack,
@@ -55,7 +56,9 @@ export const RemediationSummary = ({
   const rebootEnabled = () => {
     return (
       <div>
-        <CheckCircleIcon className="rem-c-success" />
+        <Icon status="success" className="pf-v5-u-pr-sm">
+          <CheckCircleIcon />
+        </Icon>
         <b className="ins-c-remediation-summary__reboot--enabled"> Enabled </b>
         {context.permissions.write && (
           <Button
@@ -72,7 +75,9 @@ export const RemediationSummary = ({
   const rebootDisabled = (required) => {
     return (
       <div>
-        <OffIcon />
+        <Icon className="pf-v5-u-pr-sm">
+          <OffIcon />
+        </Icon>
         <b
           className={`ins-c-remediation-summary__reboot--disabled${
             required ? '--warning' : ''
@@ -82,7 +87,9 @@ export const RemediationSummary = ({
         </b>
         {required && (
           <React.Fragment>
-            <ExclamationTriangleIcon className="ins-c-remediation-summary__reboot--required--icon" />
+            <Icon>
+              <ExclamationTriangleIcon className="ins-c-remediation-summary__reboot--required--icon" />
+            </Icon>
             <b className="ins-c-remediation-summary__reboot--required">
               {generateNumRebootString(generateNumIssuesReboot())}
             </b>

--- a/src/components/Status.scss
+++ b/src/components/Status.scss
@@ -1,7 +1,7 @@
-.rem-c-success { color: var(--pf-global--success-color--100); }
-.rem-c-failure { color: var(--pf-global--danger-color--100); }
-.rem-c-running { color: var(--pf-global--default-color--300); }
-.rem-c-canceled { color: var(--pf-global--default-color--300); }
+.rem-c-success { color: var(--pf-v5-global--success-color--100); }
+.rem-c-failure { color: var(--pf-v5-global--danger-color--100); }
+.rem-c-running { color: var(--pf-v5-global--default-color--300); }
+.rem-c-canceled { color: var(--pf-v5-global--default-color--300); }
 
 .rem-c-connection-status { margin-right: var(--pf-global--spacer--xs); }
 .rem-c-connection-status-error { color: var(--pf-chart-global--danger--Color--100); }

--- a/src/components/statusHelper.js
+++ b/src/components/statusHelper.js
@@ -16,6 +16,7 @@ import {
   Text,
   TextVariants,
   Tooltip,
+  Icon,
 } from '@patternfly/react-core';
 
 import { CancelButton } from '../containers/CancelButton';
@@ -36,60 +37,62 @@ export const normalizeStatus = (status) =>
 export const renderStatusIcon = (status) =>
   ({
     running: (
-      <InProgressIcon
-        className="rem-c-running"
-        aria-label="connection status"
-      />
+      <Icon>
+        <InProgressIcon aria-label="connection status" />
+      </Icon>
     ),
     success: (
-      <CheckCircleIcon
-        className="rem-c-success"
-        aria-label="connection status"
-      />
+      <Icon status="success">
+        <CheckCircleIcon aria-label="connection status" />
+      </Icon>
     ),
     failure: (
-      <TimesCircleIcon
-        className="rem-c-failure"
-        aria-label="connection status"
-      />
+      <Icon status="danger">
+        <TimesCircleIcon aria-label="connection status" />
+      </Icon>
     ),
     canceled: (
-      <TimesCircleIcon
-        className="rem-c-canceled"
-        aria-label="connection status"
-      />
+      <Icon>
+        <TimesCircleIcon aria-label="connection status" />
+      </Icon>
     ),
   }[status]);
 
 export const renderStatus = (status, text) =>
   ({
     running: (
-      <Flex className="rem-c-running" spacer={{ default: 'space-items-sm' }}>
+      <Flex spacer={{ default: 'space-items-sm' }}>
         <FlexItem>
           <b>{text || 'Running'}</b>
         </FlexItem>
         <FlexItem>
-          <InProgressIcon aria-label="connection status: running" />
+          <Icon>
+            <InProgressIcon aria-label="connection status: running" />
+          </Icon>
         </FlexItem>
       </Flex>
     ),
     success: (
-      <Flex className="rem-c-success" spacer={{ default: 'space-items-sm' }}>
+      <Flex spacer={{ default: 'space-items-sm' }}>
         <FlexItem>
           <b>{text || 'Success'}</b>
         </FlexItem>
         <FlexItem>
-          <CheckCircleIcon aria-label="connection status: success" />
+          <Icon status="success">
+            <CheckCircleIcon aria-label="connection status: success" />
+          </Icon>
         </FlexItem>
       </Flex>
     ),
     failure: (
-      <Flex className="rem-c-failure" spacer={{ default: 'space-items-sm' }}>
+      <Flex spacer={{ default: 'space-items-sm' }}>
         <FlexItem>
           <b>{text || 'Failed'}</b>
         </FlexItem>
         <FlexItem>
-          <TimesCircleIcon aria-label="connection status: failed" />
+          <Icon status="danger">
+            <TimesCircleIcon aria-label="connection status: failed" />
+          </Icon>
         </FlexItem>
       </Flex>
     ),
@@ -99,7 +102,9 @@ export const renderStatus = (status, text) =>
           <b>{text || 'Canceled'}</b>
         </FlexItem>
         <FlexItem>
-          <TimesCircleIcon aria-label="connection status: canceled" />
+          <Icon>
+            <TimesCircleIcon aria-label="connection status: canceled" />
+          </Icon>
         </FlexItem>
       </Flex>
     ),
@@ -139,8 +144,12 @@ export const StatusSummary = ({
   const statusBar = (
     <Flex className="rem-c-status-bar">
       {executorStatus && <FlexItem>{statusText(executorStatus)}</FlexItem>}
-      <FlexItem>{renderStatus('success', `${passCount}`)}</FlexItem>
-      <FlexItem>{renderStatus('failure', `${failCount}`)}</FlexItem>
+      <FlexItem className="rem-c-success">
+        {renderStatus('success', `${passCount}`)}
+      </FlexItem>
+      <FlexItem className="rem-c-failure">
+        {renderStatus('failure', `${failCount}`)}
+      </FlexItem>
       <FlexItem>{renderStatus('running', `${runningCount}`)}</FlexItem>
       {isDebug() &&
         hasCancel &&
@@ -220,13 +229,6 @@ export const styledConnectionStatus = (status) =>
           <Text component={TextVariants.small} style={{ margin: '0px' }}>
             RHC not responding
           </Text>
-          {/* <Button
-                    style={ { padding: '0px' } }
-                    key="troubleshoot"
-                    // eslint-disable-next-line no-console
-                    variant='link' onClick={ () => console.log('TODO: add link') }>
-                    Troubleshoot
-                </Button> */}
         </Text>
       </TextContent>
     ),
@@ -260,13 +262,6 @@ export const styledConnectionStatus = (status) =>
           <Text component={TextVariants.small} style={{ margin: '0px' }}>
             Satellite not registered for Playbook execution
           </Text>
-          {/* <Button
-                    style={ { padding: '0px' } }
-                    key="configure"
-                    // eslint-disable-next-line no-console
-                    variant='link' onClick={ () => console.log('TODO: add link') }>
-                    Learn how to register Satellite
-                </Button> */}
         </Text>
       </TextContent>
     ),


### PR DESCRIPTION
This PR adds color back to the status summary. To test, navigate to a remediations details and check the status summary.

Before: 
![Screenshot 2024-12-05 at 12 36 52 PM](https://github.com/user-attachments/assets/b1ddca83-789e-4e10-bf0f-c11c3e51d425)


After: 
![Screenshot 2024-12-05 at 12 37 06 PM](https://github.com/user-attachments/assets/fba61f24-470c-4040-9cca-aa1131051a32)

What its supposed to look like according to ticket:
![Screenshot 2024-12-05 at 12 37 27 PM](https://github.com/user-attachments/assets/e3ccde35-76fe-416a-974d-2b7857af3876)

