### PR TITLE
Actions and systems

### DIFF
--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -36,7 +36,7 @@ function RemediationDetailsDropdown({
     <React.Fragment>
       {renameDialogOpen && (
         <TextInputDialog
-          title="Rename remediation plan"
+          title="Rename remediation plan?"
           ariaLabel="RenameModal"
           value={remediation.name}
           onCancel={() => setRenameDialogOpen(false)}

--- a/src/components/SystemsTable/ConnectionStatusCol.js
+++ b/src/components/SystemsTable/ConnectionStatusCol.js
@@ -39,11 +39,9 @@ const ConnectionStatusColumn = ({ connection_status, executor_type }) => {
           </Flex>
         }
       >
-        <Flex>
+        <Flex spaceItems={{ default: 'spaceItemsXs' }}>
           <DisconnectedIcon className="pf-u-mr-xs" />
-          <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-            Not configured
-          </p>
+          <p style={{ maxWidth: 'fit-content' }}>Not configured</p>
         </Flex>
       </Tooltip>
     );
@@ -56,11 +54,9 @@ const ConnectionStatusColumn = ({ connection_status, executor_type }) => {
             'The Remote Host Configuration (RHC) client is not configured for one or more systems in this plan.'
           }
         >
-          <Flex>
+          <Flex spaceItems={{ default: 'spaceItemsXs' }}>
             <DisconnectedIcon className="pf-u-mr-xs" />
-            <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-              Disconnected
-            </p>
+            <p style={{ maxWidth: 'fit-content' }}>Disconnected</p>
           </Flex>
         </Tooltip>
       );
@@ -72,11 +68,9 @@ const ConnectionStatusColumn = ({ connection_status, executor_type }) => {
             'The Red Hat Satellite instance that this system is registered to is disconnected from Red Hat Insights.'
           }
         >
-          <Flex>
+          <Flex spaceItems={{ default: 'spaceItemsXs' }}>
             <DisconnectedIcon className="pf-u-mr-xs" />
-            <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-              Disconnected
-            </p>
+            <p style={{ maxWidth: 'fit-content' }}>Disconnected</p>
           </Flex>
         </Tooltip>
       );
@@ -84,11 +78,9 @@ const ConnectionStatusColumn = ({ connection_status, executor_type }) => {
   } else {
     return (
       <Tooltip content={'Connection Status Unkown'}>
-        <Flex>
+        <Flex spaceItems={{ default: 'spaceItemsXs' }}>
           <UnknownIcon className="pf-u-mr-xs" />
-          <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-            Unknown
-          </p>
+          <p style={{ maxWidth: 'fit-content' }}>Unknown</p>
         </Flex>
       </Tooltip>
     );

--- a/src/components/SystemsTable/ConnectionStatusCol.js
+++ b/src/components/SystemsTable/ConnectionStatusCol.js
@@ -53,7 +53,7 @@ const ConnectionStatusColumn = ({ connection_status, executor_type }) => {
         <Tooltip
           position="left"
           content={
-            'Remote Host Configuration (RHC) client communication is disconnected.'
+            'The Remote Host Configuration (RHC) client is not configured for one or more systems in this plan.'
           }
         >
           <Flex>

--- a/src/components/SystemsTable/IssuesColumn.js
+++ b/src/components/SystemsTable/IssuesColumn.js
@@ -41,7 +41,7 @@ const IssuesColumn = ({ issues, display_name }) => {
       </Button>
       <Modal
         variant={ModalVariant.medium}
-        title={`Actions for system ${display_name}`}
+        title={`Planned remediation actions`}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
       >

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -124,7 +124,7 @@ const ActionsContent = ({ remediationDetails, refetch }) => {
           text={`${
             isBulkDelete ? 'The selected actions' : `The action ${action?.[0]}`
           } will not be run when the remediation plan is executed.
-              You can add it again later if needed.
+              You can add ${isBulkDelete ? 'them' : 'it'} again later if needed.
             `}
           confirmText="Remove"
           onClose={(confirm) => {

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -120,8 +120,12 @@ const ActionsContent = ({ remediationDetails, refetch }) => {
       {isDeleteModalOpen && (
         <ConfirmationDialog
           isOpen={isDeleteModalOpen}
-          title={`Remove`}
-          text="The selected actions will no longer be executed in this plan."
+          title={`Remove action${isBulkDelete ? 's' : ''}`}
+          text={`${
+            isBulkDelete ? 'The selected actions' : `The action ${action?.[0]}`
+          } will not be run when the remediation plan is executed.
+              You can add it again later if needed.
+            `}
           confirmText="Remove"
           onClose={(confirm) => {
             setIsDeleteModalOpen(false);

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -120,7 +120,7 @@ const ActionsContent = ({ remediationDetails, refetch }) => {
       {isDeleteModalOpen && (
         <ConfirmationDialog
           isOpen={isDeleteModalOpen}
-          title={`Remove action${isBulkDelete ? 's' : ''}`}
+          title={`Remove action${isBulkDelete ? 's' : ''}?`}
           text={`${
             isBulkDelete ? 'The selected actions' : `The action ${action?.[0]}`
           } will not be run when the remediation plan is executed.

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -58,7 +58,7 @@ const RemediationDetailsPageHeader = ({
   return (
     <PageHeader>
       <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-        <FlexItem style={{ width: '50%' }}>
+        <FlexItem style={{ width: '70%' }}>
           <PageHeaderTitle title={remediation.name} className="pf-v5-u-mb-md" />
           <p>{`ID: ${remediation.id}`}</p>
         </FlexItem>
@@ -94,7 +94,7 @@ const RemediationDetailsPageHeader = ({
             <SplitItem>
               <RemediationDetailsDropdown
                 remediation={remediation}
-                remediationsList={allRemediations}
+                remediationsList={allRemediations.data}
                 updateRemPlan={updateRemPlan}
                 refetch={refetch}
               />

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/ExecutionHistoryContent.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/ExecutionHistoryContent.js
@@ -2,8 +2,10 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
+  Button,
   Checkbox,
   Modal,
+  ModalBoxFooter,
   Sidebar,
   SidebarContent,
   SidebarPanel,
@@ -207,6 +209,16 @@ const ExecutionHistoryTab = ({
                 </Toolbar>
               }
             />
+            <ModalBoxFooter>
+              <Button
+                className="pf-u-mt-md"
+                key="cancelModal"
+                variant="primary"
+                onClick={() => setIsLogOpen(false)}
+              >
+                Cancel
+              </Button>
+            </ModalBoxFooter>
           </>
         )}
       </Modal>

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button,
   Card,
   CardBody,
   CardTitle,
@@ -73,19 +72,15 @@ const LogCards = ({ systemName, status, connectionType, executedBy }) => (
             spaceItems={{ default: 'spaceItemsXs' }}
             alignItems={{ default: 'alignItemsCenter' }}
           >
-            <span>Insights connection type</span>
-            <Tooltip
-              content="Red Hat Enterprise Linux systems are connected to Insights directly via RHC, or through Satellite via Cloud Connector."
-              aria-label="Insights connection type info"
-            >
-              <Button
-                variant="plain"
-                aria-label="More info"
-                style={{ padding: '0' }}
+            <span>
+              Insights connection type{' '}
+              <Tooltip
+                content="Red Hat Enterprise Linux systems are connected to Insights directly via RHC, or through Satellite via Cloud Connector."
+                aria-label="Insights connection type info"
               >
                 <OutlinedQuestionCircleIcon />
-              </Button>
-            </Tooltip>
+              </Tooltip>
+            </span>
           </Flex>
         </CardTitle>
         <CardBody>{connectionType ?? '-'}</CardBody>

--- a/src/routes/RemediationDetailsComponents/SystemsContent/ActionsModal/ActionsModal.js
+++ b/src/routes/RemediationDetailsComponents/SystemsContent/ActionsModal/ActionsModal.js
@@ -5,11 +5,11 @@ import TableStateProvider from '../../../../Frameworks/AsyncTableTools/AsyncTabl
 
 import RemediationsTable from '../../../../components/RemediationsTable/RemediationsTable';
 import columns from './Columns';
-const ActionsModal = ({ actions, isOpen, onClose, systemName }) => {
+const ActionsModal = ({ actions, isOpen, onClose }) => {
   return (
     <Modal
       variant={ModalVariant.large}
-      title={`Actions for system ${systemName}`}
+      title="Planned remediation actions"
       isOpen={isOpen}
       onClose={onClose}
       isFooterLeftAligned

--- a/src/routes/RemediationDetailsComponents/SystemsContent/Cells.js
+++ b/src/routes/RemediationDetailsComponents/SystemsContent/Cells.js
@@ -73,11 +73,9 @@ export const ConnectionStatusCell = ({ connection_status, executor_type }) => {
           </Flex>
         }
       >
-        <Flex>
+        <Flex spaceItems={{ default: 'spaceItemsXs' }}>
           <DisconnectedIcon className="pf-u-mr-xs" />
-          <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-            Not configured
-          </p>
+          <p style={{ maxWidth: 'fit-content' }}>Not configured</p>
         </Flex>
       </Tooltip>
     );
@@ -90,11 +88,9 @@ export const ConnectionStatusCell = ({ connection_status, executor_type }) => {
             'Remote Host Configuration (RHC) client communication is disconnected.'
           }
         >
-          <Flex>
+          <Flex spaceItems={{ default: 'spaceItemsXs' }}>
             <DisconnectedIcon className="pf-u-mr-xs" />
-            <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-              Disconnected
-            </p>
+            <p style={{ maxWidth: 'fit-content' }}>Disconnected</p>
           </Flex>
         </Tooltip>
       );
@@ -106,11 +102,9 @@ export const ConnectionStatusCell = ({ connection_status, executor_type }) => {
             'The Red Hat Satellite instance that this system is registered to is disconnected from Red Hat Insights.'
           }
         >
-          <Flex>
+          <Flex spaceItems={{ default: 'spaceItemsXs' }}>
             <DisconnectedIcon className="pf-u-mr-xs" />
-            <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-              Disconnected
-            </p>
+            <p style={{ maxWidth: 'fit-content' }}>Disconnected</p>
           </Flex>
         </Tooltip>
       );
@@ -118,11 +112,9 @@ export const ConnectionStatusCell = ({ connection_status, executor_type }) => {
   } else {
     return (
       <Tooltip content={'Connection Status Unkown'}>
-        <Flex>
+        <Flex spaceItems={{ default: 'spaceItemsXs' }}>
           <UnknownIcon className="pf-u-mr-xs" />
-          <p style={{ borderBottomStyle: 'dotted', maxWidth: 'fit-content' }}>
-            Unknown
-          </p>
+          <p style={{ maxWidth: 'fit-content' }}>Unknown</p>
         </Flex>
       </Tooltip>
     );


### PR DESCRIPTION
This updates the content for Actions And Systems page
it can be a little confusing to look at all the wording changes, but here are 2 documents going over all the wording/icon changes

    https://docs.google.com/document/d/1agqdtbbeb3ZwvLMGV_B4IlHpaWG6CAzQjGW1pxb2DEA/edit?tab=t.0
    https://docs.google.com/document/d/1V3rmE8MoE2cmvVJ8OrfPQL3uGeRGHmoYhg4dLGh2dSs/edit?tab=t.0

The changes on systems pages: 
- Details page systems tab -> select an item in actions column:
       - Title for modal is now 'Planned remediation actions.'
 - Details Page actions tab
        - When renaming a remediation (top right elipse) the title of the modal is name 'Rename remediation plan?'
        - The warning text (for when you try to rename a remediation to an existing one) is now `Enter a unique name that does not already exist in your organization.`
        - the button there now says Rename instead of Save 
         (delete can be done in the top elipse or in the table as bulk/singular delete).
        - The delete modal (also in the elipse) now is titled Remove actions? with a warning icon
        - Title is pluralized depending if its bulk delete or single delete 
        - Description is also alter depending on bulk or single delete
        Single delete `The action <insert action name> will not be run when the remediation plan is executed.
You can add it again later if needed.`
         Bulk Delete: `The selected actions will not be run when the plan is executed.  You can add them again later if needed.`
         
         This also changes the page header width to 70% and adds a button to the exectuion modal 'Cancel' on the bottom (post summit there will be more buttons added)
         
         
         
      