### PR TITLE
fix(Remediation wizard): Fix incorrect system count in the pagination

### DIFF
--- a/src/Utilities/utils.js
+++ b/src/Utilities/utils.js
@@ -362,11 +362,8 @@ export const fetchSystemsInfo = async (
         )
       : {};
   return {
-    ...{
-      ...data,
-      results: sortByAttr(data.results, 'display_name', config.orderDirection),
-    },
-    total: systems.length,
+    ...data,
+    results: sortByAttr(data.results, 'display_name', config.orderDirection),
     page: config.page,
     per_page: config.per_page,
     orderBy: config.orderBy,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-10618

- Remove unnecessary object construction with instant deconstruction
- Do not overwrite `total` property of the spread `data` object -- it contains the correct system count since `total` property includes row count which is double due to including expand cells as rows