### PR TITLE
fix(RHINENG-16097| RHINENG:18147): Allow manual input for calendar filter + Link to ExecutionHistory tab

### DIFF
--- a/src/components/RemediationsTable/serealisers.js
+++ b/src/components/RemediationsTable/serealisers.js
@@ -6,11 +6,12 @@ export const paginationSerialiser = (state) => {
     return { offset, limit };
   }
 };
+const YYYY_MM_DD_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
 const toUtcIso = (yyyyMmDd) => {
   if (!yyyyMmDd) return undefined;
 
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(yyyyMmDd)) return undefined;
-
+  if (!YYYY_MM_DD_REGEX.test(yyyyMmDd)) return undefined;
   const date = new Date(`${yyyyMmDd}T00:00:00Z`);
   if (isNaN(date.getTime())) return undefined;
 

--- a/src/components/RemediationsTable/serealisers.js
+++ b/src/components/RemediationsTable/serealisers.js
@@ -6,8 +6,16 @@ export const paginationSerialiser = (state) => {
     return { offset, limit };
   }
 };
-const toUtcIso = (yyyyMmDd) =>
-  yyyyMmDd ? new Date(`${yyyyMmDd}T00:00:00Z`).toISOString() : undefined;
+const toUtcIso = (yyyyMmDd) => {
+  if (!yyyyMmDd) return undefined;
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(yyyyMmDd)) return undefined;
+
+  const date = new Date(`${yyyyMmDd}T00:00:00Z`);
+  if (isNaN(date.getTime())) return undefined;
+
+  return date.toISOString();
+};
 
 const filterSerialisers = {
   text: (_config, [value]) => value,

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -195,7 +195,7 @@ const DetailsCard = ({
             <DescriptionListDescription>
               <Button
                 variant="link"
-                style={{ padding: 0 }}
+                isInline
                 onClick={() => onNavigateToTab(null, 'executionHistory')}
               >
                 {execStatus(remediationPlaybookRuns?.status, formatedDate)}
@@ -221,7 +221,7 @@ const DetailsCard = ({
               <Button
                 variant="link"
                 onClick={() => onNavigateToTab(null, 'actions')}
-                style={{ padding: '0' }}
+                isInline
               >
                 {`${details?.issues.length} action${
                   details?.issues.length > 1 ? 's' : ''
@@ -236,7 +236,7 @@ const DetailsCard = ({
               <Button
                 variant="link"
                 onClick={() => onNavigateToTab(null, 'systems')}
-                style={{ padding: '0' }}
+                isInline
               >
                 {`${remediationStatus?.totalSystems} system${
                   remediationStatus?.totalSystems > 1 ? 's' : ''

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -193,7 +193,13 @@ const DetailsCard = ({
           <DescriptionListGroup>
             <DescriptionListTerm>Latest execution status</DescriptionListTerm>
             <DescriptionListDescription>
-              {execStatus(remediationPlaybookRuns?.status, formatedDate)}
+              <Button
+                variant="link"
+                style={{ padding: 0 }}
+                onClick={() => onNavigateToTab(null, 'executionHistory')}
+              >
+                {execStatus(remediationPlaybookRuns?.status, formatedDate)}
+              </Button>
             </DescriptionListDescription>
           </DescriptionListGroup>
           {/* Actions */}

--- a/src/routes/RemediationDetailsComponents/helpers.js
+++ b/src/routes/RemediationDetailsComponents/helpers.js
@@ -43,7 +43,7 @@ export const execStatus = (status, date) => {
   return (
     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
       {icon}
-      <TextContent>{`${displayValue} ${getTimeAgo(date)}`}</TextContent>
+      <span>{`${displayValue} ${getTimeAgo(date)}`}</span>
     </Flex>
   );
 };


### PR DESCRIPTION
This PR fixes 1 bug and implements a small feature. 

https://issues.redhat.com/browse/RHINENG-18147 : In Details page, General Tab, details card -> 
Latest execution status should now be a clickable link that takes you to the ExecutionHistory tab

Request: 
<img width="475" alt="Screenshot 2025-05-16 at 11 32 24 AM" src="https://github.com/user-attachments/assets/d6cee7be-cd42-4dbe-b0e2-57bb684f9f42" />

PR: 
<img width="520" alt="Screenshot 2025-05-16 at 11 32 08 AM" src="https://github.com/user-attachments/assets/0d9ac07c-e369-4a37-93dc-f463f4b88523" />


https://issues.redhat.com/browse/RHINENG-16097: Calendar filter would fail if you input anything manually on overview page. Typing should no longer break the page + Invalid date will show up if said date typed in is invalid. 

