### PR TITLE
fix(RHINENG-19750): Created Filter chip fix

### DIFF
--- a/src/routes/OverViewPage/CalendarFilterType.js
+++ b/src/routes/OverViewPage/CalendarFilterType.js
@@ -3,11 +3,11 @@ import CalendarFilter from '../CalendarFilter';
 export const CalendarFilterType = {
   Component: CalendarFilter,
   chips: (value = []) => {
-    return value.length ? [value[0].slice(0, 10)] : [];
+    return value.length && value[0]?.trim() ? [value[0].slice(0, 10)] : [];
   },
 
   selectValue: (selectedValue) => {
-    return [[selectedValue], true];
+    return selectedValue?.trim() ? [[selectedValue], true] : [undefined, true];
   },
   deselectValue: () => [undefined, true],
 };

--- a/src/routes/OverViewPage/CalendarFilterType.test.js
+++ b/src/routes/OverViewPage/CalendarFilterType.test.js
@@ -21,6 +21,12 @@ describe('CalendarFilterType', () => {
     it('returns empty array when value is undefined', () => {
       expect(CalendarFilterType.chips(undefined)).toEqual([]);
     });
+    it('returns empty array when value is empty string', () => {
+      expect(CalendarFilterType.chips([''])).toEqual([]);
+    });
+    it('returns empty array when value is whitespace only', () => {
+      expect(CalendarFilterType.chips(['   '])).toEqual([]);
+    });
   });
 
   describe('selectValue', () => {
@@ -30,8 +36,11 @@ describe('CalendarFilterType', () => {
         true,
       ]);
     });
-    it('works with empty string', () => {
-      expect(CalendarFilterType.selectValue('')).toEqual([[''], true]);
+    it('treats empty string as deselected', () => {
+      expect(CalendarFilterType.selectValue('')).toEqual([undefined, true]);
+    });
+    it('treats whitespace-only string as deselected', () => {
+      expect(CalendarFilterType.selectValue('   ')).toEqual([undefined, true]);
     });
   });
 

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -49,7 +49,7 @@ export const OverViewPage = () => {
   const callbacks = useStateCallbacks();
   const tableState = useRawTableState();
 
-  const currentlySelected = tableState?.selected;
+  const currentlySelected = tableState?.selected || [];
   const {
     result,
     fetchAllIds,


### PR DESCRIPTION
Theres an issue with the created filter chip where one you delete an input via backspace, the filterchip would still be present but with an empty value. This aims to resolve that as well as updates the test.

## Summary by Sourcery

Fix filter chip behavior to ignore empty or whitespace-only inputs, update selection logic accordingly, and ensure selected state defaults to an empty array while adding related unit tests.

Bug Fixes:
- Ignore empty or whitespace-only values in CalendarFilterType.chips to prevent empty filter chips
- Treat empty or whitespace-only input in CalendarFilterType.selectValue as deselection
- Default tableState.selected to an empty array in OverViewPage to avoid undefined

Tests:
- Add tests for CalendarFilterType.chips() and selectValue() handling of empty and whitespace-only strings