### PR TITLE
feat(RHINENG-24090): allow other apps to pass Rem button tooltip content

### DIFF
--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -25,54 +25,67 @@ const RemediationButtonContent = ({
   hasSelected,
   hasPermissions,
   isCompliancePrecedenceEnabled,
+  buttonTooltipContent,
 }) => {
   const [remediationsData, setRemediationsData] = useState();
   const [isNoDataModalOpen, setNoDataModalOpen] = useState(false);
 
   const tooltipContent = useMemo(() => {
-    return getTooltipContent(hasPermissions, hasSelected);
-  }, [hasSelected, hasPermissions]);
+    const base = getTooltipContent(hasPermissions, hasSelected);
+    if (base != null) {
+      return base;
+    }
+    if (buttonTooltipContent != null && buttonTooltipContent !== '') {
+      return buttonTooltipContent;
+    }
+    return null;
+  }, [hasSelected, hasPermissions, buttonTooltipContent]);
 
-  if (!hasPermissions || !hasSelected) {
-    return (
-      <Tooltip content={tooltipContent}>
-        <span>
-          <Button
-            isDisabled
-            {...buttonProps}
-            data-testid="remediationButton-no-permissions-or-selected"
-          >
-            {children}
-          </Button>
-        </span>
-      </Tooltip>
-    );
-  }
+  const isInteractionBlocked = !hasPermissions || !hasSelected;
+  const isButtonDisabled = isInteractionBlocked || isDisabled;
+
+  const button = (
+    <Button
+      isDisabled={isButtonDisabled}
+      {...buttonProps}
+      data-testid={
+        isInteractionBlocked
+          ? 'remediationButton-no-permissions-or-selected'
+          : 'remediationButton-with-permissions-and-selected'
+      }
+      onClick={
+        isInteractionBlocked
+          ? undefined
+          : () => {
+              Promise.resolve(dataProvider()).then((data) => {
+                if (!data) {
+                  setNoDataModalOpen(true);
+                  return;
+                }
+
+                try {
+                  validate(data);
+                  setRemediationsData(data);
+                } catch {
+                  setNoDataModalOpen(true);
+                }
+              });
+            }
+      }
+    >
+      {children}
+    </Button>
+  );
 
   return (
     <React.Fragment>
-      <Button
-        isDisabled={isDisabled}
-        data-testid="remediationButton-with-permissions-and-selected"
-        onClick={() => {
-          Promise.resolve(dataProvider()).then((data) => {
-            if (!data) {
-              setNoDataModalOpen(true);
-              return;
-            }
-
-            try {
-              validate(data);
-              setRemediationsData(data);
-            } catch {
-              setNoDataModalOpen(true);
-            }
-          });
-        }}
-        {...buttonProps}
-      >
-        {children}
-      </Button>
+      {tooltipContent != null ? (
+        <Tooltip content={tooltipContent}>
+          <span>{button}</span>
+        </Tooltip>
+      ) : (
+        button
+      )}
 
       <NoDataModal
         isOpen={isNoDataModalOpen}
@@ -109,6 +122,7 @@ RemediationButtonContent.propTypes = {
   hasSelected: propTypes.bool.isRequired,
   hasPermissions: propTypes.bool.isRequired,
   isCompliancePrecedenceEnabled: propTypes.bool,
+  buttonTooltipContent: propTypes.string,
 };
 
 const RemediationButtonRbacFallback = (props) => {
@@ -216,6 +230,7 @@ RemediationButton.propTypes = {
   }),
   patchNoAdvisoryText: propTypes.string,
   hasSelected: propTypes.bool.isRequired,
+  buttonTooltipContent: propTypes.string,
 };
 
 export default RemediationButton;

--- a/src/modules/tests/remediationButton.test.js
+++ b/src/modules/tests/remediationButton.test.js
@@ -145,6 +145,43 @@ describe('RemediationButton', () => {
       expect(button).toBeEnabled();
     });
 
+    it('should show buttonTooltipContent when user has permissions, selection, and buttonTooltipContent is set', async () => {
+      useChrome.mockImplementation(() => ({
+        getUserPermissions: jest.fn(
+          () =>
+            new Promise((resolve) => resolve([{ permission: CAN_REMEDIATE }])),
+        ),
+      }));
+
+      const message =
+        'The remediation plan includes only supported systems that failed compliance.';
+
+      render(
+        <RemediationButton
+          {...initialProps}
+          hasSelected={true}
+          buttonTooltipContent={message}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('remediationButton-with-permissions-and-selected'),
+        ).toBeInTheDocument();
+      });
+
+      const button = screen.getByTestId(
+        'remediationButton-with-permissions-and-selected',
+      );
+      expect(button).toBeEnabled();
+
+      await user.hover(button);
+
+      await waitFor(() => {
+        expect(screen.getByText(message)).toBeInTheDocument();
+      });
+    });
+
     it('should show btn with selection tooltip when user has permissions but no items selected', async () => {
       useChrome.mockImplementation(() => ({
         getUserPermissions: jest.fn(


### PR DESCRIPTION
Based on UX review we want to be more informative in cases when button is disabled but there is some selection made + if systems that cannot be remediated are in list of selected items

### How to test:
1. Have `insights-chrome` and put this piece below to webpack config
```
      '/apps/compliance': {
        host: 'http://localhost:8004/',
      },
      '/apps/remediations': {
        host: 'http://localhost:8003/',
      },
```
2. Run insights-chrome `npm run dev`
3. Checkout to current Remediation PR and run `npm run static`
4. Checkout to  compliance PR https://github.com/RedHatInsights/compliance-frontend/pull/2790 and run `npm run static -- -p=8004`
5. Have report with fully compliant systems, unsupported systems and systems with failed rules (you can use `comp-user-3` account
6. Ensure that in case of selected systems and passed tooltip by app - Remediation app shows provided tooltip text

Closes https://redhat.atlassian.net/browse/RHINENG-24090 and https://redhat.atlassian.net/browse/RHINENG-24091

## Summary by Sourcery

Allow the Remediations button tooltip content to be customized by consuming applications while preserving existing permission/selection behavior.

New Features:
- Add optional buttonTooltipContent prop to RemediationButton to let external apps supply custom tooltip text when the button is used.

Enhancements:
- Unify disabled/enabled Remediations button rendering with conditional tooltip wrapping based on computed tooltip content.

Tests:
- Add a test verifying that provided buttonTooltipContent is displayed when the user has permissions and a selection.