### PR TITLE
fix(konflux): Update sentry konflux var

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: path-context
     value: .
   - name: sentry-auth-token
-    value: "{{ secrets.sentry-auth.token }}"
+    value: '{{ index secrets "sentry-auth" "token" }}'
   - name: build-args
     value:
     - ENABLE_SENTRY=true


### PR DESCRIPTION
the pipeline isnt reading the token

## Summary by Sourcery

Bug Fixes:
- Fix sentry-auth-token environment variable to use '{{ index secrets "sentry-auth" "token" }}' instead of the unsupported dot notation