### PR TITLE
fix(sentry): Update sentry-auth-token value

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -30,10 +30,7 @@ spec:
   - name: path-context
     value: .
   - name: sentry-auth-token
-    valueFrom:
-      secretKeyRef:
-        name: sentry-auth
-        key: token
+    value: sentry-auth
   - name: build-args
     value:
     - ENABLE_SENTRY=true


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Set the sentry-auth-token environment variable directly instead of using a secretKeyRef in the Tekton pipeline