### PR TITLE
fix(RHINENG-19424): Alter sourcemap path + dont chain repos

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -40,18 +40,20 @@ jobs:
       - name: Install Sentry CLI
         if: ${{ github.event.inputs.commit_hash != '' }}
         run: npm install -g @sentry/cli
-
       - name: Upload sourcemaps to Sentry
         if: ${{ github.event.inputs.commit_hash != '' }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          sentry-cli sourcemaps upload \
-            --org red-hat-it \
-            --project inventory-rhel \
-            --project advisor-rhel \
-            --project vulnerability-rhel \
-            --project compliance-rhel \
-            --release ${{ github.event.inputs.commit_hash || github.sha }} \
-            --dist ${{ github.event.inputs.commit_hash || github.sha }} \
-            ./build
+          COMMIT=${{ github.event.inputs.commit_hash || github.sha }}
+
+          for PROJECT in inventory-rhel advisor-rhel vulnerability-rhel compliance-rhel; do
+            echo "Uploading sourcemaps to $PROJECT..."
+            sentry-cli releases files "$COMMIT" upload-sourcemaps ./dist/js \
+              --org red-hat-it \
+              --project "$PROJECT" \
+              --release "$COMMIT" \
+              --dist "$COMMIT" \
+              --url-prefix '~/insights/remediations/js' \
+              --validate
+          done

--- a/fec.config.js
+++ b/fec.config.js
@@ -45,15 +45,15 @@ module.exports = {
       './RootApp': resolve(__dirname, './src/AppEntry'),
       './RemediationButton': resolve(
         __dirname,
-        './src/modules/RemediationsButton.js'
+        './src/modules/RemediationsButton.js',
       ),
       './RemediationWizard': resolve(
         __dirname,
-        './src/modules/RemediationsModal/index.js'
+        './src/modules/RemediationsModal/index.js',
       ),
       './NoDataModal': resolve(
         __dirname,
-        './src/modules/RemediationsModal/NoDataModal.js'
+        './src/modules/RemediationsModal/NoDataModal.js',
       ),
     },
   },


### PR DESCRIPTION
Looks in the proper ./dist file and loops instead of chains through repos and chaining isnt supported

## Summary by Sourcery

Revise the Sentry sourcemap upload workflow to iterate per project with the correct dist path and options, and clean up resolver entries in fec.config.js.

Bug Fixes:
- Fix sourcemap upload to use ./dist/js and remove unsupported multi-project chaining by looping over each project

Enhancements:
- Add URL prefix and validation flags to Sentry CLI sourcemap uploads

Chores:
- Add trailing commas to module resolver paths in fec.config.js for consistent formatting