### PR TITLE
fix(summit): Remove sorting/wording changes

### DIFF
--- a/src/routes/Columns.js
+++ b/src/routes/Columns.js
@@ -33,7 +33,8 @@ export const LastExecuted = {
 export const ExecutionStatus = {
   title: 'Execution status',
   transforms: [wrappable],
-  sortable: 'status',
+  //TODO: Enable once Backend is ready
+  // sortable: 'status',
   exportKey: 'status',
   renderFunc: renderComponent(ExecutionStatusCell),
 };

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -5,7 +5,7 @@ import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/fronten
 import RemediationsTable from '../../components/RemediationsTable/RemediationsTable';
 import {
   CreatedByFilter,
-  ExecutionStatusFilter,
+  // ExecutionStatusFilter,
   LastExecutedFilter,
   LastModifiedFilter,
   remediationNameFilter,
@@ -188,7 +188,8 @@ export const OverViewPage = () => {
                 filterConfig: [
                   ...remediationNameFilter,
                   ...LastExecutedFilter,
-                  ...ExecutionStatusFilter,
+                  //TODO: Enable filter once backend is ready
+                  // ...ExecutionStatusFilter,
                   ...LastModifiedFilter,
                   ...CreatedByFilter,
                 ],

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -33,7 +33,7 @@ export const OverViewPageHeader = ({ hasRemediations }) => {
                     spaceItems={{ default: 'spaceItemsSm' }}
                     alignItems={{ default: 'alignItemsCenter' }}
                   >
-                    <FlexItem>Remediation plans</FlexItem>
+                    <FlexItem>Remediation Plans</FlexItem>
                     <FlexItem>
                       <RemediationsPopover />
                     </FlexItem>

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/ExecutionHistoryContent.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/ExecutionHistoryContent.js
@@ -217,7 +217,7 @@ const ExecutionHistoryTab = ({
                 variant="primary"
                 onClick={() => setIsLogOpen(false)}
               >
-                Cancel
+                Close
               </Button>
             </ModalBoxFooter>
           </>

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -54,8 +54,7 @@ const ProgressCard = ({
                   <>
                     You do not have the required&nbsp;
                     <strong>Remediations administrator</strong>&nbsp;RBAC role.
-                    Contact your IAM Organization Administrator to request
-                    access.
+                    Contact your organization administrator to request access.
                   </>
                 )}
               </span>
@@ -76,7 +75,7 @@ const ProgressCard = ({
                   'Enabled'
                 ) : (
                   <>
-                    You have not enabled RHC Manager. Enable it in&nbsp;
+                    RHC Manager is not enabled. Enable it in&nbsp;
                     <a
                       href="https://console.redhat.com/insights/connector"
                       target="_blank"
@@ -124,19 +123,12 @@ const ProgressCard = ({
           </ProgressStep>
           <ProgressStep
             variant={readyOrNot ? `success` : 'danger'}
-            description={
-              <span className="pf-v5-u-color-100">
-                {readyOrNot
-                  ? 'Ready for execution.'
-                  : 'Execution readiness check failed'}
-              </span>
-            }
             id="readyStep"
             titleId="readyStep-title"
             aria-label="Ready step"
           >
             <span className="pf-v5-u-font-weight-bold pf-v5-u-color-100">
-              {readyOrNot ? 'Ready for execution.' : 'Not ready for execution'}
+              {readyOrNot ? 'Ready for execution' : 'Not ready for execution'}
             </span>
           </ProgressStep>
         </ProgressStepper>

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -48,7 +48,16 @@ const ProgressCard = ({
             variant={permissions?.execute ? 'success' : 'danger'}
             description={
               <span className="pf-v5-u-color-100">
-                {permissions?.execute ? 'Authorized' : 'Not authorized'}
+                {permissions?.execute ? (
+                  'Authorized'
+                ) : (
+                  <>
+                    You do not have the required&nbsp;
+                    <strong>Remediations administrator</strong>&nbsp;RBAC role.
+                    Contact your IAM Organization Administrator to request
+                    access.
+                  </>
+                )}
               </span>
             }
             id="permissionsStep"
@@ -63,9 +72,25 @@ const ProgressCard = ({
             }
             description={
               <span className="pf-v5-u-color-100">
-                {remediationStatus?.detailsError !== 403
-                  ? 'Enabled'
-                  : 'Not enabled'}
+                {remediationStatus?.detailsError !== 403 ? (
+                  'Enabled'
+                ) : (
+                  <>
+                    You have not enabled RHC Manager. Enable it in&nbsp;
+                    <a
+                      href="https://console.redhat.com/insights/connector"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        textDecoration: 'none',
+                        color: 'var(--pf-v5-global--link--Color)',
+                      }}
+                    >
+                      Remote Host Configuration&nbsp;(RHC)
+                    </a>
+                    .
+                  </>
+                )}
               </span>
             }
             id="RHCStep"
@@ -82,11 +107,7 @@ const ProgressCard = ({
             }
             description={
               <div className="pf-v5-u-color-100">
-                {`${
-                  remediationStatus?.connectedSystems +
-                  '(of ' +
-                  remediationStatus?.totalSystems
-                }) connected systems`}
+                {`${remediationStatus?.connectedSystems} (of ${remediationStatus?.totalSystems}) connected systems`}{' '}
                 <Button
                   variant="link"
                   onClick={() => onNavigateToTab(null, 'systems')}


### PR DESCRIPTION
This ticket should `remove sorting in the main page for execution status`. As well as `filtering` by execution status. 

Changes the page header to capitalize the P in 'Remediation plans'
There is also a wording change in the progress card. When permissions are not granted, the description should read 

`You do not have the required Remediations administrator RBAC role. Contact your organization administrator to request access.`

Change the RHC description when failed to say `RHC Manager is not enabled. Enable it in Remote Host Configuration (RHC)`

Also fix spacing for the connected systems string
`1 (of 1) connected systems`

## Summary by Sourcery

Disable execution status sorting and filtering until backend support is available; refine messaging in ProgressCard for RBAC authorization and RHC enablement; correct connected systems formatting; update execution history modal button label

Enhancements:
- Disable execution status sorting and filtering until backend support is available
- Update unauthorized permissions description to include RBAC role guidance and request flow
- Enhance RHC enablement description with a direct link to Remote Host Configuration
- Fix spacing and formatting for connected systems count
- Rename execution history modal button from “Cancel” to “Close”