### PR TITLE
chore(sentry): Update workspace konflux variables

### DIFF
--- a/.tekton/remediations-frontend-pull-request.yaml
+++ b/.tekton/remediations-frontend-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.31.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/aa27921/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-remediations
@@ -32,6 +32,12 @@ spec:
     value: build-tools/Dockerfile
   - name: path-context
     value: .
+  - name: SENTRY_AUTH_TOKEN
+    value: '{{ sentry_auth }}'
+  - name: SENTRY_RELEASE
+    value: '{{ revision }}'
+  - name: ENABLE_SENTRY
+    value: 'true'
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:
@@ -40,4 +46,7 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: sentry-auth
+    secret:
+      secretName: '{{ sentry_auth }}'
 status: {}

--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -9,7 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.31.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/adonispuente/konflux-pipelines/raw/v1.31.0/pipelines/docker-build-oci-ta.yaml
+  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-remediations
     appstudio.openshift.io/component: remediations-frontend


### PR DESCRIPTION
Trying to pass in konflux UI secret into the pipeline

## Summary by Sourcery

Update the Tekton pipeline configuration to use a custom konflux-pipelines source and include a new Sentry authentication secret.

CI:
- Change the Tekton pipeline definition URL to use a custom konflux-pipelines fork
- Add a static creationTimestamp field to the pipeline metadata
- Introduce a sentry-auth workspace secret for injecting the Sentry UI secret into the pipeline