### PR TITLE
fix(RHINENG-21118):Update konflux-pipelines to v1.45.0

### DIFF
--- a/.tekton/remediations-frontend-push.yaml
+++ b/.tekton/remediations-frontend-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/1247166/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.45.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-remediations


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-21118](https://issues.redhat.com/browse/RHINENG-21118)

Update of [node.js in Dockerifle](https://github.com/RedHatInsights/insights-remediations-frontend/pull/642) caused failure in on-push konflux pipeline -> pipeline uses v1.43.0 konflux-pipelines which uses old buildah version that doesn't have signings for this node.js version. According to [previous PR](https://github.com/RedHatInsights/insights-remediations-frontend/pull/637), the current v1.43.0 version is being used temporarily, for testing new sentry pipeline. 

Therefore I would like to **wait for** @adonispuente approval once he is back from PTO before merging.

Possible workaround if release needs to be done sooner - revert version of node.js in the Dockerfile.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Bug Fixes:
- Reference konflux-pipelines v1.45.0 in .tekton/remediations-frontend-push.yaml to resolve pipeline failures caused by the outdated buildah version in v1.43.0.