### PR TITLE
feat(RHINENG-19447): Add tooltip to disabled download btn

### DIFF
--- a/src/Utilities/ButtonWithToolTip.js
+++ b/src/Utilities/ButtonWithToolTip.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+const ButtonWithToolTip = ({
+  isDisabled,
+  onClick,
+  tooltipContent,
+  children,
+  variant = 'secondary',
+  ...buttonProps
+}) => {
+  const button = (
+    <Button
+      isAriaDisabled={isDisabled}
+      variant={variant}
+      onClick={onClick}
+      {...buttonProps}
+    >
+      {children}
+    </Button>
+  );
+
+  return isDisabled ? (
+    <Tooltip content={tooltipContent}>{button}</Tooltip>
+  ) : (
+    button
+  );
+};
+
+ButtonWithToolTip.propTypes = {
+  isDisabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  tooltipContent: PropTypes.node,
+  children: PropTypes.node.isRequired,
+  variant: PropTypes.string,
+};
+
+export default ButtonWithToolTip;

--- a/src/Utilities/ButtonWithToolTip.test.js
+++ b/src/Utilities/ButtonWithToolTip.test.js
@@ -1,0 +1,96 @@
+/* eslint-disable react/prop-types */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ButtonWithToolTip from './ButtonWithToolTip';
+
+// Mock PatternFly Tooltip to just render its children for simplicity
+jest.mock('@patternfly/react-core', () => {
+  const original = jest.requireActual('@patternfly/react-core');
+  const Tooltip = ({ children, content }) => (
+    <div data-testid="tooltip-mock">
+      <div data-testid="tooltip-content">{content}</div>
+      {children}
+    </div>
+  );
+
+  // Map isAriaDisabled to aria-disabled for the mock
+  const Button = ({ isAriaDisabled, ...props }) => (
+    <button aria-disabled={isAriaDisabled ? 'true' : undefined} {...props}>
+      {props.children}
+    </button>
+  );
+
+  return {
+    ...original,
+    Tooltip,
+    Button,
+  };
+});
+
+describe('ButtonWithToolTip', () => {
+  it('renders enabled button and calls onClick', () => {
+    const handleClick = jest.fn();
+    render(
+      <ButtonWithToolTip
+        isDisabled={false}
+        onClick={handleClick}
+        tooltipContent={<span>Tooltip</span>}
+      >
+        Click me
+      </ButtonWithToolTip>,
+    );
+    const button = screen.getByRole('button', { name: /click me/i });
+    expect(button).not.toHaveAttribute('aria-disabled');
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalled();
+    // Tooltip should not be rendered when enabled
+    expect(screen.queryByTestId('tooltip-mock')).not.toBeInTheDocument();
+  });
+
+  it('renders disabled button with tooltip', () => {
+    const tooltipText = 'Disabled reason';
+    render(
+      <ButtonWithToolTip
+        isDisabled={true}
+        onClick={jest.fn()}
+        tooltipContent={<span>{tooltipText}</span>}
+      >
+        Disabled
+      </ButtonWithToolTip>,
+    );
+    const button = screen.getByRole('button', { name: /disabled/i });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByTestId('tooltip-mock')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+      tooltipText,
+    );
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <ButtonWithToolTip
+        isDisabled={false}
+        onClick={() => {}}
+        tooltipContent={<span>Tooltip</span>}
+      >
+        <span>Child Node</span>
+      </ButtonWithToolTip>,
+    );
+    expect(screen.getByText('Child Node')).toBeInTheDocument();
+  });
+
+  it('passes extra button props', () => {
+    render(
+      <ButtonWithToolTip
+        isDisabled={false}
+        onClick={() => {}}
+        tooltipContent={<span>Tooltip</span>}
+        data-testid="my-btn"
+      >
+        Extra Props
+      </ButtonWithToolTip>,
+    );
+    expect(screen.getByTestId('my-btn')).toBeInTheDocument();
+  });
+});

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -8,14 +8,14 @@ import { pluralize } from './utils';
 
 const verifyDownload = (selectedIds, data) => {
   const byId = keyBy(data, (r) => r.id);
-
   return selectedIds?.reduce((result, id) => {
     const remediation = byId[id];
-
-    if (remediation && remediation.issue_count > 0) {
+    if (
+      (remediation && remediation?.issue_count > 0) ||
+      remediation?.issues?.length > 0
+    ) {
       result.push(remediation.id);
     }
-
     return result;
   }, []);
 };

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 
 import PropTypes from 'prop-types';
-import { Button, Flex, Tooltip } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core';
 import { ExecuteModal } from './Modals/ExecuteModal';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ButtonWithToolTip from '../Utilities/ButtonWithToolTip';
 
 const ExecuteButton = ({
   isDisabled,
@@ -14,24 +15,13 @@ const ExecuteButton = ({
 }) => {
   const [open, setOpen] = useState(false);
 
-  const buttonWithTooltip = () => {
-    const button = (
-      <Button
-        isAriaDisabled={isDisabled}
-        data-testid="execute-button-enabled"
-        onClick={() => {
-          setOpen(true);
-        }}
-      >
-        {isDisabled && <ExclamationTriangleIcon />} Execute
-      </Button>
-    );
-
-    return isDisabled ? (
-      <Tooltip
-        minWidth="400px"
-        aria-label="details Tooltip"
-        content={
+  return (
+    <React.Fragment>
+      <ButtonWithToolTip
+        isDisabled={isDisabled}
+        variant="primary"
+        onClick={() => setOpen(true)}
+        tooltipContent={
           <Flex
             className="pf-v5-u-ml-md"
             direction={{ default: 'column' }}
@@ -45,17 +35,10 @@ const ExecuteButton = ({
             </p>
           </Flex>
         }
+        data-testid="execute-button-enabled"
       >
-        {button}
-      </Tooltip>
-    ) : (
-      button
-    );
-  };
-
-  return (
-    <React.Fragment>
-      {buttonWithTooltip()}
+        {isDisabled && <ExclamationTriangleIcon />} Execute
+      </ButtonWithToolTip>
       {open && (
         <ExecuteModal
           isOpen={open}

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -20,7 +20,7 @@ import {
   getRemediationsList,
   updateRemediationPlans,
 } from './api';
-import { getRemediations } from '../api';
+
 const RemediationDetails = () => {
   const chrome = useChrome();
   const { id } = useParams();
@@ -62,10 +62,6 @@ const RemediationDetails = () => {
       skip: true,
     },
   );
-
-  const { result: fullRemList } = useRemediationsQuery(getRemediations, {
-    params: { hide_archived: false, 'fields[data]': 'playbook_runs' },
-  });
 
   useEffect(() => {
     remediationDetails &&
@@ -112,7 +108,6 @@ const RemediationDetails = () => {
           permissions={context.permissions}
           isExecutable={getIsExecutable(isExecutable)}
           refetchRemediationPlaybookRuns={refetchRemediationPlaybookRuns}
-          fullRemList={fullRemList?.data}
         />
         <Tabs
           activeKey={searchParams.get('activeTab') || 'general'}

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -1,4 +1,4 @@
-import { Button, Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import ExecuteButton from '../../components/ExecuteButton';
 import { useDispatch } from 'react-redux';
 import { download } from '../../Utilities/DownloadPlaybookButton';
+import ButtonWithToolTip from '../../Utilities/ButtonWithToolTip';
 
 const RemediationDetailsPageHeader = ({
   remediation,
@@ -21,12 +22,11 @@ const RemediationDetailsPageHeader = ({
   permissions,
   refetchRemediationPlaybookRuns,
   isExecutable,
-  fullRemList,
 }) => {
   const dispatch = useDispatch();
   const handleDownload = useCallback(() => {
-    download([remediation.id], fullRemList, dispatch);
-  }, [remediation.id, fullRemList, dispatch]);
+    download([remediation.id], [remediation], dispatch);
+  }, [remediation, dispatch]);
 
   return (
     <PageHeader>
@@ -77,13 +77,18 @@ const RemediationDetailsPageHeader = ({
                 />
               </FlexItem>
               <FlexItem>
-                <Button
+                <ButtonWithToolTip
                   isDisabled={!remediation?.issues.length}
-                  variant="secondary"
                   onClick={handleDownload}
+                  tooltipContent={
+                    <div>
+                      The remediation plan cannot be downloaded because it does
+                      not include any actions or systems.
+                    </div>
+                  }
                 >
                   Download
-                </Button>
+                </ButtonWithToolTip>
               </FlexItem>
               <FlexItem>
                 <RemediationDetailsDropdown
@@ -123,7 +128,6 @@ RemediationDetailsPageHeader.propTypes = {
   isExecutable: PropTypes.any,
   refetchAllRemediations: PropTypes.func,
   refetchRemediationPlaybookRuns: PropTypes.func,
-  fullRemList: PropTypes.array,
 };
 
 export default RemediationDetailsPageHeader;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-19447
adds a tooltip the the disabled download button 
<img width="436" height="290" alt="Screenshot 2025-07-16 at 3 18 18 PM" src="https://github.com/user-attachments/assets/2eefd23b-56c9-4ac3-b582-e8856393121d" />

## Summary by Sourcery

Add tooltip support to disabled buttons by introducing a reusable ButtonWithToolTip component and apply it to the Execute and Download buttons.

New Features:
- Display explanatory tooltip when the execute button is disabled
- Display explanatory tooltip when the download button is disabled

Enhancements:
- Extract a reusable ButtonWithToolTip component to wrap PatternFly buttons with conditional tooltips

Tests:
- Add unit tests for the ButtonWithToolTip component