### PR TITLE
fix(RHINENG-19424): Alter urlPrefix and script

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -46,14 +46,16 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           COMMIT=${{ github.event.inputs.commit_hash || github.sha }}
+          PREFIX="/apps/remediations/js"
+          PROJECTS="inventory-rhel advisor-rhel vulnerability-rhel compliance-rhel"
 
-          for PROJECT in inventory-rhel advisor-rhel vulnerability-rhel compliance-rhel; do
-            echo "Uploading sourcemaps to $PROJECT..."
+          for PROJECT in $PROJECTS; do
+            echo "Uploading Remediations sourcemaps to $PROJECT…"
             sentry-cli releases files "$COMMIT" upload-sourcemaps ./dist/js \
               --org red-hat-it \
               --project "$PROJECT" \
               --release "$COMMIT" \
-              --dist "$COMMIT" \
-              --url-prefix '~/insights/remediations/js' \
+              --url-prefix "$PREFIX" \
+              --rewrite \
               --validate
           done

--- a/fec.config.js
+++ b/fec.config.js
@@ -20,6 +20,10 @@ module.exports = {
             }),
             org: 'red-hat-it',
             project: 'remediations-rhel',
+            release: process.env.SENTRY_RELEASE,
+            include: path.resolve(__dirname, 'dist/js'),
+            urlPrefix: '/apps/remediations/js',
+            rewrite: true,
             moduleMetadata: ({ release }) => ({
               dsn: `https://5d7d7a7fb9032c5316f131dc8323137c@o490301.ingest.us.sentry.io/4508683233787904`,
               org: 'red-hat-it',


### PR DESCRIPTION
My belief is that sentry cant map across source maps properly due to the urlPrefix. This is testing that theory

## Summary by Sourcery

Fix Sentry sourcemap mapping by standardizing the URL prefix and enabling rewrite in both the CI workflow and frontend config.

Bug Fixes:
- Refactor GitHub Actions workflow to set urlPrefix to '/apps/remediations/js' per project and add --rewrite when uploading sourcemaps
- Update fec.config.js Sentry plugin to read release from env, include dist/js, apply urlPrefix '/apps/remediations/js', and enable rewrite