### PR TITLE
fix(yaml): add APIKeyDev to yaml file and pckg-lock

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -91,6 +91,7 @@ objects:
         manifestLocation: /apps/remediations/fed-mods.json
         analytics:
           APIKey: "apRCg9V6oMXCcnTingqRYW6m1er4hkCW"
+          APIKeyDev: "aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg"
         config:
           supportCaseData:
             product: Red Hat Insights

--- a/package-lock.json
+++ b/package-lock.json
@@ -11192,7 +11192,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
As a CoP effort, we are to add the APIKEYDEV to the yaml file. This also includes an audit fix for the package.lock

## Summary by Sourcery

Deployment:
- Configure the frontend deployment with a separate APIKeyDev value for analytics in the YAML manifest.