### PR TITLE
feat(RHINENG-19699): Change app's naming on ZeroState page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -53,7 +53,7 @@ const RemediationRoutes = () => {
       module="./AppZeroState"
       scope="dashboard"
       ErrorComponent={<ErrorState />}
-      app="Remediations"
+      app="Remediation_plans"
       appId="remediation_zero_state"
       customFetchResults={hasSystems}
     >

--- a/src/Routes.test.js
+++ b/src/Routes.test.js
@@ -190,7 +190,7 @@ describe('Routes', () => {
             appName: 'dashboard',
             module: './AppZeroState',
             scope: 'dashboard',
-            app: 'Remediations',
+            app: 'Remediation_plans',
             appId: 'remediation_zero_state',
             customFetchResults: expect.any(Boolean),
           }),


### PR DESCRIPTION
# Description
Change application name from Remediations to Remediation plans on ZeroState page (page that displays when user has 0 systems).

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-19699
PR on dashboard side: https://github.com/RedHatInsights/insights-dashboard/pull/640


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Rename the application label on the ZeroState page to "Remediation_plans" and update related tests, including adjusting the future date display expectation in the created timestamp cell.

Enhancements:
- Rename ZeroState page application label from "Remediations" to "Remediation_plans"

Tests:
- Update Routes.test to expect the new app naming in the ZeroState route
- Adjust Cells.test to expect the correct future date rollover display