### PR TITLE
fix(RHINENG-26137): deal with permissions correctly based on FF

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,10 +5,11 @@ import { connect } from 'react-redux';
 import Routes from './Routes';
 
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
-import { Spinner } from '@patternfly/react-core';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import { useFlagsStatus } from '@unleash/proxy-client-react';
 
 import { useFeatureFlag } from './Utilities/Hooks/useFeatureFlag';
 import { useKesselRemediationPermissionState } from './Utilities/Hooks/useKesselRemediationPermissionState';
@@ -107,12 +108,21 @@ KesselPermissionsGate.propTypes = {
 
 const App = () => {
   const chrome = useChrome();
+  const { flagsReady } = useFlagsStatus();
   const isKesselEnabled = useFeatureFlag('kessel-for-remediations');
   const baseUrl = window.location.origin || 'https://console.redhat.com';
 
   useEffect(() => {
     chrome?.hideGlobalFilter?.(true);
   }, [chrome]);
+
+  if (!flagsReady) {
+    return (
+      <Bullseye>
+        <Spinner size="xl" />
+      </Bullseye>
+    );
+  }
 
   return isKesselEnabled ? (
     <AccessCheck.Provider baseUrl={baseUrl} apiPath={KESSEL_API_BASE_URL}>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,6 +10,9 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+jest.mock('@unleash/proxy-client-react', () => ({
+  useFlagsStatus: jest.fn(() => ({ flagsReady: true })),
+}));
 jest.mock('./Utilities/Hooks/useFeatureFlag', () => ({
   useFeatureFlag: jest.fn(() => false),
 }));
@@ -61,6 +64,7 @@ jest.mock('@project-kessel/react-kessel-access-check', () => {
 const mockStore = createStore(() => ({}));
 
 const { useFeatureFlag } = require('./Utilities/Hooks/useFeatureFlag');
+const { useFlagsStatus } = require('@unleash/proxy-client-react');
 const {
   fetchDefaultWorkspace,
   useSelfAccessCheck,
@@ -72,6 +76,7 @@ describe('App Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useFeatureFlag.mockReturnValue(false);
+    useFlagsStatus.mockReturnValue({ flagsReady: true });
 
     mockChrome = {
       hideGlobalFilter: jest.fn(),
@@ -91,6 +96,16 @@ describe('App Component', () => {
   };
 
   describe('Initialization', () => {
+    it('should render loading spinner until Unleash flags are ready', () => {
+      useFlagsStatus.mockReturnValue({ flagsReady: false });
+
+      renderApp();
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(mockChrome.getUserPermissions).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('routes')).not.toBeInTheDocument();
+    });
+
     it('should render loading spinner initially', () => {
       mockChrome.getUserPermissions.mockImplementation(
         () => new Promise(() => {}),


### PR DESCRIPTION
wait when feature flag is loaded and then fetch permissions

## Summary by Sourcery

Gate application initialization on Unleash feature flag readiness and ensure permissions are only fetched once flags are loaded.

Bug Fixes:
- Prevent user permissions from being requested before Unleash feature flags are fully loaded by blocking app rendering until flags are ready.

Tests:
- Add initialization test coverage to verify the app shows a loading spinner and skips permission fetching until Unleash flags are ready.