### PR TITLE
fix(RHINENG:16087): Small flow flixes

### DIFF
--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -27,7 +27,7 @@ export default function ConfirmationDialog({
           variant="danger"
           ouiaId="confirm"
           onClick={() => onClose(true)}
-          isDisabled={selectedItems && selectedItems?.length === 0}
+          isDisabled={selectedItems?.length === 0}
         >
           {confirmText}
         </Button>,

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -10,6 +10,7 @@ export default function ConfirmationDialog({
   text = 'This action cannot be undone',
   confirmText = 'Remove system',
   onClose = (f) => f,
+  selectedItems,
 }) {
   return (
     <Modal
@@ -26,6 +27,7 @@ export default function ConfirmationDialog({
           variant="danger"
           ouiaId="confirm"
           onClick={() => onClose(true)}
+          isDisabled={selectedItems && selectedItems?.length === 0}
         >
           {confirmText}
         </Button>,
@@ -50,4 +52,5 @@ ConfirmationDialog.propTypes = {
   text: PropTypes.string,
   confirmText: PropTypes.string,
   onClose: PropTypes.func,
+  selectedItems: PropTypes.array,
 };

--- a/src/components/NoResultsTable.js
+++ b/src/components/NoResultsTable.js
@@ -6,9 +6,10 @@ import {
   EmptyStateVariant,
   EmptyStateHeader,
   Button,
+  EmptyStateIcon,
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { CubesIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 export const NoResultsTable = () => {
   const navigate = useNavigate();
@@ -17,6 +18,7 @@ export const NoResultsTable = () => {
       <EmptyStateHeader
         titleText={<>No remediation plans</>}
         headingLevel="h5"
+        icon={<EmptyStateIcon icon={CubesIcon} />}
       />
       <EmptyStateBody>
         Create remediation plans to address Advisor recommendations, Security

--- a/src/components/NoResultsTable.js
+++ b/src/components/NoResultsTable.js
@@ -8,11 +8,10 @@ import {
   Button,
   EmptyStateIcon,
 } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { CubesIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 export const NoResultsTable = () => {
-  const navigate = useNavigate();
   return (
     <EmptyState variant={EmptyStateVariant.full}>
       <EmptyStateHeader
@@ -27,10 +26,15 @@ export const NoResultsTable = () => {
         Content advisories on your Red Hat Enterprise Linux (RHEL)
         infrastructure.
       </EmptyStateBody>
-      {/*TODO:  Need to link this somewhere */}
-      <Button onClick={() => navigate('/')}>
-        Learn More <ExternalLinkAltIcon />
-      </Button>
+      <Link
+        to={
+          'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/creating-managing-playbooks_red-hat-insights-remediation-guide'
+        }
+      >
+        <Button>
+          Learn More <ExternalLinkAltIcon />
+        </Button>
+      </Link>
     </EmptyState>
   );
 };

--- a/src/components/RenameModal.js
+++ b/src/components/RenameModal.js
@@ -14,6 +14,7 @@ const RenameModal = ({
   remediationsList,
   fetch,
   onRename,
+  refetch,
 }) => {
   return (
     <TextInputDialog
@@ -26,8 +27,10 @@ const RenameModal = ({
         await onRename(remediation.id, name);
 
         fetch && fetch();
+        refetch && refetch();
       }}
       remediationsList={remediationsList ?? []}
+      refetch={refetch}
     />
   );
 };
@@ -38,6 +41,7 @@ RenameModal.propTypes = {
   remediationsList: PropTypes.array,
   setIsRenameModalOpen: PropTypes.func,
   fetch: PropTypes.func,
+  refetch: PropTypes.func,
 };
 
 const connected = connect(null, () => ({

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -211,7 +211,7 @@ export const OverViewPage = () => {
       });
     }
   };
-
+  console.log(context.permissions.write, 'context.permissions.write ');
   const actions = useMemo(() => {
     return [
       {
@@ -237,7 +237,7 @@ export const OverViewPage = () => {
         props: {
           className:
             !context.permissions.write || !currentlySelected?.length
-              ? 'var(--pf-v5-global--disabled-color--200)'
+              ? 'pf-v5-u-color-200'
               : 'pf-v5-u-danger-color-100',
           isDisabled: !context.permissions.write || !currentlySelected?.length,
         },

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import columns from '../Columns';
 import useRemediationsQuery from '../../api/useRemediationsQuery';
 import { API_BASE } from '../../config';
@@ -27,6 +27,7 @@ import { TextContent } from '@patternfly/react-core';
 import { emptyRows } from '../../Frameworks/AsyncTableTools/AsyncTableTools/hooks/useTableView/views/helpers';
 import useRemediationFetchExtras from '../../api/useRemediationFetchExtras';
 import { OverViewPageHeader } from './OverViewPageHeader';
+import { PermissionContext } from '../../App';
 
 const getRemediations = (axios) => (params) => {
   return axios.get(`${API_BASE}/remediations/`, { params });
@@ -70,6 +71,8 @@ export const OverViewPage = () => {
   const [remediation, setRemediation] = useState('');
   const [showArchived, setShowArchived] = useState(true);
   const [isBulkDelete, setIsBulkDelete] = useState(false);
+  const context = useContext(PermissionContext);
+
   // const remediationsList = useRemediationsList();
   const callbacks = useStateCallbacks();
   const tableState = useRawTableState();
@@ -84,9 +87,8 @@ export const OverViewPage = () => {
     params: { hide_archived: showArchived, 'fields[data]': 'playbook_runs' },
   });
 
-  const { result: allRemediations } = useRemediationsQuery(
-    getRemediationsList(axios)
-  );
+  const { result: allRemediations, refetch: refetchAllRemediations } =
+    useRemediationsQuery(getRemediationsList(axios));
 
   const { fetch: archiveRemediation } = useRemediationsQuery(
     archiveRemediationPlans(axios),
@@ -214,20 +216,32 @@ export const OverViewPage = () => {
     return [
       {
         label: 'Archive',
+        props: {
+          isDisabled: !context.permissions.write || !currentlySelected?.length,
+        },
         onClick: () => {
           handleBulkArchiveClick(currentlySelected);
         },
       },
       {
         label: 'Unarchive',
+        props: {
+          isDisabled: !context.permissions.write || !currentlySelected?.length,
+        },
         onClick: () => {
           handleBulkUnArchiveClick(currentlySelected);
         },
       },
       {
-        label: (
-          <TextContent className="pf-v5-u-danger-color-100">Delete</TextContent>
-        ),
+        label: 'Delete',
+        props: {
+          className:
+            !context.permissions.write || !currentlySelected?.length
+              ? 'var(--pf-v5-global--disabled-color--200)'
+              : 'pf-v5-u-danger-color-100',
+          isDisabled: !context.permissions.write || !currentlySelected?.length,
+        },
+
         onClick: () => {
           setIsBulkDelete(true);
           setIsDeleteModalOpen(true);
@@ -259,6 +273,7 @@ export const OverViewPage = () => {
           setIsRenameModalOpen={setIsRenameModalOpen}
           remediationsList={allRemediations.data}
           fetch={fetchRemediations}
+          refetch={refetchAllRemediations}
         />
       )}
       {isDeleteModalOpen && (
@@ -267,6 +282,7 @@ export const OverViewPage = () => {
           title={`Remove playbook(s)`}
           text="You will not be able to recover this Playbook"
           confirmText="Remove playbook"
+          selectedItems={currentlySelected}
           onClose={(confirm) => {
             setIsDeleteModalOpen(false);
             if (confirm) {


### PR DESCRIPTION
[RHINENG-16087](https://issues.redhat.com/browse/RHINENG-16087)

This fixes a few issues found in QA

-User cannot do any bulk action filters if nothing is selected : 
![Screenshot 2025-04-16 at 12 13 14 PM](https://github.com/user-attachments/assets/68cce09d-8616-4c61-abcf-172ec4b5d9b1)

There was a renaming error where we wouldnt refetch one a name is changed. Now when you rename an item, the remList will be updated, so when you go to rename an additional item, you cannot match the name of a previous one: example flow 

If I do

take a playbook, rename it to "abc" (choose a non-existent name)
rename a different playbook to "abc"
The modal displays no error. Instead we get the error in an alert. The renaming doesn't happen.
If I do
take a playbook named "abc"
rename it to "abcde"
try to rename it back to "abc"

Now, the modal will tell you that you can rename something to a playbook with an existing name. To test just follow that flow