### PR TITLE
chore(konflux): Update konflux pipeline ref

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.26.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/aa27921/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-remediations


### PR DESCRIPTION
This allows me to use the latest changes in the konflux pipeline that allow for sentry args to be passed in and allow of testing sourcemap uploads 