### PR TITLE
fix(RHINENG-18973): Reload after deleting an action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,10 @@
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.0",
         "@redhat-cloud-services/remediations-client": "^3.1.0",
         "@redhat-cloud-services/sources-client": "^3.0.1",
-        "@scalprum/react-core": "^0.1.1",
         "@sentry/webpack-plugin": "^3.1.0",
         "@unleash/proxy-client-react": "^4.5.2",
         "axios": "^1.7.7",
-        "bastilian-tabletools": "^1.16.0",
+        "bastilian-tabletools": "^2.1.0",
         "classnames": "^2.3.1",
         "p-all": "^5.0.0",
         "react": "^18.0.0",
@@ -5199,70 +5198,6 @@
         "redux": ">=4.2.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.22.tgz",
-      "integrity": "sha512-FEDxxNHF0Jg6thM1IIFxHZSVbsS5Eq4QxOuPvbhlXA7ijvxzkgh5hDwBZyRSYhL2za+sZPqZzYTgwwu1Mb3MNw==",
-      "dependencies": {
-        "@patternfly/react-component-groups": "^5.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@scalprum/core": "^0.8.1",
-        "@scalprum/react-core": "^0.9.1",
-        "classnames": "^2.2.5",
-        "sanitize-html": "^2.13.1"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.2",
-        "react": "^18.2.0",
-        "react-content-loader": "^6.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.19.tgz",
-      "integrity": "sha512-CD3tp/fHWK/qiHfxsbiKW+odlUrQM8hQ+XxhkMzLcIJFBGbH3CTSpP9ALXdO+3UsaE5h3Hk3LRoFCYWp0Aajxg==",
-      "dependencies": {
-        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@sentry/browser": "^7.119.1",
-        "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.1 || ^1.7.0",
-        "commander": "^2.20.3",
-        "mkdirp": "^1.0.4",
-        "p-all": "^5.0.0",
-        "react-content-loader": "^6.2.0"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@scalprum/react-core": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.9.4.tgz",
-      "integrity": "sha512-92lI7fZ0kTjF+AhSyLH+Q8hJUlzHiDDm0SwYb08Wmwz99vx/Z4xT5OFV5jPkmRSHwztv7czQnw52RB2pbtugmQ==",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.8.2",
-        "lodash": "^4.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/redux-promise-middleware": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
@@ -5517,24 +5452,6 @@
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "tslib": "^2.6.2"
       }
-    },
-    "node_modules/@scalprum/react-core": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.1.9.tgz",
-      "integrity": "sha512-lb6sQQp7eylEF8z6UIeGygzURWXJ+1dbQi2NXctp7EU8zJ/3vfDD3dDGp2YOjs1DEVrG6Byxjf5394jlBFB2Vw==",
-      "dependencies": {
-        "@scalprum/core": "^0.1.2",
-        "lodash": "^4.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 || >=17.0.0",
-        "react-dom": ">=16.8.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-dupFyb1niBpyy1Mb6+bSbhZhNGYGQ4T32iNNdLB6Pvey64bApSnXl7AFl2D8468xO1YTb4Bah1libovLWvZovQ=="
     },
     "node_modules/@sentry-internal/feedback": {
       "version": "7.120.3",
@@ -8703,20 +8620,20 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-1.16.0.tgz",
-      "integrity": "sha512-V/M4mkD1Wx1fsSgNSBoRDuN7hDen/dCuCZfxbFg5EK9q9qmy/rrtOhbm4b6opWHbSjiYnhIs0YATOndFFeEcxQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-2.1.0.tgz",
+      "integrity": "sha512-JpIXM71cGAPCfIKVwdlOhJbK7wXx9zpfgQm+zJmTaLn3VezfyBAizV2PzBsUjLZNJuu2uajck4zhifSHDgeNfw==",
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
         "@jsonquerylang/jsonquery": "^5.0.4",
-        "@patternfly/patternfly": "^5.4.2",
-        "@patternfly/react-component-groups": "^5.5.8",
-        "@patternfly/react-core": "^5.4.14",
-        "@patternfly/react-table": "^5.4.16",
-        "@redhat-cloud-services/frontend-components": "^5.2.12",
-        "@redhat-cloud-services/frontend-components-utilities": "^5.0.13",
+        "@patternfly/patternfly": "^6.0.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "@redhat-cloud-services/frontend-components": "^6.1.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.1.0",
         "@tanstack/react-query": "^5.83.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@sentry/webpack-plugin": "^3.1.0",
         "@unleash/proxy-client-react": "^4.5.2",
         "axios": "^1.7.7",
-        "bastilian-tabletools": "^1.12.0",
+        "bastilian-tabletools": "^1.16.0",
         "classnames": "^2.3.1",
         "p-all": "^5.0.0",
         "react": "^18.0.0",
@@ -8703,9 +8703,9 @@
       "license": "MIT"
     },
     "node_modules/bastilian-tabletools": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-1.12.0.tgz",
-      "integrity": "sha512-bVBC1jRWUfLz07cc7tUAwPUngr+u65yI6oXQrxcZFfP32d+MHpCHsze3YWxxXmsK60BrmnXPVU/QwmSJjXVBog==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/bastilian-tabletools/-/bastilian-tabletools-1.16.0.tgz",
+      "integrity": "sha512-V/M4mkD1Wx1fsSgNSBoRDuN7hDen/dCuCZfxbFg5EK9q9qmy/rrtOhbm4b6opWHbSjiYnhIs0YATOndFFeEcxQ==",
       "engines": {
         "node": ">=22.0.0"
       },
@@ -8717,7 +8717,7 @@
         "@patternfly/react-table": "^5.4.16",
         "@redhat-cloud-services/frontend-components": "^5.2.12",
         "@redhat-cloud-services/frontend-components-utilities": "^5.0.13",
-        "@tanstack/react-query": "^5.82.0",
+        "@tanstack/react-query": "^5.83.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "use-deep-compare": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/webpack-plugin": "^3.1.0",
     "@unleash/proxy-client-react": "^4.5.2",
     "axios": "^1.7.7",
-    "bastilian-tabletools": "^1.12.0",
+    "bastilian-tabletools": "^1.16.0",
     "classnames": "^2.3.1",
     "p-all": "^5.0.0",
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": false,
   "repository": "https://github.com/RedHatInsights/insights-remediations-frontend",
   "engines": {
-   "node": ">=20.11",
-   "npm": ">=9"
+    "node": ">=20.11",
+    "npm": ">=9"
   },
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "^3.21.0",
@@ -20,15 +20,14 @@
     "@redhat-cloud-services/frontend-components": "^5.2.0",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^5.0.13",
-    "@scalprum/react-core": "^0.1.1",
-    "@redhat-cloud-services/host-inventory-client": "^4.1.0",
+    "@redhat-cloud-services/host-inventory-client": "^4.0.1",
     "@redhat-cloud-services/javascript-clients-shared": "^2.0.0",
     "@redhat-cloud-services/remediations-client": "^3.1.0",
     "@redhat-cloud-services/sources-client": "^3.0.1",
     "@sentry/webpack-plugin": "^3.1.0",
     "@unleash/proxy-client-react": "^4.5.2",
     "axios": "^1.7.7",
-    "bastilian-tabletools": "^1.16.0",
+    "bastilian-tabletools": "^2.1.0",
     "classnames": "^2.3.1",
     "p-all": "^5.0.0",
     "react": "^18.0.0",
@@ -128,6 +127,14 @@
     "start": "fec dev",
     "start:proxy": "PROXY=true fec dev",
     "verify": "npm-run-all build lint test:jest"
+  },
+  "overrides": {
+    "@patternfly/patternfly": "^5.4.2",
+    "@patternfly/react-component-groups": "^5.2.0",
+    "@patternfly/react-core": "^5.1.2",
+    "@patternfly/react-table": "^5.0.0",
+    "@redhat-cloud-services/frontend-components": "^5.2.0",
+    "@redhat-cloud-services/frontend-components-utilities": "^5.0.13"
   },
   "insights": {
     "appname": "remediations"

--- a/src/components/Modals/Columns.js
+++ b/src/components/Modals/Columns.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   ConnectionTypeCell,
   SystemsCell,
@@ -6,30 +5,25 @@ import {
 } from './Cells.js';
 import { wrappable } from '@patternfly/react-table';
 
-// eslint-disable-next-line react/display-name
-export const renderComponent = (Component, props) => (_data, _id, entity) => (
-  <Component {...entity} {...props} />
-);
-
 export const Systems = {
   title: 'Systems',
   transforms: [wrappable],
   sortable: 'system_count',
   exportKey: 'system_count',
-  renderFunc: renderComponent(SystemsCell),
+  Component: SystemsCell,
 };
 
 export const ConnectionType = {
   title: 'Connection type',
   transforms: [wrappable],
   exportKey: 'connection_type',
-  renderFunc: renderComponent(ConnectionTypeCell),
+  Component: ConnectionTypeCell,
 };
 
 export const ConnectionStatus = {
   title: 'Connection status',
   transforms: [wrappable],
   exportKey: 'connection_status',
-  renderFunc: renderComponent(ConnectionStatusCell),
+  Component: ConnectionStatusCell,
 };
 export default [ConnectionType, Systems, ConnectionStatus];

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -11,7 +11,7 @@ import ConfirmationDialog from '../../../components/ConfirmationDialog';
 import { actionNameFilter } from '../Filters';
 import SystemsModal from './SystemsModal/SystemsModal';
 import {
-  useTableState,
+  useFullTableState,
   TableStateProvider,
   useStateCallbacks,
   useSerialisedTableState,
@@ -23,9 +23,9 @@ import RemediationsTable from '../../../components/RemediationsTable/Remediation
 
 const ActionsContent = ({ remediationDetails, refetch, loading }) => {
   const { id } = useParams();
-  const tableState = useTableState();
+  const fullTableState = useFullTableState();
   const serialisedTableState = useSerialisedTableState();
-  const currentlySelected = tableState?.selected;
+  const currentlySelected = fullTableState?.tableState?.selected;
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isBulkDelete, setIsBulkDelete] = useState(false);
   const [action, setAction] = useState();

--- a/src/routes/RemediationDetailsComponents/ActionsContent/SystemsModal/Columns.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/SystemsModal/Columns.js
@@ -1,12 +1,11 @@
 import { wrappable } from '@patternfly/react-table';
 import { SystemNameCell } from './Cells';
-import { renderComponent } from '../../helpers';
 
 export default [
   {
     title: 'Name',
     transforms: [wrappable],
-    exportKey: 'name',
-    renderFunc: renderComponent(SystemNameCell),
+    exportKey: 'display_name',
+    Component: SystemNameCell,
   },
 ];

--- a/src/routes/RemediationDetailsComponents/ActionsContent/SystemsModal/SystemsModal.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/SystemsModal/SystemsModal.js
@@ -1,15 +1,36 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import columns from './Columns';
 import { actionsSystemFilter } from '../../Filters';
 import {
   TableStateProvider,
-  StaticTableToolsTable,
+  useSerialisedTableState,
 } from 'bastilian-tabletools';
 import TableEmptyState from '../../../OverViewPage/TableEmptyState';
+import RemediationsTable from '../../../../components/RemediationsTable/RemediationsTable';
 
 const SystemsModal = ({ systems, isOpen, onClose, actionName }) => {
+  const serialisedTableState = useSerialisedTableState();
+
+  const filteredSystems = useMemo(() => {
+    const filterState = serialisedTableState?.filters;
+    if (!filterState || Object.keys(filterState).length === 0) {
+      return systems;
+    }
+
+    const searchTerm = filterState?.filter?.display_name;
+    if (!searchTerm) {
+      return systems;
+    }
+
+    const lowerSearchTerm = searchTerm.toLowerCase();
+
+    return systems.filter((item) =>
+      item.display_name?.toLowerCase().includes(lowerSearchTerm),
+    );
+  }, [systems, serialisedTableState]);
+
   return (
     <Modal
       variant={ModalVariant.large}
@@ -19,14 +40,20 @@ const SystemsModal = ({ systems, isOpen, onClose, actionName }) => {
       isFooterLeftAligned
     >
       <b>Action:</b> {actionName}
-      <StaticTableToolsTable
+      <RemediationsTable
         aria-label="SystemsModalTable"
         ouiaId="SystemsModalTable"
         variant="compact"
-        items={systems}
+        items={filteredSystems}
+        total={filteredSystems?.length}
         columns={[...columns]}
         filters={{ filterConfig: [...actionsSystemFilter] }}
-        options={{ EmptyState: TableEmptyState }}
+        options={{
+          EmptyState: TableEmptyState,
+          itemIdsInTable: () => filteredSystems.map(({ id }) => id),
+          itemIdsOnPage: () => filteredSystems.map(({ id }) => id),
+          total: filteredSystems?.length,
+        }}
       />
     </Modal>
   );


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-18973
This is a fix for the acitons table not reloading after deleting an action.

To Test:
Go to a remediation details (with actions)
Delete an action with the bulk select OR single select,
verify the table reloads 
Also ensure filtering works as the table was migrated to tan async abletools instead of a static tabletools table

The systems modal table was also migrated, so ensure filtering works there as well

## Summary by Sourcery

Migrate actions and systems tables to the async RemediationsTable component with client-side filtering, ensure the actions table reloads after deletions by awaiting refetch, and bump bastilian-tabletools to v1.16.0

Bug Fixes:
- Reload the actions table after deleting an action by awaiting refetch and resetting selection

Enhancements:
- Replace static StaticTableToolsTable with async RemediationsTable and use useSerialisedTableState for client-side filtering of actions and systems

Build:
- Update bastilian-tabletools dependency to v1.16.0