### PR TITLE
fix(RHINENG-25230): pagination for exechistory tables

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import React, { createContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { connect } from 'react-redux';
+import Routes from './Routes';
+
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
 import { Spinner } from '@patternfly/react-core';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAut
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 
-import Routes from './Routes';
 import { useFeatureFlag } from './Utilities/Hooks/useFeatureFlag';
 import { useKesselRemediationPermissionState } from './Utilities/Hooks/useKesselRemediationPermissionState';
 import { getChromePerms } from './Utilities/remediationsPermissions';

--- a/src/Utilities/utils.test.js
+++ b/src/Utilities/utils.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /* eslint-disable no-unused-vars */
 import React from 'react';
 import '@testing-library/jest-dom';

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -46,12 +46,6 @@ export const downloadPlaybook = async (selectedIds) => {
   }
 };
 
-export function getIsReceptorConfigured() {
-  return doGet(
-    `${window.location.origin}/api/sources/v2.0/endpoints?filter[receptor_node][not_nil]`,
-  );
-}
-
 export function deleteSystemsFromRemediation(systems, remediation) {
   const systemIds = systems.map((system) => system.id);
   return remediationsApi.deleteRemediationSystems(remediation.id, {

--- a/src/api/index.test.js
+++ b/src/api/index.test.js
@@ -5,10 +5,6 @@ jest.mock('../Utilities/http', () => ({
   doGet: jest.fn(),
 }));
 
-jest.mock('../routes/api', () => ({
-  API_BASE: '/api/remediations/v1',
-}));
-
 jest.mock('../Utilities/helpers.js', () => ({
   downloadFile: jest.fn(),
 }));
@@ -176,49 +172,6 @@ describe('API Module', () => {
 
       await expect(apiModule.downloadPlaybook(selectedIds)).rejects.toThrow(
         'Playbook fetch failed',
-      );
-    });
-  });
-
-  describe('getIsReceptorConfigured', () => {
-    it('should call doGet with correct sources endpoint', () => {
-      doGet.mockResolvedValue({ data: 'receptor-status' });
-
-      apiModule.getIsReceptorConfigured();
-
-      expect(doGet).toHaveBeenCalledWith(
-        'http://localhost/api/sources/v2.0/endpoints?filter[receptor_node][not_nil]',
-      );
-    });
-
-    it('should return the result from doGet', async () => {
-      const mockReceptorStatus = { data: { configured: true } };
-      doGet.mockResolvedValue(mockReceptorStatus);
-
-      const result = await apiModule.getIsReceptorConfigured();
-
-      expect(result).toEqual(mockReceptorStatus);
-    });
-
-    it('should handle errors from doGet', async () => {
-      const error = new Error('Receptor check failed');
-      doGet.mockRejectedValue(error);
-
-      await expect(apiModule.getIsReceptorConfigured()).rejects.toThrow(
-        'Receptor check failed',
-      );
-    });
-
-    it('should use window.location.origin in endpoint URL', () => {
-      doGet.mockResolvedValue({ data: 'test' });
-
-      apiModule.getIsReceptorConfigured();
-
-      // Just verify doGet was called with a sources endpoint
-      expect(doGet).toHaveBeenCalledWith(
-        expect.stringContaining(
-          '/api/sources/v2.0/endpoints?filter[receptor_node][not_nil]',
-        ),
       );
     });
   });

--- a/src/components/Modals/__tests__/ExecuteModal.test.js
+++ b/src/components/Modals/__tests__/ExecuteModal.test.js
@@ -383,10 +383,7 @@ describe('ExecuteModal', () => {
       };
 
       render(
-        <ExecuteModal
-          {...defaultProps}
-          remediationStatus={undefinedStatus}
-        />,
+        <ExecuteModal {...defaultProps} remediationStatus={undefinedStatus} />,
       );
 
       expect(

--- a/src/components/RemediationWizard.test.js
+++ b/src/components/RemediationWizard.test.js
@@ -64,7 +64,6 @@ jest.mock('../api', () => ({
   sourcesApi: {},
   getHosts: jest.fn(),
   downloadPlaybook: jest.fn(),
-  getIsReceptorConfigured: jest.fn(),
   deleteSystemsFromRemediation: jest.fn(),
   createRemediation: jest.fn(),
   patchRemediation: jest.fn(),
@@ -429,10 +428,7 @@ describe('RemediationWizard', () => {
       };
 
       renderWithRouter(
-        <RemediationWizard
-          setOpen={mockSetOpen}
-          data={dataExceedingSystems}
-        />,
+        <RemediationWizard setOpen={mockSetOpen} data={dataExceedingSystems} />,
       );
 
       expect(
@@ -453,10 +449,7 @@ describe('RemediationWizard', () => {
       };
 
       renderWithRouter(
-        <RemediationWizard
-          setOpen={mockSetOpen}
-          data={dataExceedingActions}
-        />,
+        <RemediationWizard setOpen={mockSetOpen} data={dataExceedingActions} />,
       );
 
       expect(
@@ -485,10 +478,7 @@ describe('RemediationWizard', () => {
       };
 
       renderWithRouter(
-        <RemediationWizard
-          setOpen={mockSetOpen}
-          data={dataExceedingSystems}
-        />,
+        <RemediationWizard setOpen={mockSetOpen} data={dataExceedingSystems} />,
       );
 
       const alerts = screen.getAllByText(/Remediation plan exceeds limits/i);
@@ -1334,9 +1324,7 @@ describe('RemediationWizard', () => {
 
   describe('Edge cases', () => {
     it('should handle null data gracefully', () => {
-      renderWithRouter(
-        <RemediationWizard setOpen={mockSetOpen} data={null} />,
-      );
+      renderWithRouter(<RemediationWizard setOpen={mockSetOpen} data={null} />);
 
       // Check for chart titles which are more reliably queryable than SVG labels
       expect(screen.getAllByText(/0 System/i).length).toBeGreaterThan(0);

--- a/src/components/RemediationWizard.test.js
+++ b/src/components/RemediationWizard.test.js
@@ -3,6 +3,21 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('@patternfly/react-charts', () => {
+  const React = require('react');
+  const PropTypes = require('prop-types');
+  const ChartBullet = (props) =>
+    props.title != null ? React.createElement('span', null, props.title) : null;
+  ChartBullet.propTypes = {
+    title: PropTypes.node,
+  };
+  return {
+    ChartAxis: () => null,
+    ChartBullet,
+  };
+});
+
 import { RemediationWizard } from './RemediationWizard/RemediationWizard';
 import { EXECUTION_LIMITS_HEADER_DESCRIPTION } from '../routes/RemediationDetailsComponents/helpers';
 

--- a/src/components/SystemsTable/SystemsTable.test.js
+++ b/src/components/SystemsTable/SystemsTable.test.js
@@ -54,13 +54,14 @@ jest.mock(
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry',
   () => {
+    const state = {
+      entities: { selected: new Map(), loaded: true, rows: [] },
+    };
     return jest.fn().mockImplementation(() => ({
       store: {
-        getState: () => ({
-          entities: { selected: new Map(), loaded: true, rows: [] },
-        }),
+        getState: () => state,
         dispatch: jest.fn(),
-        subscribe: jest.fn(),
+        subscribe: jest.fn(() => jest.fn()),
       },
       register: jest.fn(),
     }));
@@ -82,6 +83,18 @@ jest.mock('./helpers', () => ({
 jest.mock('./Columns', () => []);
 jest.mock('./useBulkSelect', () => jest.fn(() => ({})));
 jest.mock('./useOnConfirm', () => jest.fn(() => jest.fn()));
+
+jest.mock('../../Utilities/Hooks/api/useRemediations', () => {
+  const fetchSystems = jest.fn();
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      result: null,
+      loading: false,
+      fetch: fetchSystems,
+    })),
+  };
+});
 
 describe('SystemsTable', () => {
   const defaultProps = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,7 +42,6 @@ export const SEARCH_DEBOUNCE_DELAY = 500;
 export const FETCH_SELECTED_HOSTS = 'FETCH_SELECTED_HOSTS';
 export const FETCH_RESOLUTIONS = 'FETCH_RESOLUTIONS';
 
-/** Remediations service base path (RBAC v1 / legacy client) */
 export const API_BASE = '/api/remediations/v1';
 
 export const KESSEL_API_BASE_URL = '/api/kessel/v1beta2';

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.test.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.test.js
@@ -583,15 +583,14 @@ describe('ActionsContent', () => {
     it('chunks large delete operations', async () => {
       mockFetchQueue.mockResolvedValue();
 
-      // Create many issues to test chunking
-      const manyIssues = Array.from({ length: 250 }, (_, i) => ({
+      const manyIssues = Array.from({ length: 50 }, (_, i) => ({
         id: `issue-${i}`,
         description: `Action ${i}`,
         systems: [],
         system_count: 0,
       }));
 
-      renderComponent({ issues: manyIssues }); // Pass issues directly
+      renderComponent({ issues: manyIssues });
 
       fireEvent.click(screen.getByTestId('action-remove-0'));
       fireEvent.click(screen.getByTestId('confirm-button'));

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Columns.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Columns.js
@@ -5,12 +5,15 @@ import {
   ExecutionStatusCell,
 } from './Cells';
 
+/** Default API `sort` for playbook run systems; must match TableTools default (column 0 asc). */
+export const RUN_SYSTEMS_DEFAULT_SORT = 'system_name';
+
 const useColumns = () => {
   return [
     {
       title: 'System name',
       transforms: [wrappable],
-      // sortable: 'action',
+      sortable: RUN_SYSTEMS_DEFAULT_SORT,
       exportKey: 'action',
       Component: SystemNameCell,
     },

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Columns.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Columns.js
@@ -5,7 +5,6 @@ import {
   ExecutionStatusCell,
 } from './Cells';
 
-/** Default API `sort` for playbook run systems; must match TableTools default (column 0 asc). */
 export const RUN_SYSTEMS_DEFAULT_SORT = 'system_name';
 
 const useColumns = () => {

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Filter.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Filter.js
@@ -5,6 +5,6 @@ export const systemFilter = [
     type: conditionalFilterType.text,
     label: 'System',
     placeholder: 'Search',
-    filterAttribute: 'description',
+    filterAttribute: 'ansible_host',
   },
 ];

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Filter.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/Filter.test.js
@@ -51,7 +51,7 @@ describe('ExecutionHistoryContent Filter', () => {
 
     it('should have correct filter attribute', () => {
       const filter = systemFilter[0];
-      expect(filter.filterAttribute).toBe('description');
+      expect(filter.filterAttribute).toBe('ansible_host');
     });
 
     it('should have all required properties defined', () => {
@@ -172,7 +172,7 @@ describe('ExecutionHistoryContent Filter', () => {
       const filter = systemFilter[0];
 
       // filterAttribute should be a valid property name
-      expect(filter.filterAttribute).toBe('description');
+      expect(filter.filterAttribute).toBe('ansible_host');
       expect(typeof filter.filterAttribute).toBe('string');
       expect(filter.filterAttribute.length).toBeGreaterThan(0);
     });

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunSystemsTable.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunSystemsTable.js
@@ -1,21 +1,13 @@
 import React from 'react';
-import { useRawTableState } from 'bastilian-tabletools';
 import RemediationsTable from '../../../components/RemediationsTable/RemediationsTable';
 import useColumns from './Columns';
 import { systemFilter } from './Filter';
 import PropTypes from 'prop-types';
 import TableEmptyState from '../../OverViewPage/TableEmptyState';
 
-const RunSystemsTable = ({ run, loading, viewLogColumn }) => {
-  const tableState = useRawTableState();
+const RunSystemsTable = ({ run, loading, total, viewLogColumn }) => {
   const columns = useColumns();
-  const nameFilter = tableState?.filters?.system?.[0]?.toLowerCase() ?? '';
-
-  const filtered = nameFilter
-    ? run.systems.filter((s) =>
-        s.system_name.toLowerCase().includes(nameFilter),
-      )
-    : run.systems;
+  const systems = run.systems ?? [];
 
   return (
     <RemediationsTable
@@ -23,14 +15,14 @@ const RunSystemsTable = ({ run, loading, viewLogColumn }) => {
       ouiaId={`ExecutionHistory-${run.id}`}
       variant="compact"
       loading={loading}
-      items={filtered}
-      total={filtered.length}
+      items={systems}
+      total={total}
       columns={[...columns, viewLogColumn]}
       filters={{ filterConfig: [...systemFilter] }}
       options={{
         manageColumns: true,
-        itemIdsOnPage: filtered.map((s) => s.system_id),
-        total: filtered.length,
+        itemIdsOnPage: systems.map((s) => s.system_id),
+        total,
         EmptyState: TableEmptyState,
       }}
     />
@@ -40,6 +32,7 @@ const RunSystemsTable = ({ run, loading, viewLogColumn }) => {
 RunSystemsTable.propTypes = {
   run: PropTypes.object.isRequired,
   loading: PropTypes.bool.isRequired,
+  total: PropTypes.number.isRequired,
   viewLogColumn: PropTypes.object.isRequired,
 };
 

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunSystemsTable.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunSystemsTable.test.js
@@ -4,10 +4,6 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import RunSystemsTable from './RunSystemsTable';
 
-jest.mock('bastilian-tabletools', () => ({
-  useRawTableState: jest.fn(),
-}));
-
 jest.mock('./Columns', () => {
   const mockUseColumns = jest.fn(() => [
     {
@@ -73,12 +69,6 @@ jest.mock('../../OverViewPage/TableEmptyState', () => {
 });
 
 describe('RunSystemsTable', () => {
-  const mockUseRawTableState = require('bastilian-tabletools').useRawTableState;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   const mockRun = {
     id: 'run-123',
     systems: [
@@ -95,12 +85,6 @@ describe('RunSystemsTable', () => {
   };
 
   beforeEach(() => {
-    mockUseRawTableState.mockReturnValue({
-      filters: {},
-    });
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
   });
 
@@ -110,6 +94,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -129,6 +114,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={true}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -141,6 +127,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -150,17 +137,18 @@ describe('RunSystemsTable', () => {
   });
 
   describe('Data handling', () => {
-    it('should display all systems when no filter is applied', () => {
+    it('should display systems and total from props (server-driven)', () => {
       render(
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={56}
           viewLogColumn={mockViewLogColumn}
         />,
       );
 
       expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
+      expect(screen.getByTestId('total')).toHaveTextContent('56');
     });
 
     it('should include viewLogColumn in columns', () => {
@@ -168,11 +156,11 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
 
-      // Base columns (2) + viewLogColumn (1) = 3
       expect(screen.getByTestId('columns-count')).toHaveTextContent('3');
     });
 
@@ -181,6 +169,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={100}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -189,7 +178,7 @@ describe('RunSystemsTable', () => {
       const options = JSON.parse(optionsText);
 
       expect(options.itemIdsOnPage).toEqual(['sys1', 'sys2', 'sys3']);
-      expect(options.total).toBe(3);
+      expect(options.total).toBe(100);
       expect(options.EmptyState).toBe('TableEmptyState');
     });
 
@@ -200,87 +189,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={emptyRun}
           loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      expect(screen.getByTestId('items-count')).toHaveTextContent('0');
-      expect(screen.getByTestId('total')).toHaveTextContent('0');
-    });
-  });
-
-  describe('Filtering functionality', () => {
-    it('should filter systems by name when filter is applied', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['Server'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should show only systems with 'Server' in name (Server-1, Server-2)
-      expect(screen.getByTestId('items-count')).toHaveTextContent('2');
-      expect(screen.getByTestId('total')).toHaveTextContent('2');
-    });
-
-    it('should handle case-insensitive filtering', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['server'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should still match 'Server-1' and 'Server-2'
-      expect(screen.getByTestId('items-count')).toHaveTextContent('2');
-      expect(screen.getByTestId('total')).toHaveTextContent('2');
-    });
-
-    it('should filter by partial matches', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['base'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should match 'Database-1'
-      expect(screen.getByTestId('items-count')).toHaveTextContent('1');
-      expect(screen.getByTestId('total')).toHaveTextContent('1');
-    });
-
-    it('should return no results for non-matching filter', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['NonExistent'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
+          total={0}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -289,131 +198,17 @@ describe('RunSystemsTable', () => {
       expect(screen.getByTestId('total')).toHaveTextContent('0');
     });
 
-    it('should handle empty filter string', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: [''],
-        },
-      });
-
+    it('should treat missing run.systems as empty list', () => {
       render(
         <RunSystemsTable
-          run={mockRun}
+          run={{ id: 'run-1' }}
           loading={false}
+          total={0}
           viewLogColumn={mockViewLogColumn}
         />,
       );
 
-      // Empty filter should show all systems
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
-    });
-
-    it('should handle filter with multiple entries (uses first)', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['Server', 'Database'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should use first filter 'Server'
-      expect(screen.getByTestId('items-count')).toHaveTextContent('2');
-      expect(screen.getByTestId('total')).toHaveTextContent('2');
-    });
-  });
-
-  describe('Edge cases and null handling', () => {
-    it('should handle null tableState', () => {
-      mockUseRawTableState.mockReturnValue(null);
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should show all systems when tableState is null
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
-    });
-
-    it('should handle undefined tableState', () => {
-      mockUseRawTableState.mockReturnValue(undefined);
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      // Should show all systems when tableState is undefined
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
-    });
-
-    it('should handle tableState without filters', () => {
-      mockUseRawTableState.mockReturnValue({});
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
-    });
-
-    it('should handle tableState with filters but no system filter', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          other: ['someValue'],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
-    });
-
-    it('should handle system filter as empty array', () => {
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: [],
-        },
-      });
-
-      render(
-        <RunSystemsTable
-          run={mockRun}
-          loading={false}
-          viewLogColumn={mockViewLogColumn}
-        />,
-      );
-
-      expect(screen.getByTestId('items-count')).toHaveTextContent('3');
-      expect(screen.getByTestId('total')).toHaveTextContent('3');
+      expect(screen.getByTestId('items-count')).toHaveTextContent('0');
     });
   });
 
@@ -423,6 +218,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={mockRun}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -445,6 +241,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={customRun}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -467,6 +264,7 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={customRun}
           loading={false}
+          total={2}
           viewLogColumn={mockViewLogColumn}
         />,
       );
@@ -497,12 +295,13 @@ describe('RunSystemsTable', () => {
         <RunSystemsTable
           run={runWithVariedSystems}
           loading={false}
+          total={42}
           viewLogColumn={mockViewLogColumn}
         />,
       );
 
       expect(screen.getByTestId('items-count')).toHaveTextContent('2');
-      expect(screen.getByTestId('total')).toHaveTextContent('2');
+      expect(screen.getByTestId('total')).toHaveTextContent('42');
     });
 
     it('should handle systems with special characters in names', () => {
@@ -527,21 +326,15 @@ describe('RunSystemsTable', () => {
         ],
       };
 
-      mockUseRawTableState.mockReturnValue({
-        filters: {
-          system: ['with'],
-        },
-      });
-
       render(
         <RunSystemsTable
           run={runWithSpecialNames}
           loading={false}
+          total={3}
           viewLogColumn={mockViewLogColumn}
         />,
       );
 
-      // Should match all three systems (case-insensitive 'with')
       expect(screen.getByTestId('items-count')).toHaveTextContent('3');
       expect(screen.getByTestId('total')).toHaveTextContent('3');
     });

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.js
@@ -10,9 +10,8 @@ import useRunSystems from './hooks/useRunSystems';
 import { StatusLabel } from '../../helpers';
 import { RedoIcon } from '@patternfly/react-icons';
 
-const RunTabContent = ({
+const RunTabBody = ({
   run,
-  idx,
   isActive,
   remId,
   fetchSystems,
@@ -22,12 +21,11 @@ const RunTabContent = ({
   manualRefreshClicked,
   isPlaybookRunsLoading,
 }) => {
-  const { systems = [], loading } = useRunSystems(
-    run,
-    isActive,
-    remId,
-    fetchSystems,
-  );
+  const {
+    systems = [],
+    loading,
+    total,
+  } = useRunSystems(run, isActive, remId, fetchSystems);
 
   const handleClick = async () => {
     setManualRefreshClicked(true);
@@ -37,12 +35,7 @@ const RunTabContent = ({
   const isLoading = isPlaybookRunsLoading || loading || manualRefreshClicked;
 
   return (
-    <TabContent
-      eventKey={idx}
-      id={`run-${idx}`}
-      activeKey={isActive ? idx : -1}
-      hidden={!isActive}
-    >
+    <>
       <Flex
         className="pf-v6-u-mb-lg pf-v6-u-mt-lg"
         justifyContent={{ default: 'justifyContentSpaceBetween' }}
@@ -74,26 +67,54 @@ const RunTabContent = ({
         canceledAt={run.updated_at}
       />
 
+      <RunSystemsTable
+        run={{ ...run, systems }}
+        loading={isLoading}
+        total={total}
+        viewLogColumn={{
+          title: '',
+          props: { screenReaderText: 'View log' },
+          exportKey: 'viewLog',
+          Component: (system) => (
+            <Button
+              variant="link"
+              style={{ padding: 0 }}
+              onClick={() => openLogModal(run, system)}
+              data-testid="view-log-button"
+            >
+              View log
+            </Button>
+          ),
+        }}
+      />
+    </>
+  );
+};
+
+RunTabBody.propTypes = {
+  run: PropTypes.object.isRequired,
+  isActive: PropTypes.bool.isRequired,
+  remId: PropTypes.string.isRequired,
+  fetchSystems: PropTypes.func.isRequired,
+  openLogModal: PropTypes.func.isRequired,
+  refetchRemediationPlaybookRuns: PropTypes.func.isRequired,
+  setManualRefreshClicked: PropTypes.func.isRequired,
+  manualRefreshClicked: PropTypes.bool.isRequired,
+  isPlaybookRunsLoading: PropTypes.bool.isRequired,
+};
+
+const RunTabContent = (props) => {
+  const { idx, isActive } = props;
+
+  return (
+    <TabContent
+      eventKey={idx}
+      id={`run-${idx}`}
+      activeKey={isActive ? idx : -1}
+      hidden={!isActive}
+    >
       <TableStateProvider>
-        <RunSystemsTable
-          run={{ ...run, systems }}
-          loading={isLoading}
-          viewLogColumn={{
-            title: '',
-            props: { screenReaderText: 'View log' },
-            exportKey: 'viewLog',
-            Component: (system) => (
-              <Button
-                variant="link"
-                style={{ padding: 0 }}
-                onClick={() => openLogModal(run, system)}
-                data-testid="view-log-button"
-              >
-                View log
-              </Button>
-            ),
-          }}
-        />
+        <RunTabBody {...props} />
       </TableStateProvider>
     </TabContent>
   );

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/RunTabContent.test.js
@@ -13,6 +13,7 @@ jest.mock('./hooks/useRunSystems', () =>
   jest.fn(() => ({
     systems: [],
     loading: false,
+    total: 0,
   })),
 );
 
@@ -29,10 +30,11 @@ jest.mock('../DetailsBanners', () => {
 });
 
 jest.mock('./RunSystemsTable', () => {
-  const MockRunSystemsTable = ({ run, loading, viewLogColumn }) => (
+  const MockRunSystemsTable = ({ run, loading, total, viewLogColumn }) => (
     <div data-testid="mock-run-systems-table">
       <span data-testid="table-run-id">{run.id}</span>
       <span data-testid="table-loading">{loading.toString()}</span>
+      <span data-testid="table-total">{total}</span>
       <span data-testid="table-systems-count">{run.systems?.length || 0}</span>
       {viewLogColumn && (
         <button
@@ -156,6 +158,7 @@ describe('RunTabContent', () => {
     mockUseRunSystems.mockReturnValue({
       systems: [],
       loading: false,
+      total: 0,
     });
   });
 

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/hooks/useRunSystems.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/hooks/useRunSystems.js
@@ -1,45 +1,79 @@
 import { useEffect, useRef, useState } from 'react';
+import { useDeepCompareEffect, useDeepCompareMemo } from 'use-deep-compare';
+
+import useRemediationTableState from '../../../../api/useRemediationTableState';
+
+import { RUN_SYSTEMS_DEFAULT_SORT } from '../Columns';
+
+const DEFAULT_PAGE_LIMIT = 10;
+
+const normaliseSystemsResponse = (result) => {
+  const data = result?.data;
+  const rows = Array.isArray(data) ? data : (data?.data ?? []);
+  const total = data?.meta?.total ?? result?.meta?.total ?? rows.length;
+  return { rows, total };
+};
 
 const useRunSystems = (run, shouldFetch, remId, fetchSystems) => {
   const [systems, setSystems] = useState();
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
 
-  const fetchedOnce = useRef(false);
   const prevStatusRef = useRef(run?.status);
-  const prevRemIdRef = useRef(remId);
-  const prevFetchSystemsRef = useRef(fetchSystems);
-  const prevRunIdRef = useRef(run?.id);
+  const fetchSystemsRef = useRef(fetchSystems);
+  fetchSystemsRef.current = fetchSystems;
 
-  useEffect(() => {
-    // Reset fetchedOnce if remId, fetchSystems, or run.id changed
-    if (
-      prevRemIdRef.current !== remId ||
-      prevFetchSystemsRef.current !== fetchSystems ||
-      prevRunIdRef.current !== run?.id
-    ) {
-      fetchedOnce.current = false;
-      prevRemIdRef.current = remId;
-      prevFetchSystemsRef.current = fetchSystems;
-      prevRunIdRef.current = run?.id;
-    }
+  const { params: tableParams } = useRemediationTableState(true, {
+    remId,
+    playbook_run_id: run?.id,
+  });
 
-    if (!shouldFetch || !run || fetchedOnce.current) return;
+  const limit = tableParams?.limit ?? DEFAULT_PAGE_LIMIT;
+  const offset = tableParams?.offset ?? 0;
 
-    fetchedOnce.current = true;
+  const fetchParams = useDeepCompareMemo(
+    () => ({
+      remId,
+      playbook_run_id: run?.id,
+      limit,
+      offset,
+      sort: tableParams?.sort ?? RUN_SYSTEMS_DEFAULT_SORT,
+      ...(tableParams?.filter && { filter: tableParams.filter }),
+    }),
+    [remId, run?.id, limit, offset, tableParams?.sort, tableParams?.filter],
+  );
+
+  useDeepCompareEffect(() => {
+    if (!shouldFetch || !run) return undefined;
+
+    let cancelled = false;
     setLoading(true);
 
-    fetchSystems({ remId, playbook_run_id: run.id })
-      .then(({ data }) => {
-        setSystems(data ?? []);
+    fetchSystemsRef
+      .current(fetchParams)
+      .then((result) => {
+        if (cancelled) return;
+        const { rows, total: nextTotal } = normaliseSystemsResponse(result);
+        setSystems(rows);
+        setTotal(nextTotal);
       })
       .catch((error) => {
-        console.error('Failed to fetch systems:', error);
+        if (!cancelled) {
+          console.error('Failed to fetch systems:', error);
+        }
       })
-      .finally(() => setLoading(false));
-  }, [shouldFetch, run, remId, fetchSystems]);
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // Do not depend on fetchSystems — useQuery's fetch is a new callback whenever its internal loading/params change.
+  }, [shouldFetch, run?.id, fetchParams]);
 
   useEffect(() => {
-    if (!fetchedOnce.current || !shouldFetch || !run) return;
+    if (!shouldFetch || !run) return;
 
     const hasJustFinished =
       prevStatusRef.current === 'running' && run.status !== 'running';
@@ -48,17 +82,21 @@ const useRunSystems = (run, shouldFetch, remId, fetchSystems) => {
     if (!hasJustFinished) return;
 
     setLoading(true);
-    fetchSystems({ remId, playbook_run_id: run.id })
-      .then(({ data }) => {
-        setSystems(data ?? []);
+    fetchSystemsRef
+      .current(fetchParams)
+      .then((result) => {
+        const { rows, total: nextTotal } = normaliseSystemsResponse(result);
+        setSystems(rows);
+        setTotal(nextTotal);
       })
       .catch((error) => {
         console.error('Failed to fetch systems:', error);
       })
       .finally(() => setLoading(false));
-  }, [run?.status, shouldFetch, run, remId, fetchSystems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run?.status, shouldFetch, run?.id, remId, fetchParams]);
 
-  return { systems, loading };
+  return { systems, loading, total };
 };
 
 export default useRunSystems;

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/hooks/useRunSystems.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/hooks/useRunSystems.test.js
@@ -1,5 +1,22 @@
+import React from 'react';
 import { renderHook, act } from '@testing-library/react';
+import { TableStateProvider } from 'bastilian-tabletools';
+
 import useRunSystems from './useRunSystems';
+
+const hookWrapper = ({ children }) => (
+  <TableStateProvider>{children}</TableStateProvider>
+);
+
+const expectPagedFetch = (mockFn, remId, playbookRunId) =>
+  expect(mockFn).toHaveBeenCalledWith(
+    expect.objectContaining({
+      remId,
+      playbook_run_id: playbookRunId,
+      limit: 10,
+      offset: 0,
+    }),
+  );
 
 describe('useRunSystems Hook', () => {
   let mockFetchSystems;
@@ -44,8 +61,9 @@ describe('useRunSystems Hook', () => {
 
   describe('Initial render and basic functionality', () => {
     it('should return initial state', () => {
-      const { result } = renderHook(() =>
-        useRunSystems(null, false, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(null, false, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       expect(result.current.systems).toBeUndefined();
@@ -55,20 +73,25 @@ describe('useRunSystems Hook', () => {
     it('should not fetch when shouldFetch is false', () => {
       const run = createMockRun();
 
-      renderHook(() => useRunSystems(run, false, 'rem-123', mockFetchSystems));
+      renderHook(() => useRunSystems(run, false, 'rem-123', mockFetchSystems), {
+        wrapper: hookWrapper,
+      });
 
       expect(mockFetchSystems).not.toHaveBeenCalled();
     });
 
     it('should not fetch when run is null', () => {
-      renderHook(() => useRunSystems(null, true, 'rem-123', mockFetchSystems));
+      renderHook(() => useRunSystems(null, true, 'rem-123', mockFetchSystems), {
+        wrapper: hookWrapper,
+      });
 
       expect(mockFetchSystems).not.toHaveBeenCalled();
     });
 
     it('should not fetch when run is undefined', () => {
-      renderHook(() =>
-        useRunSystems(undefined, true, 'rem-123', mockFetchSystems),
+      renderHook(
+        () => useRunSystems(undefined, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       expect(mockFetchSystems).not.toHaveBeenCalled();
@@ -82,14 +105,12 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockResolvedValue({ data: mockData });
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
-      expect(mockFetchSystems).toHaveBeenCalledWith({
-        remId: 'rem-123',
-        playbook_run_id: 'run-123',
-      });
+      expectPagedFetch(mockFetchSystems, 'rem-123', 'run-123');
 
       // Should be loading initially
       expect(result.current.loading).toBe(true);
@@ -116,8 +137,9 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockRejectedValue(new Error('Fetch failed'));
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       expect(result.current.loading).toBe(true);
@@ -135,8 +157,9 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockResolvedValue({ data: null });
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       await act(async () => {
@@ -152,8 +175,9 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockResolvedValue({ data: undefined });
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       await act(async () => {
@@ -170,8 +194,9 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockResolvedValue({ data: mockData });
 
-      const { rerender } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { rerender } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       await act(async () => {
@@ -194,8 +219,9 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockResolvedValue({ data: mockData });
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       await act(async () => {
@@ -216,14 +242,61 @@ describe('useRunSystems Hook', () => {
       );
     });
 
+    it('should expose meta.total for paged Axios body { data: { meta, data } }', async () => {
+      const run = createMockRun();
+      const pageRows = createMockSystemsData().slice(0, 2);
+
+      mockFetchSystems.mockResolvedValue({
+        data: {
+          meta: { count: 2, total: 56 },
+          data: pageRows,
+        },
+      });
+
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.systems).toHaveLength(2);
+      expect(result.current.total).toBe(56);
+    });
+
+    it('should expose meta.total when response is bare list DTO { meta, data }', async () => {
+      const run = createMockRun();
+      const pageRows = createMockSystemsData().slice(0, 2);
+
+      mockFetchSystems.mockResolvedValue({
+        meta: { count: 2, total: 56 },
+        data: pageRows,
+      });
+
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.systems).toHaveLength(2);
+      expect(result.current.total).toBe(56);
+    });
+
     it('should handle missing executor type', async () => {
       const run = createMockRun();
       const mockData = createMockSystemsData();
 
       mockFetchSystems.mockResolvedValue({ data: mockData });
 
-      const { result } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result } = renderHook(
+        () => useRunSystems(run, true, 'rem-123', mockFetchSystems),
+        { wrapper: hookWrapper },
       );
 
       await act(async () => {
@@ -246,6 +319,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -290,6 +364,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -334,6 +409,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -378,6 +454,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -391,10 +468,7 @@ describe('useRunSystems Hook', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockFetchSystems).toHaveBeenCalledWith({
-        remId: 'rem-123',
-        playbook_run_id: 'run-123',
-      });
+      expectPagedFetch(mockFetchSystems, 'rem-123', 'run-123');
 
       // Change remId - should trigger new fetch due to useEffect dependency
       rerender({
@@ -408,10 +482,7 @@ describe('useRunSystems Hook', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockFetchSystems).toHaveBeenCalledWith({
-        remId: 'rem-456',
-        playbook_run_id: 'run-123',
-      });
+      expectPagedFetch(mockFetchSystems, 'rem-456', 'run-123');
     });
 
     it('should handle fetchSystems function change', async () => {
@@ -427,6 +498,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -442,7 +514,7 @@ describe('useRunSystems Hook', () => {
 
       expect(mockFetchSystems).toHaveBeenCalledTimes(1);
 
-      // Change fetchSystems function
+      // Swap fetch implementation (stable deps — no automatic refetch from fetch identity alone)
       rerender({
         run,
         shouldFetch: true,
@@ -454,10 +526,21 @@ describe('useRunSystems Hook', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(newMockFetchSystems).toHaveBeenCalledWith({
-        remId: 'rem-123',
-        playbook_run_id: 'run-123',
+      expect(newMockFetchSystems).not.toHaveBeenCalled();
+
+      // Next param-driven fetch uses the updated ref
+      rerender({
+        run,
+        shouldFetch: true,
+        remId: 'rem-789',
+        fetchSystems: newMockFetchSystems,
       });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expectPagedFetch(newMockFetchSystems, 'rem-789', 'run-123');
     });
 
     it('should handle run object change', async () => {
@@ -470,6 +553,7 @@ describe('useRunSystems Hook', () => {
         ({ run, shouldFetch, remId, fetchSystems }) =>
           useRunSystems(run, shouldFetch, remId, fetchSystems),
         {
+          wrapper: hookWrapper,
           initialProps: {
             run,
             shouldFetch: true,
@@ -499,14 +583,11 @@ describe('useRunSystems Hook', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockFetchSystems).toHaveBeenCalledWith({
-        remId: 'rem-123',
-        playbook_run_id: 'run-456',
-      });
+      expectPagedFetch(mockFetchSystems, 'rem-123', 'run-456');
     });
 
     it('should handle loading state correctly during concurrent fetches', async () => {
-      const run = createMockRun({ status: 'running' });
+      let run = createMockRun({ status: 'running' });
       let resolvePromise;
       const promise = new Promise((resolve) => {
         resolvePromise = resolve;
@@ -514,24 +595,34 @@ describe('useRunSystems Hook', () => {
 
       mockFetchSystems.mockReturnValue(promise);
 
-      const { result, rerender } = renderHook(() =>
-        useRunSystems(run, true, 'rem-123', mockFetchSystems),
+      const { result, rerender } = renderHook(
+        ({ run: r, shouldFetch, remId, fetchSystems }) =>
+          useRunSystems(r, shouldFetch, remId, fetchSystems),
+        {
+          wrapper: hookWrapper,
+          initialProps: {
+            run,
+            shouldFetch: true,
+            remId: 'rem-123',
+            fetchSystems: mockFetchSystems,
+          },
+        },
       );
 
       expect(result.current.loading).toBe(true);
 
-      // Change status to trigger refetch while first fetch is still pending
-      createMockRun({ status: 'success' });
-      rerender();
+      run = createMockRun({ status: 'success' });
+      rerender({
+        run,
+        shouldFetch: true,
+        remId: 'rem-123',
+        fetchSystems: mockFetchSystems,
+      });
 
       expect(result.current.loading).toBe(true);
 
-      // Resolve the promise
-      act(() => {
-        resolvePromise({ data: createMockSystemsData() });
-      });
-
       await act(async () => {
+        resolvePromise({ data: createMockSystemsData() });
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -33,35 +33,22 @@ export const deleteRemediationSystems = (systems, remediation) => {
  *  @param   {number}  [rawParams.limit]         - Page size
  *  @param   {number}  [rawParams.offset]        - Page offset
  *  @param   {string}  [rawParams.sort]          - e.g. system_name or -system_name
- *  @param   {object}  [rawParams.filter]        - { ansible_host } from table filters
- *  @param   {object}  [rawParams.options]       - Axios options (filter[…] query params)
+ *  @param   {object}  [rawParams.options]       - After useRemediations, table filters live in options.params['filter[ansible_host]']
  *  @returns {Promise}                           API response promise
  */
 export const getRemediationPlaybookSystemsList = (rawParams) => {
   const params = Array.isArray(rawParams) ? rawParams[0] : rawParams;
-  const { remId, playbook_run_id, limit, offset, sort, filter, options } =
-    params || {};
+  const { remId, playbook_run_id, limit, offset, sort, options } = params || {};
+  const ansibleHost = options?.params?.['filter[ansible_host]'];
 
-  let ansibleHost = filter?.ansible_host;
-  if (ansibleHost === undefined || ansibleHost === null || ansibleHost === '') {
-    const fromQuery = options?.params?.['filter[ansible_host]'];
-    if (fromQuery !== undefined && fromQuery !== null && fromQuery !== '') {
-      ansibleHost = fromQuery;
-    }
-  }
-
-  const clientParams = {
+  return remediationsApi.getPlaybookRunSystems({
     id: remId,
     playbookRunId: playbook_run_id,
-    ...(limit !== undefined && limit !== null && { limit }),
-    ...(offset !== undefined && offset !== null && { offset }),
-    ...(sort !== undefined && sort !== null && sort !== '' && { sort }),
-    ...(ansibleHost !== undefined &&
-      ansibleHost !== null &&
-      ansibleHost !== '' && { ansibleHost }),
-  };
-
-  return remediationsApi.getPlaybookRunSystems(clientParams);
+    limit: limit ?? undefined,
+    offset: offset ?? undefined,
+    sort: sort ? sort : undefined,
+    ansibleHost: ansibleHost ? ansibleHost : undefined,
+  });
 };
 
 /**

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -27,16 +27,41 @@ export const deleteRemediationSystems = (systems, remediation) => {
 /**
  * Used by ExecutionHistoryContent for fetching playbook run systems.
  *
- *  @param   {object}  params                 - Parameters object
- *  @param   {string}  params.remId           - Remediation ID
- *  @param   {string}  params.playbook_run_id - Playbook run ID
- *  @returns {Promise}                        API response promise
+ *  @param   {object}  rawParams                 - Parameters object (pass-through from useRemediations / table state)
+ *  @param   {string}  rawParams.remId           - Remediation ID
+ *  @param   {string}  rawParams.playbook_run_id - Playbook run ID
+ *  @param   {number}  [rawParams.limit]         - Page size
+ *  @param   {number}  [rawParams.offset]        - Page offset
+ *  @param   {string}  [rawParams.sort]          - e.g. system_name or -system_name
+ *  @param   {object}  [rawParams.filter]        - { ansible_host } from table filters
+ *  @param   {object}  [rawParams.options]       - Axios options (filter[…] query params)
+ *  @returns {Promise}                           API response promise
  */
-export const getRemediationPlaybookSystemsList = ({
-  remId,
-  playbook_run_id,
-}) => {
-  return remediationsApi.getPlaybookRunSystems(remId, playbook_run_id);
+export const getRemediationPlaybookSystemsList = (rawParams) => {
+  const params = Array.isArray(rawParams) ? rawParams[0] : rawParams;
+  const { remId, playbook_run_id, limit, offset, sort, filter, options } =
+    params || {};
+
+  let ansibleHost = filter?.ansible_host;
+  if (ansibleHost === undefined || ansibleHost === null || ansibleHost === '') {
+    const fromQuery = options?.params?.['filter[ansible_host]'];
+    if (fromQuery !== undefined && fromQuery !== null && fromQuery !== '') {
+      ansibleHost = fromQuery;
+    }
+  }
+
+  const clientParams = {
+    id: remId,
+    playbookRunId: playbook_run_id,
+    ...(limit !== undefined && limit !== null && { limit }),
+    ...(offset !== undefined && offset !== null && { offset }),
+    ...(sort !== undefined && sort !== null && sort !== '' && { sort }),
+    ...(ansibleHost !== undefined &&
+      ansibleHost !== null &&
+      ansibleHost !== '' && { ansibleHost }),
+  };
+
+  return remediationsApi.getPlaybookRunSystems(clientParams);
 };
 
 /**

--- a/src/routes/api.test.js
+++ b/src/routes/api.test.js
@@ -89,8 +89,35 @@ describe('Routes API', () => {
       expect(remediationsApi.getPlaybookRunSystems).toHaveBeenCalledWith({
         id: remId,
         playbookRunId: playbook_run_id,
+        limit: undefined,
+        offset: undefined,
+        sort: undefined,
+        ansibleHost: undefined,
       });
       expect(result).toBe(mockResponse);
+    });
+
+    it('should pass ansibleHost from useRemediations-style options.params', async () => {
+      const remId = 'remediation-123';
+      const playbook_run_id = 'run-456';
+      remediationsApi.getPlaybookRunSystems.mockResolvedValue({});
+
+      await getRemediationPlaybookSystemsList({
+        remId,
+        playbook_run_id,
+        options: {
+          params: { 'filter[ansible_host]': 'my-host' },
+        },
+      });
+
+      expect(remediationsApi.getPlaybookRunSystems).toHaveBeenCalledWith({
+        id: remId,
+        playbookRunId: playbook_run_id,
+        limit: undefined,
+        offset: undefined,
+        sort: undefined,
+        ansibleHost: 'my-host',
+      });
     });
   });
 

--- a/src/routes/api.test.js
+++ b/src/routes/api.test.js
@@ -86,10 +86,10 @@ describe('Routes API', () => {
         playbook_run_id,
       });
 
-      expect(remediationsApi.getPlaybookRunSystems).toHaveBeenCalledWith(
-        remId,
-        playbook_run_id,
-      );
+      expect(remediationsApi.getPlaybookRunSystems).toHaveBeenCalledWith({
+        id: remId,
+        playbookRunId: playbook_run_id,
+      });
       expect(result).toBe(mockResponse);
     });
   });


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-25230

This PR should resolve two things

- Removes old receptor code that is no longer used on the BE, and now the FE
- Fixes pagination on execHistory Tables. (was not implemented at all)

## Summary by Sourcery

Add server-side pagination, sorting, and filtering support for execution history systems tables and remove deprecated receptor configuration code.

Bug Fixes:
- Correct execution history systems tables to use paginated API requests and expose total record counts for proper paging behavior.

Enhancements:
- Integrate table state management into execution history run systems fetching, including support for limit, offset, sorting, and ansible_host filter parameters.
- Normalize playbook run systems API responses to handle both wrapped and bare list DTO formats and surface total counts.
- Wire the execution history systems table to use backend-driven filtering and totals instead of local client-side filtering.
- Unify remediations API base configuration via a shared REMEDIATIONS_API_BASE constant.

Tests:
- Extend useRunSystems tests to cover pagination parameters, total counts, response shape variations, and stable refetch behavior.
- Update execution history and routes API tests to reflect the new paginated systems API contract and table state integration.
- Remove tests related to deprecated receptor configuration checks from App and API modules.

Chores:
- Remove unused receptor configuration API and associated wiring from the application and its tests.