### PR TITLE
fix(viewLog): Correctly migrate viewLog cell

### DIFF
--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.js
@@ -90,7 +90,7 @@ const RunTabContent = ({
             title: '',
             props: { screenReaderText: 'View log' },
             exportKey: 'viewLog',
-            renderFunc: (_d, _i, system) => (
+            Component: (system) => (
               <Button
                 variant="link"
                 style={{ padding: 0 }}

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.test.js
@@ -37,9 +37,7 @@ jest.mock('./RunSystemsTable', () => {
       {viewLogColumn && (
         <button
           data-testid="view-log-button"
-          onClick={() =>
-            viewLogColumn.renderFunc(null, null, { id: 'test-system' })
-          }
+          onClick={() => viewLogColumn.Component({ id: 'test-system' })}
         >
           {viewLogColumn.title || 'View log'}
         </button>


### PR DESCRIPTION
The viewLog cell isnt rendered properly in prod

## Summary by Sourcery

Bug Fixes:
- Migrate viewLog column to use Component prop instead of deprecated renderFunc to restore proper rendering in production