### PR TITLE
feat(RHINENG-16778): Remove unneccesary fetch from wizard

### DIFF
--- a/src/modules/RemediationsModal/steps/selectPlaybook.js
+++ b/src/modules/RemediationsModal/steps/selectPlaybook.js
@@ -6,7 +6,6 @@ import {
   Skeleton,
   SkeletonSize,
 } from '@redhat-cloud-services/frontend-components/Skeleton';
-import * as api from '../../../api';
 import { Fragment } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import FetchError from './fetchError';
@@ -43,8 +42,8 @@ const SelectPlaybook = (props) => {
   const formOptions = useFormApi();
   const values = formOptions.getState().values;
   const [isDisabled, setIsDisabled] = useState(false);
-
-  const [existingRemediations, setExistingRemediations] = useState();
+  const existingRemediations = remediationsList;
+  // const [existingRemediations, setExistingRemediations] = useState();
   const [existingPlaybookSelected, setExistingPlaybookSelected] = useState(
     values[EXISTING_PLAYBOOK_SELECTED],
   );
@@ -71,15 +70,6 @@ const SelectPlaybook = (props) => {
   const isLoading = useSelector(
     ({ resolutionsReducer }) => resolutionsReducer?.isLoading,
   );
-
-  useEffect(() => {
-    async function fetchData() {
-      const { data: existingRemediations } = await api.getRemediations();
-      setExistingRemediations(existingRemediations);
-    }
-
-    fetchData();
-  }, []);
 
   useEffect(() => {
     if (differenceWith(resolutions, values[RESOLUTIONS], isEqual)?.length > 0) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-16778
For some reason theres some old code that fetches a list of all remediation+ their details when you open the wizard, and the list in the wizard is in loading state till that happens. However we dont need the details for plan create, we just need the list of current plans. 

This PR removes that fetch, and replaces it with an existing remediationsList that is already called (only grabs names) on modal open. Ive also removed the test that ensure the api request is called, though i was unsure what to replace it with. 

For testing, simply create remediation plans in different apps. Advisor,vulnerability,compliance -> make sure there arent any issues in plan create wether its a new plan or existing plan

## Summary by Sourcery

Remove unnecessary fetch of remediation details in the plan creation wizard by using the already fetched remediationsList and clean up related code and tests.

Enhancements:
- Reuse existing remediationsList instead of fetching detailed remediation data on wizard open
- Remove redundant API call and associated state management in SelectPlaybook component

Tests:
- Remove test that checked getRemediation API call on playbook selection