### PR TITLE
feat(RHINENG-19424): Upgrade source map uploads

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -19,18 +19,39 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.commit_hash || 'refs/heads/master' }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: 'npm'
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         env:
           ENABLE_SENTRY:  ${{ secrets.ENABLE_SENTRY }}
-          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash && github.event.inputs.commit_hash }}
+          SENTRY_RELEASE: ${{ github.event.inputs.commit_hash || github.sha }}
           SENTRY_AUTH_TOKEN: ${{ github.event.inputs.commit_hash && secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG:      ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT:  ${{ secrets.SENTRY_PROJECT }}
         run: npm run build --if-present
+
+      - name: Install Sentry CLI
+        if: ${{ github.event.inputs.commit_hash != '' }}
+        run: npm install -g @sentry/cli
+
+      - name: Upload sourcemaps to Sentry
+        if: ${{ github.event.inputs.commit_hash != '' }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          sentry-cli sourcemaps upload \
+            --org red-hat-it \
+            --project inventory-rhel \
+            --project advisor-rhel \
+            --project vulnerability-rhel \
+            --project compliance-rhel \
+            --release ${{ github.event.inputs.commit_hash || github.sha }} \
+            --dist ${{ github.event.inputs.commit_hash || github.sha }} \
+            ./build


### PR DESCRIPTION
The goal is to upload remediations source maps to all apps that consume the application. This first one is a test

## Summary by Sourcery

Enable uploading of source maps to Sentry for multiple Red Hat remediations applications by updating the GitHub Actions workflow.

CI:
- Update sentry.yml to set SENTRY_RELEASE to use github.sha as a fallback when no commit hash is provided
- Add conditional installation of Sentry CLI and a step to upload sourcemaps to Sentry across multiple projects