### PR TITLE
fix(RHINENG-9779): Change Details Page Header layout

### DIFF
--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -30,8 +30,6 @@ import { InvalidObject } from '@redhat-cloud-services/frontend-components/Invali
 import {
   Stack,
   StackItem,
-  Level,
-  LevelItem,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -39,6 +37,8 @@ import {
   SplitItem,
   Tabs,
   Tab,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
 
 import RemediationDetailsSkeleton from '../skeletons/RemediationDetailsSkeleton';
@@ -198,11 +198,13 @@ const RemediationDetails = ({
             </BreadcrumbItem>
             <BreadcrumbItem isActive> {remediation.name} </BreadcrumbItem>
           </Breadcrumb>
-          <Level className="rem-l-level">
-            <LevelItem>
+
+          <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+            <FlexItem style={{ width: '50%' }}>
               <PageHeaderTitle title={remediation.name} />
-            </LevelItem>
-            <LevelItem>
+            </FlexItem>
+
+            <FlexItem>
               <Split hasGutter>
                 <SplitItem>
                   <ExecutePlaybookButton
@@ -246,8 +248,8 @@ const RemediationDetails = ({
                   />
                 </SplitItem>
               </Split>
-            </LevelItem>
-          </Level>
+            </FlexItem>
+          </Flex>
           <RemediationSummary
             remediation={remediation}
             playbookRuns={playbookRuns}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-9779

Alters layout of remediation details page header so that if theres a really long name it doesnt move the buttons, but instead just wraps under itself:

Before PR: 
![Screenshot 2024-12-05 at 1 32 17 PM](https://github.com/user-attachments/assets/04e5d313-d789-4a98-b709-00446aebc670)


With PR 
![Screenshot 2024-12-05 at 1 31 23 PM](https://github.com/user-attachments/assets/0fed1857-940e-4857-b9bf-34d20aa6c7e8)
