### PR TITLE
fix(detailsPage): Fix details page redux to work with both details pages during migration

### DIFF
--- a/src/Utilities/useConnectionStatus.js
+++ b/src/Utilities/useConnectionStatus.js
@@ -42,7 +42,7 @@ export const useConnectionStatus = (remediation) => {
     return () => {
       mounted.current = false;
     };
-  }, []);
+  }, [remediation?.id]);
 
   return [
     connectedSystems,

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -320,43 +320,50 @@ RemediationDetails.propTypes = {
   executable: PropTypes.object,
 };
 
-const RemediationDetailsComponent = () => {
+const RemediationDetailsConnector = (props) => {
   const remediationsV2 = useFeatureFlag('remediationsV2');
-  return remediationsV2 === undefined ? (
-    <Bullseye>
-      <Spinner />
-    </Bullseye>
-  ) : remediationsV2 ? (
-    <RemediationDetailsV2 />
+
+  if (remediationsV2 === undefined) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  return remediationsV2 ? (
+    <RemediationDetailsV2 {...props} />
   ) : (
-    <RemediationDetails />
+    <RemediationDetails {...props} />
   );
 };
 
+const mapStateToProps = ({
+  selectedRemediation,
+  selectedRemediationStatus,
+  executePlaybookBanner,
+  playbookRuns,
+  executable,
+}) => ({
+  selectedRemediation,
+  selectedRemediationStatus,
+  executePlaybookBanner,
+  playbookRuns: playbookRuns.data,
+  executable,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  loadRemediation: (id) => dispatch(actions.loadRemediation(id)),
+  loadRemediationStatus: (id) => dispatch(actions.loadRemediationStatus(id)),
+  switchAutoReboot: (id, auto_reboot) =>
+    dispatch(actions.patchRemediation(id, { auto_reboot })),
+  deleteRemediation: (id) => dispatch(actions.deleteRemediation(id)),
+  addNotification: (content) => dispatch(addNotification(content)),
+  getPlaybookRuns: (id) => dispatch(actions.getPlaybookRuns(id)),
+  checkExecutable: (id) => dispatch(actions.checkExecutable(id)),
+});
+
 export default connect(
-  ({
-    selectedRemediation,
-    selectedRemediationStatus,
-    executePlaybookBanner,
-    playbookRuns,
-    executable,
-  }) => ({
-    selectedRemediation,
-    selectedRemediationStatus,
-    executePlaybookBanner,
-    playbookRuns: playbookRuns.data,
-    remediation: selectedRemediation.remediation,
-    executable,
-  }),
-  (dispatch) => ({
-    loadRemediation: (id) => dispatch(actions.loadRemediation(id)),
-    loadRemediationStatus: (id) => dispatch(actions.loadRemediationStatus(id)),
-    // eslint-disable-next-line camelcase
-    switchAutoReboot: (id, auto_reboot) =>
-      dispatch(actions.patchRemediation(id, { auto_reboot })),
-    deleteRemediation: (id) => dispatch(actions.deleteRemediation(id)),
-    addNotification: (content) => dispatch(addNotification(content)),
-    getPlaybookRuns: (id) => dispatch(actions.getPlaybookRuns(id)),
-    checkExecutable: (id) => dispatch(actions.checkExecutable(id)),
-  })
-)(RemediationDetailsComponent);
+  mapStateToProps,
+  mapDispatchToProps
+)(RemediationDetailsConnector);


### PR DESCRIPTION
I noticed that when flipping the preview toggle on in stage that the original details page breaks. This fixes that issue.

To test, run remediations details page in both preview and default environments with the toggle. Both should load without issue