### PR TITLE
feat(RHINENG-19424): Add sentry vars to the konflux pipeline

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -29,6 +29,16 @@ spec:
     value: build-tools/Dockerfile
   - name: path-context
     value: .
+  - name: sentry-auth-token
+    valueFrom:
+      secretKeyRef:
+        name: sentry-auth
+        key: token
+  - name: build-args
+    value:
+    - ENABLE_SENTRY=true
+    - SENTRY_AUTH_TOKEN=$(params.sentry-auth-token)
+    - SENTRY_RELEASE=$(params.revision)
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:


### PR DESCRIPTION
This should all for passing in of sentry vars to konflux

## Summary by Sourcery

Add Sentry integration to the Konflux Tekton pipeline by sourcing authentication tokens from Kubernetes secrets and passing them as build arguments during Docker builds

New Features:
- Introduce sentry-auth-token pipeline parameter sourced from a K8s secret
- Pass ENABLE_SENTRY, SENTRY_AUTH_TOKEN, and SENTRY_RELEASE as Docker build-args

CI:
- Update .tekton/remediations-frontend-push.yaml to include Sentry-related parameters in the pipeline spec