### PR TITLE
feat(RHINENG-18108):Implement Remediations QuickStart

### DIFF
--- a/src/components/NoRemediationsPage.js
+++ b/src/components/NoRemediationsPage.js
@@ -38,7 +38,7 @@ export const NoRemediationsPage = () => {
             <EmptyStateActions>
               <Button
                 onClick={() =>
-                  quickStarts.activateQuickstart(
+                  quickStarts?.activateQuickstart(
                     'insights-remediate-plan-create'
                   )
                 }

--- a/src/components/NoRemediationsPage.js
+++ b/src/components/NoRemediationsPage.js
@@ -7,35 +7,50 @@ import {
   EmptyStateHeader,
   Button,
   EmptyStateIcon,
+  PageSection,
+  Page,
+  EmptyStateActions,
+  EmptyStateFooter,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
-import { CubesIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { CubesIcon, OpenDrawerRightIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 export const NoRemediationsPage = () => {
+  const { quickStarts } = useChrome();
+
   return (
-    <EmptyState variant={EmptyStateVariant.full}>
-      <EmptyStateHeader
-        titleText={<>No remediation plans</>}
-        headingLevel="h5"
-        icon={<EmptyStateIcon icon={CubesIcon} />}
-      />
-      <EmptyStateBody>
-        Create remediation plans to address Advisor recommendations, Security
-        CVEs, and
-        <br />
-        Content advisories on your Red Hat Enterprise Linux (RHEL)
-        infrastructure.
-      </EmptyStateBody>
-      <Link
-        to={
-          'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/creating-managing-playbooks_red-hat-insights-remediation-guide'
-        }
-      >
-        <Button>
-          Learn More <ExternalLinkAltIcon />
-        </Button>
-      </Link>
-    </EmptyState>
+    <Page>
+      <PageSection isFilled>
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateHeader
+            titleText={<>No remediation plans</>}
+            headingLevel="h5"
+            icon={<EmptyStateIcon icon={CubesIcon} />}
+          />
+          <EmptyStateBody>
+            Create remediation plans to address Advisor recommendations,
+            Security CVEs, and
+            <br />
+            Content advisories on your Red Hat Enterprise Linux (RHEL)
+            infrastructure.
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button
+                onClick={() =>
+                  quickStarts.activateQuickstart(
+                    'insights-remediate-plan-create'
+                  )
+                }
+              >
+                Launch Quick Start{' '}
+                <OpenDrawerRightIcon className="pf-v5-u-ml-sm" />
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </PageSection>
+    </Page>
   );
 };
 

--- a/src/routes/Filters.js
+++ b/src/routes/Filters.js
@@ -26,7 +26,7 @@ export const LastExecutedFilter = [
 
     items: [
       { label: 'Last hour', value: subtractHours(1) },
-      { label: 'Last 24 hrs', value: subtractHours(24) },
+      { label: 'Last 24 hours', value: subtractHours(24) },
       { label: 'Last week', value: subtractDays(7) },
       { label: 'Last 30 days', value: subtractDays(30) },
       { label: 'Last 90 days', value: subtractDays(90) },

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -164,90 +164,95 @@ export const OverViewPage = () => {
         />
       )}
       {allRemediations?.data.length === 0 ? (
-        <NoRemediationsPage />
+        <>
+          <OverViewPageHeader
+            hasRemediations={Boolean(allRemediations?.data?.length)}
+          />
+          <NoRemediationsPage />
+        </>
       ) : (
-        <RemediationsTable
-          aria-label="OverViewTable"
-          ouiaId="OverViewTable"
-          variant="compact"
-          loading={loading}
-          items={result?.data}
-          total={result?.meta?.total}
-          columns={[...columns]}
-          filters={{
-            filterConfig: [
-              ...remediationNameFilter,
-              ...LastExecutedFilter,
-              ...ExecutionStatusFilter,
-              ...LastModifiedFilter,
-              ...CreatedByFilter,
-            ],
-          }}
-          options={{
-            sortBy: {
-              index: 6,
-              direction: 'desc',
-            },
-            onSelect: () => '',
-            itemIdsInTable: fetchAllIds,
-            manageColumns: true,
-            itemIdsOnPage: result?.data.map(({ id }) => id),
-            total: result?.meta?.total,
-            actionResolver: () => {
-              return [
-                {
-                  title: 'Download',
-                  onClick: (_event, _index, { item }) => {
-                    handleDownloadClick(item.id);
-                  },
+        <>
+          <OverViewPageHeader
+            hasRemediations={Boolean(allRemediations?.data?.length)}
+          />
+          <section className="pf-v5-l-page__main-section pf-v5-c-page__main-section">
+            <RemediationsTable
+              aria-label="OverViewTable"
+              ouiaId="OverViewTable"
+              variant="compact"
+              loading={loading}
+              items={result?.data}
+              total={result?.meta?.total}
+              columns={[...columns]}
+              filters={{
+                filterConfig: [
+                  ...remediationNameFilter,
+                  ...LastExecutedFilter,
+                  ...ExecutionStatusFilter,
+                  ...LastModifiedFilter,
+                  ...CreatedByFilter,
+                ],
+              }}
+              options={{
+                sortBy: {
+                  index: 6,
+                  direction: 'desc',
                 },
-                {
-                  title: 'Rename',
-                  onClick: (_event, _index, { item }) => {
-                    setRemediation(item);
-                    setIsRenameModalOpen(true);
-                  },
+                onSelect: () => '',
+                itemIdsInTable: fetchAllIds,
+                manageColumns: true,
+                itemIdsOnPage: result?.data.map(({ id }) => id),
+                total: result?.meta?.total,
+                actionResolver: () => {
+                  return [
+                    {
+                      title: 'Download',
+                      onClick: (_event, _index, { item }) => {
+                        handleDownloadClick(item.id);
+                      },
+                    },
+                    {
+                      title: 'Rename',
+                      onClick: (_event, _index, { item }) => {
+                        setRemediation(item);
+                        setIsRenameModalOpen(true);
+                      },
+                    },
+                    {
+                      title: (
+                        <TextContent className="pf-v5-u-danger-color-100">
+                          Delete
+                        </TextContent>
+                      ),
+                      onClick: (_event, _index, { item }) => {
+                        setIsBulkDelete(false);
+                        setRemediation(item);
+                        setIsDeleteModalOpen(true);
+                      },
+                    },
+                  ];
                 },
-                {
-                  title: (
-                    <TextContent className="pf-v5-u-danger-color-100">
-                      Delete
-                    </TextContent>
-                  ),
-                  onClick: (_event, _index, { item }) => {
-                    setIsBulkDelete(false);
-                    setRemediation(item);
-                    setIsDeleteModalOpen(true);
-                  },
-                },
-              ];
-            },
-            actions: actions,
-            dedicatedAction: () => (
-              <DownloadPlaybookButton
-                selectedItems={currentlySelected}
-                data={result?.data}
-                dispatch={dispatch}
-              />
-            ),
-            emptyRows: emptyRows(columns.length),
-          }}
-        />
+                actions: actions,
+                dedicatedAction: () => (
+                  <DownloadPlaybookButton
+                    selectedItems={currentlySelected}
+                    data={result?.data}
+                    dispatch={dispatch}
+                  />
+                ),
+                emptyRows: emptyRows(columns.length),
+              }}
+            />
+          </section>
+        </>
       )}
     </div>
   );
 };
 
-const OverViewPageProvider = () => {
-  return (
-    <TableStateProvider>
-      <OverViewPageHeader />
-      <section
-        className={'pf-v5-l-page__main-section pf-v5-c-page__main-section'}
-      >
-        <OverViewPage />
-      </section>
-    </TableStateProvider>
-  );
-};
+const OverViewPageProvider = () => (
+  <TableStateProvider>
+    <OverViewPage />
+  </TableStateProvider>
+);
 export default OverViewPageProvider;

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -6,15 +6,11 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import {
-  ExternalLinkAltIcon,
-  OpenDrawerRightIcon,
-} from '@patternfly/react-icons';
+import { OpenDrawerRightIcon } from '@patternfly/react-icons';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
-import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { RemediationsPopover } from '../RemediationsPopover';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PropTypes from 'prop-types';
@@ -50,13 +46,6 @@ export const OverViewPageHeader = ({ hasRemediations }) => {
               <p>
                 Remediation plans use Ansible playbooks to resolve issues
                 identified by Red Hat Insights.
-                <InsightsLink
-                  className="pf-v5-u-ml-md"
-                  to="https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/index"
-                  style={{ textDecoration: 'none' }}
-                >
-                  Learn more <ExternalLinkAltIcon />
-                </InsightsLink>
               </p>
             </StackItem>
           </Stack>

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -1,44 +1,77 @@
 import React from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import {
+  ExternalLinkAltIcon,
+  OpenDrawerRightIcon,
+} from '@patternfly/react-icons';
 import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components/PageHeader';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { RemediationsPopover } from '../RemediationsPopover';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-export const OverViewPageHeader = () => (
-  <PageHeader>
-    <PageHeaderTitle
-      className="pf-v5-u-mb-lg"
-      title={
-        <Flex
-          direction={{ default: 'row' }}
-          spaceItems={{ default: 'spaceItemsSm' }}
-          alignItems={{ default: 'alignItemsCenter' }}
-        >
-          <FlexItem>Remediation plans</FlexItem>
-          <FlexItem>
-            <RemediationsPopover />
-          </FlexItem>
-        </Flex>
-      }
-    />
-    <div>
-      <p>
-        Remediation plans use Ansible playbooks to resolve issues identified by
-        Red Hat Insights.
-        <InsightsLink
-          style={{ textDecoration: 'none' }}
-          className="pf-v5-u-ml-md"
-          to={
-            'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/index'
-          }
-        >
-          Learn more <ExternalLinkAltIcon />
-        </InsightsLink>
-      </p>
-    </div>
-  </PageHeader>
-);
+export const OverViewPageHeader = () => {
+  const { quickStarts } = useChrome();
+
+  return (
+    <PageHeader className="pf-v5-u-pb-lg">
+      <Flex
+        justifyContent={{ default: 'spaceBetween' }}
+        alignItems={{ default: 'alignItemsFlexStart' }}
+      >
+        <FlexItem flex={{ default: 'flex_1' }}>
+          <Stack hasGutter>
+            <StackItem>
+              <PageHeaderTitle
+                title={
+                  <Flex
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                  >
+                    <FlexItem>Remediation plans</FlexItem>
+                    <FlexItem>
+                      <RemediationsPopover />
+                    </FlexItem>
+                  </Flex>
+                }
+              />
+            </StackItem>
+
+            <StackItem>
+              <p>
+                Remediation plans use Ansible playbooks to resolve issues
+                identified by Red Hat Insights.
+                <InsightsLink
+                  className="pf-v5-u-ml-md"
+                  to="https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/red_hat_insights_remediations_guide/index"
+                  style={{ textDecoration: 'none' }}
+                >
+                  Learn more <ExternalLinkAltIcon />
+                </InsightsLink>
+              </p>
+            </StackItem>
+          </Stack>
+        </FlexItem>
+
+        <FlexItem>
+          <Button
+            variant="secondary"
+            onClick={() =>
+              quickStarts.activateQuickstart('insights-remediate-plan-create')
+            }
+          >
+            Launch Quick Start <OpenDrawerRightIcon className="pf-v5-u-ml-sm" />
+          </Button>
+        </FlexItem>
+      </Flex>
+    </PageHeader>
+  );
+};

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -17,8 +17,9 @@ import {
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { RemediationsPopover } from '../RemediationsPopover';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import PropTypes from 'prop-types';
 
-export const OverViewPageHeader = () => {
+export const OverViewPageHeader = ({ hasRemediations }) => {
   const { quickStarts } = useChrome();
 
   return (
@@ -61,17 +62,26 @@ export const OverViewPageHeader = () => {
           </Stack>
         </FlexItem>
 
-        <FlexItem>
-          <Button
-            variant="secondary"
-            onClick={() =>
-              quickStarts.activateQuickstart('insights-remediate-plan-create')
-            }
-          >
-            Launch Quick Start <OpenDrawerRightIcon className="pf-v5-u-ml-sm" />
-          </Button>
-        </FlexItem>
+        {hasRemediations && (
+          <FlexItem>
+            <Button
+              variant="secondary"
+              onClick={() =>
+                quickStarts?.activateQuickstart(
+                  'insights-remediate-plan-create'
+                )
+              }
+            >
+              Launch Quick Start
+              <OpenDrawerRightIcon className="pf-v5-u-ml-sm" />
+            </Button>
+          </FlexItem>
+        )}
       </Flex>
     </PageHeader>
   );
+};
+
+OverViewPageHeader.propTypes = {
+  hasRemediations: PropTypes.bool,
 };

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -11,8 +11,8 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 import PropTypes from 'prop-types';
-import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { OpenDrawerRightIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const ProgressCard = ({
   remediationStatus,
@@ -20,6 +20,8 @@ const ProgressCard = ({
   readyOrNot,
   onNavigateToTab,
 }) => {
+  const { quickStarts } = useChrome();
+
   return permissions === undefined ? (
     <Spinner />
   ) : (
@@ -119,18 +121,16 @@ const ProgressCard = ({
         </ProgressStepper>
       </CardBody>
       <CardFooter className="pf-v5-u-font-size-sm">
-        Need help to pass the remediations execution readiness check? Learn
-        more.
-        <InsightsLink
-          to={
-            'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html-single/red_hat_insights_remediations_guide/index#executing-playbooks-from-insights_remediations-from-insights'
+        Need help to pass the remediations execution readiness check?
+        <Button
+          onClick={() =>
+            quickStarts.activateQuickstart('insights-remediate-plan-create')
           }
-          target="_blank"
+          variant="link"
+          className="pf-v5-u-font-size-sm"
         >
-          <Button variant="link" className="pf-v5-u-font-size-sm">
-            Learn more. <ExternalLinkAltIcon />
-          </Button>{' '}
-        </InsightsLink>
+          Learn more <OpenDrawerRightIcon className="pf-v5-u-ml-sm" />
+        </Button>
       </CardFooter>
     </Card>
   );

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -124,7 +124,7 @@ const ProgressCard = ({
         Need help to pass the remediations execution readiness check?
         <Button
           onClick={() =>
-            quickStarts.activateQuickstart('insights-remediate-plan-create')
+            quickStarts?.activateQuickstart('insights-remediate-plan-create')
           }
           variant="link"
           className="pf-v5-u-font-size-sm"


### PR DESCRIPTION
This implements Quick start in remediations: https://issues.redhat.com/browse/RHINENG-18108 

These are the mocks (wording has been updated since so the word around some of the links can be ignored): https://www.figma.com/design/FyfDGBiNpa1CgArgJd9bHk/CPUX5904_remediation_redoMVP?node-id=8628-3593&p=f&t=JvqHe0fX2K8M2PtK-0

The quick start should be available for 3 different locations. main overview page, no remediations page, and details page -> progress card (general tab right side). To test the no remediations page, use the comp user account 


Overview Page Mocks : <img width="1057" alt="Screenshot 2025-05-14 at 5 59 28 PM" src="https://github.com/user-attachments/assets/9f656059-6ca5-43ce-8ffd-4b772458eb6b" />

Overview Page PR :
<img width="1197" alt="Screenshot 2025-05-14 at 6 01 42 PM" src="https://github.com/user-attachments/assets/c6761708-6407-45d6-a14c-2b08d8503b0c" />


Details Page Mocks:
<img width="917" alt="Screenshot 2025-05-14 at 5 59 52 PM" src="https://github.com/user-attachments/assets/90d88c43-d6bd-4bbf-845d-0350cb911593" />


Details Page PR
<img width="686" alt="Screenshot 2025-05-14 at 6 02 01 PM" src="https://github.com/user-attachments/assets/4a520359-467e-4d19-bf03-6d168e40c9d0" />


No remediation page Mocks
<img width="904" alt="Screenshot 2025-05-14 at 6 00 06 PM" src="https://github.com/user-attachments/assets/d155b344-53c1-46c5-983c-a96febca140d" />


No remediations Page PR: 
<img width="1178" alt="Screenshot 2025-05-14 at 6 26 53 PM" src="https://github.com/user-attachments/assets/00581e5c-d5f8-4611-8ebf-201c68809b7e" />


## Summary by Sourcery

Enable users to launch the remediation plan creation QuickStart from the main overview header, the ‘no remediations’ empty state, and the remediation details progress card.

New Features:
- Add ‘Launch Quick Start’ button to the overview page header to start remediation plan creation
- Introduce QuickStart launch action in the no-remediations empty state view
- Embed a QuickStart launch link in the progress card footer on the remediation details page

Enhancements:
- Refactor overview header and no-remediations page layout with PatternFly Stack and PageSection components
- Replace static external documentation links with QuickStart activation calls for remediation guidance