### PR TITLE
fix(RHINENG-19424): Add sentry args to push.yml

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -32,6 +32,13 @@ spec:
   - name: build-args
     value:
     - ENABLE_SENTRY=true
+    - SENTRY_RELEASE={{revision}}
+    - SENTRY_AUTH_TOKEN=$(params.sentry-auth-token)
+  - name: sentry-auth-token
+    valueFrom:
+        secretKeyRef:
+          name: sentry-auth
+          key: remediations
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include SENTRY_RELEASE and SENTRY_AUTH_TOKEN build arguments in .tekton/remediations-frontend-push.yaml