### PR TITLE
Fix(MVP): Fix small bugs and update execution flow 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "!**/node_modules/**"
     ],
     "transformIgnorePatterns": [
-      "/node_modules/(?!(uuid|@redhat-cloud-services|react-syntax-highlighter))"
+      "/node_modules/(?!(uuid|@redhat-cloud-services|react-syntax-highlighter|p-all|p-map|aggregate-error|indent-string|clean-stack)/)"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -36,38 +36,42 @@ const ExecuteButton = ({
   }, [remediationStatus]);
 
   const buttonWithTooltip = () => {
-    return (
+    const button = (
+      <Button
+        isAriaDisabled={isDisabled}
+        data-testid="execute-button-enabled"
+        onClick={() => {
+          setOpen(true);
+          getConnectionStatus(remediation.id);
+        }}
+      >
+        {isDisabled && <ExclamationTriangleIcon />} Execute
+      </Button>
+    );
+
+    return isDisabled ? (
       <Tooltip
         minWidth="400px"
         aria-label="details Tooltip"
         content={
-          <>
-            <Flex
-              className="pf-v5-u-ml-md"
-              direction={{ default: 'column' }}
-              spaceItems={{ default: 'spaceItemsNone' }}
-              alignItems={{ default: 'alignItemsFlexStart' }}
-            >
-              <p>
-                The remediation plan cannot be executed. Review the plan details
-                and
-                <strong> Execution readiness </strong>information.
-              </p>
-            </Flex>
-          </>
+          <Flex
+            className="pf-v5-u-ml-md"
+            direction={{ default: 'column' }}
+            spaceItems={{ default: 'spaceItemsNone' }}
+            alignItems={{ default: 'alignItemsFlexStart' }}
+          >
+            <p>
+              The remediation plan cannot be executed. Review the plan details
+              and
+              <strong> Execution readiness </strong>information.
+            </p>
+          </Flex>
         }
       >
-        <Button
-          isAriaDisabled={isDisabled}
-          data-testid="execute-button-enabled"
-          onClick={() => {
-            setOpen(true);
-            getConnectionStatus(remediation.id);
-          }}
-        >
-          {isDisabled && <ExclamationTriangleIcon />} Execute
-        </Button>
+        {button}
       </Tooltip>
+    ) : (
+      button
     );
   };
 

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -14,12 +14,12 @@ const ExecuteButton = ({
   data,
   getConnectionStatus,
   issueCount,
-  runRemediation,
   etag,
   remediationStatus,
   setEtag,
   areDetailsLoading,
   remediation,
+  refetchRemediationPlaybookRuns,
 }) => {
   const [open, setOpen] = useState(false);
   const [showRefreshMessage, setShowRefreshMessage] = useState(false);
@@ -92,8 +92,8 @@ const ExecuteButton = ({
           etag={etag}
           isLoading={isLoading}
           issueCount={issueCount}
-          runRemediation={runRemediation}
           setEtag={setEtag}
+          refetchRemediationPlaybookRuns={refetchRemediationPlaybookRuns}
         />
       )}
     </React.Fragment>
@@ -106,7 +106,6 @@ ExecuteButton.propTypes = {
   isLoading: PropTypes.bool,
   data: PropTypes.array,
   getConnectionStatus: PropTypes.func,
-  runRemediation: PropTypes.func,
   remediation: PropTypes.string,
   remediationStatus: PropTypes.string,
   issueCount: PropTypes.number,
@@ -119,6 +118,7 @@ ExecuteButton.propTypes = {
   detailsError: PropTypes.any,
   permissions: PropTypes.bool,
   totalSystems: PropTypes.number,
+  refetchRemediationPlaybookRuns: PropTypes.func,
 };
 
 ExecuteButton.defaultProps = {

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -27,6 +27,9 @@ import './ExecuteModal.scss';
 import EmptyExecutePlaybookState from '../EmptyExecutePlaybookState';
 import { dispatchNotification } from '../../Utilities/dispatcher';
 import { renderConnectionStatus } from '../../routes/helpers';
+import useRemediationsQuery from '../../api/useRemediationsQuery';
+import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/frontend-components-utilities/interceptors';
+import { executeRemediation } from '../../routes/api';
 
 export const ExecuteModal = ({
   isOpen,
@@ -37,10 +40,11 @@ export const ExecuteModal = ({
   remediationId,
   remediationName,
   issueCount,
-  runRemediation,
   etag,
   setEtag,
+  refetchRemediationPlaybookRuns,
 }) => {
+  const axios = useAxiosWithPlatformInterceptors();
   const [connected, setConnected] = useState([]);
   const [disconnected, setDisconnected] = useState([]);
   const isDebug = () => localStorage.getItem('remediations:debug') === 'true';
@@ -95,6 +99,43 @@ export const ExecuteModal = ({
   const pluralize = (number, str) =>
     number > 1 ? `${number} ${str}s` : `${number} ${str}`;
 
+  const { fetch: executeRun } = useRemediationsQuery(
+    executeRemediation(axios),
+    {
+      skip: true,
+    }
+  );
+
+  const handleClick = () => {
+    const exclude = disconnected.map((e) => e.executor_id).filter(Boolean);
+
+    executeRun({ id: remediationId, etag, exclude })
+      .then(() => {
+        refetchRemediationPlaybookRuns();
+        dispatchNotification({
+          title: `Executing playbook ${remediationName}`,
+          description: (
+            <span>
+              View results in the <b>Execution History tab</b>
+            </span>
+          ),
+          variant: 'success',
+          dismissable: true,
+          autoDismiss: true,
+        });
+        onClose();
+      })
+      .catch((err) => {
+        dispatchNotification({
+          title: `Failed to execute playbook`,
+          description: err.message || 'Unknown error',
+          variant: 'danger',
+          dismissable: true,
+          autoDismiss: true,
+        });
+      });
+  };
+
   return (
     <Modal
       data-testid="execute-modal"
@@ -112,24 +153,7 @@ export const ExecuteModal = ({
                 variant="primary"
                 ouiaId="etag"
                 isDisabled={connected.length === 0}
-                onClick={() => {
-                  runRemediation(
-                    remediationId,
-                    etag,
-                    disconnected.map((e) => e.executor_id).filter((e) => e)
-                  );
-                  dispatchNotification({
-                    title: `Executing playbook ${remediationName}`,
-                    description: (
-                      <span>
-                        View results in the <b>Execution History tab</b>
-                      </span>
-                    ),
-                    variant: 'success',
-                    dismissable: true,
-                    autoDismiss: true,
-                  });
-                }}
+                onClick={handleClick}
               >
                 {isLoading
                   ? 'Execute playbook'
@@ -305,7 +329,7 @@ ExecuteModal.propTypes = {
   remediationId: PropTypes.string,
   remediationName: PropTypes.string,
   issueCount: PropTypes.number,
-  runRemediation: PropTypes.func,
   etag: PropTypes.string,
   setEtag: PropTypes.func,
+  refetchRemediationPlaybookRuns: PropTypes.func,
 };

--- a/src/components/Modals/__tests__/ExecuteModal.test.js
+++ b/src/components/Modals/__tests__/ExecuteModal.test.js
@@ -80,7 +80,6 @@ describe('Execute modal', () => {
         isLoading={false}
         issueCount={1}
         remediationStatus={'initial'}
-        runRemediation={() => null}
         setEtag={() => null}
       />
     );

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -224,7 +224,7 @@ const DetailsCard = ({
                 isInline
               >
                 {`${details?.issues.length} action${
-                  details?.issues.length > 1 ? 's' : ''
+                  details?.issues.length !== 1 ? 's' : ''
                 }`}
               </Button>
             </DescriptionListDescription>
@@ -239,7 +239,7 @@ const DetailsCard = ({
                 isInline
               >
                 {`${remediationStatus?.totalSystems} system${
-                  remediationStatus?.totalSystems > 1 ? 's' : ''
+                  remediationStatus?.totalSystems !== 1 ? 's' : ''
                 }`}
               </Button>
             </DescriptionListDescription>

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -14,6 +14,7 @@ const DetailsGeneralContent = ({
   allRemediations,
   permissions,
   remediationPlaybookRuns,
+  refetchAllRemediations,
 }) => {
   const readyOrNot =
     !permissions?.exectute &&
@@ -48,6 +49,7 @@ const DetailsGeneralContent = ({
             onNavigateToTab={onNavigateToTab}
             allRemediations={allRemediations}
             remediationPlaybookRuns={remediationPlaybookRuns}
+            refetchAllRemediations={refetchAllRemediations}
           />
         </GridItem>
         <GridItem span={12} md={6}>
@@ -73,6 +75,7 @@ DetailsGeneralContent.propTypes = {
   allRemediations: PropTypes.array,
   permissions: PropTypes.object,
   remediationPlaybookRuns: PropTypes.any,
+  refetchAllRemediations: PropTypes.func,
 };
 
 export default DetailsGeneralContent;

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -19,6 +19,7 @@ const RemediationDetailsPageHeader = ({
   updateRemPlan,
   refetch,
   permissions,
+  refetchRemediationPlaybookRuns,
 }) => {
   const handleDownload = useCallback(async () => {
     dispatchNotification({
@@ -75,7 +76,7 @@ const RemediationDetailsPageHeader = ({
         </FlexItem>
         <FlexItem style={{ marginTop: 'var(--pf-v5-global--spacer--sm)' }}>
           <Flex
-            spaceItems={{ default: 'spaceItemsXs' }}
+            spaceItems={{ default: 'spaceItemsSm' }}
             flexWrap={{ default: 'wrap' }}
           >
             <FlexItem>
@@ -92,6 +93,7 @@ const RemediationDetailsPageHeader = ({
                 permissions={permissions.execute}
                 issueCount={remediation?.issues}
                 remediation={remediation}
+                refetchRemediationPlaybookRuns={refetchRemediationPlaybookRuns}
               />
             </FlexItem>
             <FlexItem>
@@ -139,6 +141,7 @@ RemediationDetailsPageHeader.propTypes = {
   permissions: PropTypes.obj,
   isExecutable: PropTypes.any,
   refetchAllRemediations: PropTypes.func,
+  refetchRemediationPlaybookRuns: PropTypes.func,
 };
 
 export default RemediationDetailsPageHeader;

--- a/src/routes/RemediationDetailsV2.js
+++ b/src/routes/RemediationDetailsV2.js
@@ -44,10 +44,13 @@ const RemediationDetailsV2 = () => {
       params: { remId: id },
     });
 
-  const { result: remediationPlaybookRuns, loading: isPlaybookRunsLoading } =
-    useRemediationsQuery(getRemediationPlaybook(axios), {
-      params: { remId: id },
-    });
+  const {
+    result: remediationPlaybookRuns,
+    loading: isPlaybookRunsLoading,
+    refetch: refetchRemediationPlaybookRuns,
+  } = useRemediationsQuery(getRemediationPlaybook(axios), {
+    params: { remId: id },
+  });
 
   const { fetch: updateRemPlan } = useRemediationsQuery(
     updateRemediationPlans(axios),
@@ -100,6 +103,7 @@ const RemediationDetailsV2 = () => {
           refetch={fetchRemediation}
           permissions={context.permissions}
           isExecutable={getIsExecutable(isExecutable)}
+          refetchRemediationPlaybookRuns={refetchRemediationPlaybookRuns}
         />
         <Tabs
           activeKey={searchParams.get('activeTab') || 'general'}

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -59,3 +59,12 @@ export const deleteRemediationList = (axios) => (params) => {
     },
   });
 };
+
+export const executeRemediation = (axios) => (params) => {
+  const { id, etag, exclude } = params;
+  return axios.post(
+    `${API_BASE}/remediations/${id}/playbook_runs`,
+    { exclude },
+    { headers: { 'If-Match': etag } }
+  );
+};


### PR DESCRIPTION
There are no Jira tickets associated with the following bugs, these were just found. 

The tooltip over execution button now ONLY appears when the button is disabled
Passed down the refetchRem function so rename on the details card works
Update the flow on the execution button so when a user executes the section reloads (This whole component is getting rewritten in another PR)

## Summary by Sourcery

Fix small bugs in execution button UI and refetch logic, and update the execution flow to use the new executeRemediation API with remediationsV2 feature flag and data refetch on completion.

Bug Fixes:
- Display tooltip over execute button only when it’s disabled
- Pass refetchRemediationPlaybookRuns prop through detail components to enable rename refresh

Enhancements:
- Centralize execution logic in ExecuteModal.handleClick supporting both legacy and v2 flows via remediationsV2 flag
- Introduce executeRemediation API call and integrate useRemediationsQuery for playbook runs
- Refresh remediation playbook runs and close modal on successful execution