### PR TITLE
chore(sentry): Temporarily update tekton pointer

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.39.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/1247166/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-remediations


### PR DESCRIPTION
This is for testing the new sentry pipeline

## Summary by Sourcery

CI:
- Update Tekton pipeline URL to use commit 1247166 instead of v1.39.0 for Sentry pipeline testing