### PR TITLE
fix(RHINENG-20628): Fix TypeError in Created filter

### DIFF
--- a/src/routes/OverViewPage/CalendarFilterType.js
+++ b/src/routes/OverViewPage/CalendarFilterType.js
@@ -7,7 +7,7 @@ export const CalendarFilterType = {
   },
 
   selectValue: (selectedValue) => {
-    return selectedValue?.trim() ? [[selectedValue], true] : [undefined, true];
+    return selectedValue?.trim() ? [selectedValue] : [];
   },
-  deselectValue: () => [undefined, true],
+  deselectValue: () => [],
 };

--- a/src/routes/OverViewPage/CalendarFilterType.test.js
+++ b/src/routes/OverViewPage/CalendarFilterType.test.js
@@ -30,23 +30,22 @@ describe('CalendarFilterType', () => {
   });
 
   describe('selectValue', () => {
-    it('returns array with selected value and true', () => {
+    it('returns array with selected value', () => {
       expect(CalendarFilterType.selectValue('2024-07-01')).toEqual([
-        ['2024-07-01'],
-        true,
+        '2024-07-01',
       ]);
     });
     it('treats empty string as deselected', () => {
-      expect(CalendarFilterType.selectValue('')).toEqual([undefined, true]);
+      expect(CalendarFilterType.selectValue('')).toEqual([]);
     });
     it('treats whitespace-only string as deselected', () => {
-      expect(CalendarFilterType.selectValue('   ')).toEqual([undefined, true]);
+      expect(CalendarFilterType.selectValue('   ')).toEqual([]);
     });
   });
 
   describe('deselectValue', () => {
-    it('returns [undefined, true]', () => {
-      expect(CalendarFilterType.deselectValue()).toEqual([undefined, true]);
+    it('returns empty array []', () => {
+      expect(CalendarFilterType.deselectValue()).toEqual([]);
     });
   });
 


### PR DESCRIPTION
# Description

Associated Jira ticket: RHINENG-20628

CalendarFilterType drops wrapping selected value to additional array and appending boolean into the array, since it seems to be redundant.

# How to test the PR

Filter by Created on Remediation plans page.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Fix return types in CalendarFilterType to prevent TypeError in the Created filter

Bug Fixes:
- Change selectValue to return [selectedValue, true] or undefined instead of nested arrays
- Update deselectValue to return undefined instead of [undefined, true]

## Summary by Sourcery

Fix CalendarFilterType return values to eliminate nested arrays and booleans and prevent TypeError in the Created filter

Bug Fixes:
- Adjust CalendarFilterType.selectValue to return [selectedValue] or [] instead of nested arrays and boolean flags
- Change CalendarFilterType.deselectValue to return [] instead of [undefined, true]

Tests:
- Update CalendarFilterType tests to reflect new return values for selectValue and deselectValue