### PR TITLE
feat(RHINENG-19641): Add rerouting and No permissions page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import { getIsReceptorConfigured } from './api';
 
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
 import { Spinner } from '@patternfly/react-core';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 
 export const PermissionContext = createContext();
 
@@ -51,23 +52,18 @@ const App = () => {
               (permissions) => permissions.permission,
             );
             if (
-              permissionList.includes(
-                'remediations:*:*' || 'remediations:remediation:*',
-              )
+              permissionList.includes('remediations:*:*') ||
+              permissionList.includes('remediations:remediation:*')
             ) {
               handlePermissionUpdate(true, true, true);
             } else {
               handlePermissionUpdate(
-                permissionList.includes(
-                  'remediations:remediation:read' || 'remediations:*:read',
-                ),
-                permissionList.includes(
-                  'remediations:remediation:write' || 'remediations:*:write',
-                ),
-                permissionList.includes(
-                  'remediations:remediation:execute' ||
-                    'remediations:*:execute',
-                ),
+                permissionList.includes('remediations:remediation:read') ||
+                  permissionList.includes('remediations:*:read'),
+                permissionList.includes('remediations:remediation:write') ||
+                  permissionList.includes('remediations:*:write'),
+                permissionList.includes('remediations:remediation:execute') ||
+                  permissionList.includes('remediations:*:execute'),
               );
             }
           })
@@ -80,21 +76,26 @@ const App = () => {
     }
   }, []);
 
+  const hasRequiredPermissions = readPermission || writePermission;
   return arePermissionLoaded ? (
-    <NotificationsProvider>
-      <PermissionContext.Provider
-        value={{
-          permissions: {
-            read: readPermission,
-            write: writePermission,
-            execute: executePermission,
-          },
-          isReceptorConfigured,
-        }}
-      >
-        <Routes />
-      </PermissionContext.Provider>
-    </NotificationsProvider>
+    hasRequiredPermissions ? (
+      <NotificationsProvider>
+        <PermissionContext.Provider
+          value={{
+            permissions: {
+              read: readPermission,
+              write: writePermission,
+              execute: executePermission,
+            },
+            isReceptorConfigured,
+          }}
+        >
+          <Routes />
+        </PermissionContext.Provider>
+      </NotificationsProvider>
+    ) : (
+      <NotAuthorized serviceName="Remediation Plans" />
+    )
   ) : (
     <Spinner />
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -30,6 +30,10 @@ jest.mock(
   },
 );
 
+jest.mock('@redhat-cloud-services/frontend-components/NotAuthorized', () => ({
+  NotAuthorized: () => <div data-testid="not-authorized">Not Authorized</div>,
+}));
+
 const mockStore = createStore(() => ({}));
 
 describe('App Component', () => {
@@ -151,8 +155,10 @@ describe('App Component', () => {
       renderApp();
 
       await waitFor(() => {
-        expect(screen.getByTestId('routes')).toBeInTheDocument();
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
       });
+
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
 
     it('should handle multiple specific permissions', async () => {
@@ -201,8 +207,10 @@ describe('App Component', () => {
       renderApp();
 
       await waitFor(() => {
-        expect(screen.getByTestId('routes')).toBeInTheDocument();
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
       });
+
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
 
     it('should handle no permissions', async () => {
@@ -211,8 +219,10 @@ describe('App Component', () => {
       renderApp();
 
       await waitFor(() => {
-        expect(screen.getByTestId('routes')).toBeInTheDocument();
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
       });
+
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
 
     it('should handle different permission formats', async () => {
@@ -223,8 +233,10 @@ describe('App Component', () => {
       renderApp();
 
       await waitFor(() => {
-        expect(screen.getByTestId('routes')).toBeInTheDocument();
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
       });
+
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
     });
 
     it('should handle getUserPermissions error', async () => {
@@ -243,6 +255,79 @@ describe('App Component', () => {
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Authorization Handling', () => {
+    it('should show NotAuthorized when user has only execute permissions', async () => {
+      mockChrome.getUserPermissions.mockResolvedValue([
+        { permission: 'remediations:remediation:execute' },
+      ]);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Not Authorized')).toBeInTheDocument();
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
+    });
+
+    it('should show NotAuthorized when user has no permissions', async () => {
+      mockChrome.getUserPermissions.mockResolvedValue([]);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('not-authorized')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Not Authorized')).toBeInTheDocument();
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
+    });
+
+    it('should show Routes when user has read permission', async () => {
+      mockChrome.getUserPermissions.mockResolvedValue([
+        { permission: 'remediations:*:read' },
+      ]);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('routes')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('not-authorized')).not.toBeInTheDocument();
+    });
+
+    it('should show Routes when user has write permission', async () => {
+      mockChrome.getUserPermissions.mockResolvedValue([
+        { permission: 'remediations:*:write' },
+      ]);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('routes')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('not-authorized')).not.toBeInTheDocument();
+    });
+
+    it('should show Routes when user has both read and write permissions', async () => {
+      mockChrome.getUserPermissions.mockResolvedValue([
+        { permission: 'remediations:remediation:read' },
+        { permission: 'remediations:remediation:write' },
+      ]);
+
+      renderApp();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('routes')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('not-authorized')).not.toBeInTheDocument();
     });
   });
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense, useEffect, useState } from 'react';
 import axios from 'axios';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { Spinner } from '@patternfly/react-core';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
@@ -64,6 +64,7 @@ const RemediationRoutes = () => {
               <Route key={key} path={path} element={<Component />} />
             ),
           )}
+          <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       </Suspense>
     </AsyncComponent>

--- a/src/components/NoRemediationsPage.js
+++ b/src/components/NoRemediationsPage.js
@@ -5,8 +5,6 @@ import {
   EmptyStateBody,
   EmptyStateVariant,
   Button,
-  PageSection,
-  Page,
   EmptyStateActions,
   EmptyStateFooter,
 } from '@patternfly/react-core';
@@ -17,38 +15,32 @@ export const NoRemediationsPage = () => {
   const { quickStarts } = useChrome();
 
   return (
-    <Page>
-      <PageSection hasBodyWrapper={false} isFilled>
-        <EmptyState
-          headingLevel="h5"
-          icon={CubesIcon}
-          titleText={<>No remediation plans</>}
-          variant={EmptyStateVariant.full}
-        >
-          <EmptyStateBody>
-            Create remediation plans to address Advisor recommendations,
-            Security CVEs, and
-            <br />
-            Content advisories on your Red Hat Enterprise Linux (RHEL)
-            infrastructure.
-          </EmptyStateBody>
-          <EmptyStateFooter>
-            <EmptyStateActions>
-              <Button
-                icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
-                onClick={() =>
-                  quickStarts?.activateQuickstart(
-                    'insights-remediate-plan-create',
-                  )
-                }
-              >
-                Launch Quick Start{' '}
-              </Button>
-            </EmptyStateActions>
-          </EmptyStateFooter>
-        </EmptyState>
-      </PageSection>
-    </Page>
+    <EmptyState
+      headingLevel="h5"
+      icon={CubesIcon}
+      titleText={<>No remediation plans</>}
+      variant={EmptyStateVariant.full}
+    >
+      <EmptyStateBody>
+        Create remediation plans to address Advisor recommendations, Security
+        CVEs, and
+        <br />
+        Content advisories on your Red Hat Enterprise Linux (RHEL)
+        infrastructure.
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button
+            icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
+            onClick={() =>
+              quickStarts?.activateQuickstart('insights-remediate-plan-create')
+            }
+          >
+            Launch Quick Start{' '}
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
   );
 };
 

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import useRemediationsQuery from '../api/useRemediationsQuery';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import DetailsGeneralContent from './RemediationDetailsComponents/DetailsGeneralContent';
@@ -24,6 +24,7 @@ import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/fronten
 const RemediationDetails = () => {
   const chrome = useChrome();
   const { id } = useParams();
+  const navigate = useNavigate();
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const { isFedramp } = chrome;
@@ -40,6 +41,7 @@ const RemediationDetails = () => {
     result: remediationDetails,
     refetch: refetchRemediationDetails,
     loading: detailsLoading,
+    error: remediationDetailsError,
   } = useRemediationsQuery(getRemediationDetails, {
     params: { remId: id },
   });
@@ -65,6 +67,20 @@ const RemediationDetails = () => {
         `${remediationDetails.name} - Remediation Plans - Automation`,
       );
   }, [chrome, remediationDetails]);
+
+  useEffect(() => {
+    if (remediationDetailsError) {
+      const isNotFound =
+        remediationDetailsError?.status === 404 ||
+        remediationDetailsError?.status === 400;
+      remediationDetailsError?.errors?.[0]?.status === 404 ||
+        remediationDetailsError?.errors?.[0]?.status === 400;
+
+      if (isNotFound) {
+        navigate('/insights/remediations');
+      }
+    }
+  }, [remediationDetailsError, navigate]);
 
   const [
     connectedSystems,

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import useRemediationsQuery from '../api/useRemediationsQuery';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import DetailsGeneralContent from './RemediationDetailsComponents/DetailsGeneralContent';
@@ -12,6 +12,7 @@ import ActionsContent from './RemediationDetailsComponents/ActionsContent/Action
 // import SystemsContent from './RemediationDetailsComponents/SystemsContent/SystemsContent';
 import SystemsTable from '../components/SystemsTable/SystemsTable';
 import ExecutionHistoryTab from './RemediationDetailsComponents/ExecutionHistoryContent/ExecutionHistoryContent';
+import PlanNotFound from './RemediationDetailsComponents/PlanNotFound';
 import {
   checkExecutableStatus,
   getRemediationDetails,
@@ -24,9 +25,10 @@ import { useAxiosWithPlatformInterceptors } from '@redhat-cloud-services/fronten
 const RemediationDetails = () => {
   const chrome = useChrome();
   const { id } = useParams();
-  const navigate = useNavigate();
+
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [showPlanNotFound, setShowPlanNotFound] = useState(false);
   const { isFedramp } = chrome;
   const context = useContext(PermissionContext);
   const axios = useAxiosWithPlatformInterceptors();
@@ -72,15 +74,15 @@ const RemediationDetails = () => {
     if (remediationDetailsError) {
       const isNotFound =
         remediationDetailsError?.status === 404 ||
-        remediationDetailsError?.status === 400;
-      remediationDetailsError?.errors?.[0]?.status === 404 ||
+        remediationDetailsError?.status === 400 ||
+        remediationDetailsError?.errors?.[0]?.status === 404 ||
         remediationDetailsError?.errors?.[0]?.status === 400;
 
       if (isNotFound) {
-        navigate('/insights/remediations');
+        setShowPlanNotFound(true);
       }
     }
-  }, [remediationDetailsError, navigate]);
+  }, [remediationDetailsError]);
 
   const [
     connectedSystems,
@@ -105,6 +107,11 @@ const RemediationDetails = () => {
     });
 
   const getIsExecutable = (item) => String(item).trim().toUpperCase() === 'OK';
+
+  if (showPlanNotFound) {
+    return <PlanNotFound planId={id} />;
+  }
+
   return (
     remediationDetails && (
       <>

--- a/src/routes/RemediationDetails.test.js
+++ b/src/routes/RemediationDetails.test.js
@@ -15,6 +15,7 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({ id: '123' }),
   useSearchParams: () => [new URLSearchParams(), jest.fn()],
+  useNavigate: () => jest.fn(),
 }));
 
 import RemediationDetails from './RemediationDetails';

--- a/src/routes/RemediationDetailsComponents/PlanNotFound.js
+++ b/src/routes/RemediationDetailsComponents/PlanNotFound.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  EmptyStateFooter,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+import useInsightsNavigate from '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate';
+
+/**
+ * Empty state when Plan was not found in users account.
+ *  @param   {object}        props        - Component props
+ *  @param   {string}        props.planId - The ID of the plan that was not found
+ *  @returns {React.Element}              PlanNotFound component
+ */
+const PlanNotFound = ({ planId }) => {
+  const navigate = useInsightsNavigate();
+  return (
+    <EmptyState
+      headingLevel="h5"
+      icon={CubesIcon}
+      titleText="Remediation Plan not found"
+      variant={EmptyStateVariant.full}
+    >
+      <EmptyStateBody>
+        Remediation Plan with ID {planId} does not exist
+      </EmptyStateBody>
+      <EmptyStateFooter>
+        <Button
+          variant="primary"
+          onClick={() => navigate('/insights/remediations')}
+        >
+          Back to all remediation plans
+        </Button>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+};
+
+PlanNotFound.propTypes = {
+  planId: PropTypes.string.isRequired,
+};
+
+export default PlanNotFound;

--- a/src/routes/RemediationDetailsComponents/PlanNotFound.test.js
+++ b/src/routes/RemediationDetailsComponents/PlanNotFound.test.js
@@ -1,0 +1,224 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlanNotFound from './PlanNotFound';
+
+jest.mock('@patternfly/react-core', () => ({
+  Button: function MockButton({ children, variant, onClick, ...props }) {
+    return (
+      <button
+        data-testid="button"
+        data-variant={variant}
+        onClick={onClick}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+  EmptyState: function MockEmptyState({
+    headingLevel,
+    icon: Icon,
+    titleText,
+    variant,
+    children,
+    ...props
+  }) {
+    return (
+      <div
+        data-testid="empty-state"
+        data-heading-level={headingLevel}
+        data-title-text={titleText}
+        data-variant={variant}
+        {...props}
+      >
+        {Icon && <Icon data-testid="empty-state-icon" />}
+        <div data-testid="empty-state-title">{titleText}</div>
+        {children}
+      </div>
+    );
+  },
+  EmptyStateBody: function MockEmptyStateBody({ children, ...props }) {
+    return (
+      <div data-testid="empty-state-body" {...props}>
+        {children}
+      </div>
+    );
+  },
+  EmptyStateFooter: function MockEmptyStateFooter({ children, ...props }) {
+    return (
+      <div data-testid="empty-state-footer" {...props}>
+        {children}
+      </div>
+    );
+  },
+  EmptyStateVariant: {
+    full: 'full',
+    small: 'small',
+    large: 'large',
+  },
+}));
+
+jest.mock('@patternfly/react-icons', () => ({
+  CubesIcon: function MockCubesIcon(props) {
+    return <div data-testid="cubes-icon" {...props} />;
+  },
+}));
+
+const mockNavigate = jest.fn();
+jest.mock(
+  '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate',
+  () => {
+    return jest.fn(() => mockNavigate);
+  },
+);
+
+describe('PlanNotFound', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic rendering', () => {
+    it('should render empty state with correct structure', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+      expect(screen.getByTestId('empty-state-body')).toBeInTheDocument();
+      expect(screen.getByTestId('empty-state-footer')).toBeInTheDocument();
+    });
+
+    it('should display correct title text', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-title')).toHaveTextContent(
+        'Remediation Plan not found',
+      );
+    });
+
+    it('should display the plan ID in the body text', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        `Remediation Plan with ID ${planId} does not exist`,
+      );
+    });
+
+    it('should render CubesIcon', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-icon')).toBeInTheDocument();
+    });
+
+    it('should render back button with correct text', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      const button = screen.getByTestId('button');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent('Back to all remediation plans');
+      expect(button).toHaveAttribute('data-variant', 'primary');
+    });
+
+    it('should set correct empty state attributes', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      const emptyState = screen.getByTestId('empty-state');
+      expect(emptyState).toHaveAttribute('data-heading-level', 'h5');
+      expect(emptyState).toHaveAttribute('data-variant', 'full');
+    });
+  });
+
+  describe('Navigation functionality', () => {
+    it('should call navigate with correct path when back button is clicked', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      const button = screen.getByTestId('button');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/insights/remediations');
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Props handling', () => {
+    it('should handle normal plan ID', () => {
+      const planId = 'remediation-plan-456';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        `Remediation Plan with ID ${planId} does not exist`,
+      );
+    });
+
+    it('should handle empty plan ID', () => {
+      const planId = '';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        'Remediation Plan with ID does not exist',
+      );
+    });
+
+    it('should handle very long plan ID', () => {
+      const planId = 'a'.repeat(1000);
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        `Remediation Plan with ID ${planId} does not exist`,
+      );
+    });
+
+    it('should handle unicode characters in plan ID', () => {
+      const planId = '测试-🚀-Тест-עברית-العربية';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        `Remediation Plan with ID ${planId} does not exist`,
+      );
+    });
+  });
+
+  describe('Edge cases and error handling', () => {
+    it('should handle null planId gracefully', () => {
+      render(<PlanNotFound planId={null} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        'Remediation Plan with ID does not exist',
+      );
+    });
+
+    it('should handle undefined planId gracefully', () => {
+      render(<PlanNotFound planId={undefined} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        'Remediation Plan with ID does not exist',
+      );
+    });
+
+    it('should handle plan ID with only whitespace', () => {
+      const planId = '   ';
+      render(<PlanNotFound planId={planId} />);
+
+      expect(screen.getByTestId('empty-state-body')).toHaveTextContent(
+        'Remediation Plan with ID does not exist',
+      );
+    });
+
+    it('should handle navigation function calls', () => {
+      const planId = 'test-plan-123';
+      render(<PlanNotFound planId={planId} />);
+
+      const button = screen.getByTestId('button');
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/insights/remediations');
+    });
+  });
+});


### PR DESCRIPTION
This adds a 404 page for when an remediation ID results in a 404 on the details page (bookmarked a deleted plan)
<img width="815" height="466" alt="Screenshot 2025-09-02 at 12 07 12 PM" src="https://github.com/user-attachments/assets/33046062-b63d-4a1e-b154-59d9886a446b" />

Adds a no permissions page 
fixes the styling in PF6 No remediations page as well as updates the endpoint used to determine if the user has remediations or not. 

For testing reroute: you can use insights-qa 
Navigate to the details page of any remediation and then alter the id in the url to mimic a deleted plan, and see you are rerouted to the home page 

For testing **NoRemediations**: policies-noaccess-user-1 - with this user you can test a user with no remediations WITH permissions that can see the updated NoRemediationsPLans page styling (Note: This page is scoped by the orgs remediations, no if a user has remediations).
<img width="1097" height="722" alt="Screenshot 2025-08-26 at 11 13 52 AM" src="https://github.com/user-attachments/assets/e215a430-8de7-43a5-8d7f-e3632f0a522e" />

For the no access, if you cant alter/create a user, you can navigate to hasRequiredPermissions in App.js and locally change it to false
<img width="1091" height="709" alt="Screenshot 2025-08-26 at 11 14 33 AM" src="https://github.com/user-attachments/assets/60f52c40-d489-4cd5-b8a3-ac609498dab3" />

