### PR TITLE
fix(RHINENG-15230): Add ouidID to autoreboot switch

### DIFF
--- a/src/modules/RemediationsModal/steps/review.js
+++ b/src/modules/RemediationsModal/steps/review.js
@@ -133,6 +133,7 @@ const Review = (props) => {
           labelOff="Auto reboot is off"
           isChecked={input.value}
           onChange={() => input.onChange(!input.value)}
+          ouiaId="autoreboot-switch"
         />
       </StackItem>
       <Table


### PR DESCRIPTION
To test, go to any app where the Remediation modal lives and go through the steps until you get to the Remediation review step. There is an "Auto reboot is on/off" switch. Inspecting it should reveal the new ouiaID.

One place to check is Vulnerability. Simply select a CVE and go to the CVE details table. From the details table, add systems and then click the "Remediate" button to open the Remediate modal.

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
