### PR TITLE
fix(RHINENG-14725): Reword auto reboot toggle

### DIFF
--- a/src/modules/RemediationsModal/steps/review.js
+++ b/src/modules/RemediationsModal/steps/review.js
@@ -116,11 +116,13 @@ const Review = (props) => {
           <Text>
             The playbook <b>{formOptions.getState().values[SELECT_PLAYBOOK]}</b>
             {input.value ? (
-              ' does'
+              ' auto reboots systems.'
             ) : (
-              <span className="ins-c-remediation-danger-text"> does not</span>
-            )}{' '}
-            auto reboot systems.
+              <span className="ins-c-remediation-danger-text">
+                {' '}
+                does not auto reboot systems.
+              </span>
+            )}
           </Text>
         </TextContent>
       </StackItem>

--- a/src/modules/RemediationsModal/steps/review.js
+++ b/src/modules/RemediationsModal/steps/review.js
@@ -127,8 +127,8 @@ const Review = (props) => {
       <StackItem>
         <Switch
           data-testid="autoreboot-switch"
-          label="Turn off autoreboot"
-          labelOff="Turn on autoreboot"
+          label="Auto reboot is on"
+          labelOff="Auto reboot is off"
           isChecked={input.value}
           onChange={() => input.onChange(!input.value)}
         />

--- a/src/modules/tests/steps/review.test.js
+++ b/src/modules/tests/steps/review.test.js
@@ -106,10 +106,10 @@ describe('Review', () => {
 
     const autoreboot_switch = screen.getByTestId('autoreboot-switch');
     expect(autoreboot_switch).toBeChecked();
-    expect(autoreboot_switch).toHaveAccessibleName('Turn off autoreboot');
+    expect(autoreboot_switch).toHaveAccessibleName('Auto reboot is on');
     await userEvent.click(autoreboot_switch);
     expect(autoreboot_switch).not.toBeChecked();
-    expect(autoreboot_switch).toHaveAccessibleName('Turn on autoreboot');
+    expect(autoreboot_switch).toHaveAccessibleName('Auto reboot is off');
   });
 
   it('should sort records correctly', async () => {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-14725 
This simply renames the toggle in remediations step 3.
Navigate to anywhere you can remediate, in this case Advisor

Advisor -> a recommendation you can remdiation (a non-manual one)
select a system -> click remediate process, get to step 3

Desired behavior:
Toggle is gray: "The playbook ___ does not auto reboot systems." and "Auto reboot is off"
Toggle is blue: "The playbook ___ auto reboots systems." and "Auto reboot is on"

With this PR:
![Screenshot 2024-12-12 at 6 21 15 AM](https://github.com/user-attachments/assets/df39f7cb-38b9-4362-9e43-2dc584067081)
![Screenshot 2024-12-12 at 6 21 26 AM](https://github.com/user-attachments/assets/4c425d16-fdcc-4870-95b2-775ed66819f4)

