### PR TITLE
fix(RHiNENG-19424): Inject and include flags in sentry plugin

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -22,7 +22,10 @@ module.exports = {
             project: 'remediations-rhel',
             release: process.env.SENTRY_RELEASE,
             urlPrefix: '/apps/remediations/js',
+            include: 'dist/js',
             rewrite: true,
+            inject: false,
+            cleanArtifacts: true,
             moduleMetadata: ({ release }) => ({
               dsn: `https://5d7d7a7fb9032c5316f131dc8323137c@o490301.ingest.us.sentry.io/4508683233787904`,
               org: 'red-hat-it',


### PR DESCRIPTION
Sentry still isnt finding source maps. I believe the include and inject commands should help the version mismatches of sourcemaps being uploaded.

## Summary by Sourcery

Bug Fixes:
- Add include, inject, and cleanArtifacts options to the Sentry plugin configuration to fix sourcemap upload mismatches