### PR TITLE
feat(RHINENG-25605): Add batching to the system-deletion bulk requests

### DIFF
--- a/src/components/SystemsTable/RemoveSystemModal.js
+++ b/src/components/SystemsTable/RemoveSystemModal.js
@@ -9,12 +9,14 @@ const RemoveSystemModal = ({
   onConfirm,
   onClose,
   remediationName,
+  isRemoving = false,
 }) => (
   <Modal
     variant={ModalVariant.medium}
     title={`Remove selected system${selected?.length > 1 ? 's' : ''}?`}
     isOpen={isOpen}
-    onClose={onClose}
+    onClose={isRemoving ? () => {} : onClose}
+    showClose={!isRemoving}
     titleIconVariant={'warning'}
     data-testid="modal"
     actions={[
@@ -23,12 +25,18 @@ const RemoveSystemModal = ({
         variant="primary"
         onClick={onConfirm}
         data-testid="confirm-delete"
+        isDisabled={isRemoving}
+        isLoading={isRemoving}
       >
         Remove
       </Button>,
-      <Button key="remove-cancel" variant="link" onClick={onClose}>
-        Cancel
-      </Button>,
+      ...(!isRemoving
+        ? [
+            <Button key="remove-cancel" variant="link" onClick={onClose}>
+              Cancel
+            </Button>,
+          ]
+        : []),
     ]}
   >
     <span data-testid="modal-content">
@@ -49,11 +57,12 @@ RemoveSystemModal.propTypes = {
       id: PropTypes.string,
       display_name: PropTypes.string,
     }),
-  ).isRequired,
+  ),
   remediationName: PropTypes.string.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onConfirm: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
+  isRemoving: PropTypes.bool,
 };
 
 export default RemoveSystemModal;

--- a/src/components/SystemsTable/RemoveSystemModal.test.js
+++ b/src/components/SystemsTable/RemoveSystemModal.test.js
@@ -10,6 +10,8 @@ jest.mock('@patternfly/react-core', () => ({
     children,
     variant,
     onClick,
+    isLoading,
+    isDisabled,
     ouiaId,
     ...props
   }) {
@@ -17,6 +19,8 @@ jest.mock('@patternfly/react-core', () => ({
       <button
         data-testid={ouiaId || 'button'}
         data-variant={variant}
+        data-loading={isLoading ? 'true' : 'false'}
+        disabled={isDisabled}
         onClick={onClick}
         {...props}
       >
@@ -24,6 +28,9 @@ jest.mock('@patternfly/react-core', () => ({
       </button>
     );
   },
+}));
+
+jest.mock('@patternfly/react-core/deprecated', () => ({
   Modal: function MockModal({
     children,
     variant,
@@ -32,6 +39,7 @@ jest.mock('@patternfly/react-core', () => ({
     onClose,
     titleIconVariant,
     actions,
+    showClose = true,
     ...props
   }) {
     if (!isOpen) return null;
@@ -43,11 +51,17 @@ jest.mock('@patternfly/react-core', () => ({
         {...props}
       >
         <div data-testid="modal-title">{title}</div>
-        <div data-testid="modal-content">{children}</div>
+        <div data-testid="modal-body">{children}</div>
         <div data-testid="modal-actions">{actions}</div>
-        <button data-testid="modal-close" onClick={onClose}>
-          X
-        </button>
+        {showClose !== false && (
+          <button
+            data-testid="modal-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            X
+          </button>
+        )}
       </div>
     );
   },
@@ -69,6 +83,7 @@ describe('RemoveSystemModal', () => {
     onConfirm: mockOnConfirm,
     onClose: mockOnClose,
     remediationName: 'Test Remediation Plan',
+    isRemoving: false,
   };
 
   beforeEach(() => {
@@ -151,12 +166,29 @@ describe('RemoveSystemModal', () => {
     expect(removeButton).toHaveAttribute('data-variant', 'primary');
   });
 
+  it('should disable Remove button and show loading state while removing', () => {
+    render(<RemoveSystemModal {...defaultProps} isRemoving={true} />);
+
+    const removeButton = screen.getByTestId('confirm-delete');
+    expect(removeButton).toBeDisabled();
+    expect(removeButton).toHaveAttribute('data-loading', 'true');
+  });
+
   it('should render Cancel button with correct properties', () => {
     render(<RemoveSystemModal {...defaultProps} />);
 
     const cancelButton = screen.getByRole('button', { name: 'Cancel' });
     expect(cancelButton).toBeInTheDocument();
     expect(cancelButton).toHaveAttribute('data-variant', 'link');
+  });
+
+  it('should hide Cancel and close buttons while removing', () => {
+    render(<RemoveSystemModal {...defaultProps} isRemoving={true} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
   });
 
   it('should call onConfirm when Remove button is clicked', () => {

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -39,6 +39,7 @@ const SystemsTableWrapper = ({
 }) => {
   const inventory = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
   const systemsRef = useRef();
   const configRef = useRef({});
   const activeSystem = useRef(undefined);
@@ -85,6 +86,7 @@ const SystemsTableWrapper = ({
       await refreshRemediation();
     },
     refetchConnectionStatus,
+    setIsRemoving,
     setIsOpen,
     addNotification,
     clearSelection,
@@ -174,13 +176,14 @@ const SystemsTableWrapper = ({
           <Button
             variant="secondary"
             onClick={() => setIsOpen(true)}
-            isDisabled={selected.size === 0}
+            isDisabled={selected.size === 0 || isRemoving}
           >
             Remove
           </Button>
         )}
         <RemoveSystemModal
           isOpen={isOpen}
+          isRemoving={isRemoving}
           onConfirm={onConfirm}
           selected={
             selected.size > 0
@@ -188,6 +191,9 @@ const SystemsTableWrapper = ({
               : [activeSystem.current]
           }
           onClose={() => {
+            if (isRemoving) {
+              return;
+            }
             activeSystem.current = undefined;
             setIsOpen(false);
           }}

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -69,6 +69,11 @@ const SystemsTableWrapper = ({
     setRefreshKey((prev) => prev + 1);
   }, []);
 
+  const handleClose = useCallback(() => {
+    activeSystem.current = undefined;
+    setIsOpen(false);
+  }, []);
+
   useEffect(() => {
     systemsRef.current = [];
   }, []);
@@ -190,13 +195,7 @@ const SystemsTableWrapper = ({
               ? Array.from(selected, ([, value]) => value)
               : [activeSystem.current]
           }
-          onClose={() => {
-            if (isRemoving) {
-              return;
-            }
-            activeSystem.current = undefined;
-            setIsOpen(false);
-          }}
+          onClose={handleClose}
           remediationName={remediation.name}
         />
       </InventoryTable>

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -26,7 +26,7 @@ import useBulkSelect from './useBulkSelect';
 import useOnConfirm from './useOnConfirm';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
-import { deleteRemediationSystems } from '../../routes/api';
+import { deleteRemediationSystemsBatched } from '../../routes/api';
 import { selectEntity } from '../../actions';
 
 const SystemsTableWrapper = ({
@@ -79,7 +79,7 @@ const SystemsTableWrapper = ({
   const onConfirm = useOnConfirm({
     selected,
     activeSystem,
-    deleteRemediationSystems,
+    deleteRemediationSystemsBatched,
     remediation,
     refreshRemediation: async () => {
       await refreshRemediation();

--- a/src/components/SystemsTable/useOnConfirm.js
+++ b/src/components/SystemsTable/useOnConfirm.js
@@ -9,6 +9,7 @@ const useOnConfirm = ({
   remediation,
   refreshRemediation,
   refetchConnectionStatus,
+  setIsRemoving,
   setIsOpen,
   addNotification,
   clearSelection,
@@ -27,6 +28,7 @@ const useOnConfirm = ({
               },
             ];
       const itemsToDelete = selectedSystems.length;
+      setIsRemoving?.(true);
       const rawResult = await deleteSystems(selectedSystems, remediation);
       const result = rawResult?.status
         ? rawResult
@@ -82,6 +84,7 @@ const useOnConfirm = ({
         dismissable: true,
       });
     } finally {
+      setIsRemoving?.(false);
       setIsOpen(false);
     }
   }, [
@@ -92,6 +95,7 @@ const useOnConfirm = ({
     remediation,
     refreshRemediation,
     refetchConnectionStatus,
+    setIsRemoving,
     setIsOpen,
     addNotification,
     clearSelection,

--- a/src/components/SystemsTable/useOnConfirm.js
+++ b/src/components/SystemsTable/useOnConfirm.js
@@ -34,7 +34,7 @@ const useOnConfirm = ({
         ? rawResult
         : {
             status: 'success',
-            successfullBatches: 1,
+            successfulBatches: 1,
             failedBatches: 0,
             errors: [],
           };

--- a/src/components/SystemsTable/useOnConfirm.js
+++ b/src/components/SystemsTable/useOnConfirm.js
@@ -1,8 +1,10 @@
 import { useCallback } from 'react';
+import { pluralize } from '../../Utilities/utils';
 
 const useOnConfirm = ({
   selected,
   activeSystem,
+  deleteRemediationSystemsBatched,
   deleteRemediationSystems,
   remediation,
   refreshRemediation,
@@ -14,6 +16,8 @@ const useOnConfirm = ({
 }) => {
   return useCallback(async () => {
     try {
+      const deleteSystems =
+        deleteRemediationSystemsBatched || deleteRemediationSystems;
       const selectedSystems =
         selected.size > 0
           ? Array.from(selected, ([, value]) => value)
@@ -22,29 +26,54 @@ const useOnConfirm = ({
                 ...activeSystem.current,
               },
             ];
-      await deleteRemediationSystems(selectedSystems, remediation);
-      await refreshRemediation();
-      if (refetchConnectionStatus) {
-        await refetchConnectionStatus();
+      const itemsToDelete = selectedSystems.length;
+      const rawResult = await deleteSystems(selectedSystems, remediation);
+      const result = rawResult?.status
+        ? rawResult
+        : {
+            status: 'success',
+            successfullBatches: 1,
+            failedBatches: 0,
+            errors: [],
+          };
+
+      if (result.status !== 'complete_failure') {
+        await refreshRemediation();
+        if (refetchConnectionStatus) {
+          await refetchConnectionStatus();
+        }
+
+        activeSystem.current = undefined;
+
+        clearSelection();
+        reloadTable();
       }
 
-      activeSystem.current = undefined;
-
-      clearSelection();
-      reloadTable();
-
-      const itemsToDelete = selected.size > 0 ? selected.size : 1;
-      addNotification({
-        title: `Removed ${itemsToDelete} ${
-          itemsToDelete > 1 ? 'systems' : 'system'
-        } from playbook`,
-        description: '',
-        variant: 'success',
-        dismissable: true,
-        autoDismiss: true,
-      });
-
-      setIsOpen(false);
+      if (result.status === 'success') {
+        addNotification({
+          title: `Removed ${pluralize(itemsToDelete, 'system')} from playbook`,
+          description: '',
+          variant: 'success',
+          dismissable: true,
+          autoDismiss: true,
+        });
+      } else if (result.status === 'partial_failure') {
+        addNotification({
+          title: 'Some selected systems may not have been removed',
+          description:
+            'The system list has been refreshed to show the current state.',
+          variant: 'warning',
+          dismissable: true,
+          autoDismiss: true,
+        });
+      } else {
+        addNotification({
+          title: 'Failed to remove systems',
+          description: result?.errors?.[0] || 'An error occurred',
+          variant: 'danger',
+          dismissable: true,
+        });
+      }
     } catch (error) {
       addNotification({
         title: 'Failed to remove systems',
@@ -52,11 +81,13 @@ const useOnConfirm = ({
         variant: 'danger',
         dismissable: true,
       });
+    } finally {
       setIsOpen(false);
     }
   }, [
     selected,
     activeSystem,
+    deleteRemediationSystemsBatched,
     deleteRemediationSystems,
     remediation,
     refreshRemediation,

--- a/src/components/SystemsTable/useOnConfirm.test.js
+++ b/src/components/SystemsTable/useOnConfirm.test.js
@@ -12,6 +12,7 @@ describe('useOnConfirm Hook', () => {
   let mockDeleteSystems;
   let mockRefreshRemediation;
   let mockSetIsOpen;
+  let mockSetIsRemoving;
   let mockActiveSystem;
   let mockSelected;
   let mockRemediation;
@@ -25,6 +26,7 @@ describe('useOnConfirm Hook', () => {
     mockDeleteSystems = jest.fn().mockResolvedValue({});
     mockRefreshRemediation = jest.fn().mockResolvedValue({});
     mockSetIsOpen = jest.fn();
+    mockSetIsRemoving = jest.fn();
     mockAddNotification = jest.fn();
     mockClearSelection = jest.fn();
     mockReloadTable = jest.fn();
@@ -38,6 +40,7 @@ describe('useOnConfirm Hook', () => {
     mockDeleteSystems.mockClear();
     mockRefreshRemediation.mockClear();
     mockSetIsOpen.mockClear();
+    mockSetIsRemoving.mockClear();
     mockAddNotification.mockClear();
     mockDispatch.mockClear();
     mockClearSelection.mockClear();
@@ -421,6 +424,34 @@ describe('useOnConfirm Hook', () => {
       });
 
       expect(mockRefreshRemediation).toHaveBeenCalled();
+    });
+
+    it('should toggle removing state while delete is in progress', async () => {
+      mockSelected = new Map();
+      mockDeleteSystems.mockResolvedValue({});
+      mockRefreshRemediation.mockResolvedValue();
+
+      const { result } = renderHook(() =>
+        useOnConfirm({
+          selected: mockSelected,
+          activeSystem: mockActiveSystem,
+          deleteRemediationSystems: mockDeleteSystems,
+          clearSelection: mockClearSelection,
+          reloadTable: mockReloadTable,
+          remediation: mockRemediation,
+          refreshRemediation: mockRefreshRemediation,
+          setIsRemoving: mockSetIsRemoving,
+          setIsOpen: mockSetIsOpen,
+          addNotification: mockAddNotification,
+        }),
+      );
+
+      await act(async () => {
+        await result.current();
+      });
+
+      expect(mockSetIsRemoving).toHaveBeenNthCalledWith(1, true);
+      expect(mockSetIsRemoving).toHaveBeenLastCalledWith(false);
     });
 
     it('should call refetchConnectionStatus when provided', async () => {

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -198,6 +198,7 @@ const RemediationDetails = () => {
                 refetchConnectionStatus={refetchConnectionStatus}
                 detailsLoading={detailsLoading}
                 initialNestedTab={searchParams.get('nestedTab') || 'actions'}
+                onNavigateToTab={handleTabClick}
                 remediationId={id}
               />
             </Tab>

--- a/src/routes/RemediationDetailsComponents/PlannedRemediationsContent.js
+++ b/src/routes/RemediationDetailsComponents/PlannedRemediationsContent.js
@@ -22,6 +22,7 @@ const PlannedRemediationsContent = ({
   refetchConnectionStatus,
   detailsLoading,
   initialNestedTab = 'actions',
+  onNavigateToTab,
   remediationId,
 }) => {
   const [nestedActiveTab, setNestedActiveTab] = useState(initialNestedTab);
@@ -55,6 +56,7 @@ const PlannedRemediationsContent = ({
 
   const handleNestedTabClick = (_event, tabName) => {
     setNestedActiveTab(tabName);
+    onNavigateToTab?.(_event, `plannedRemediations:${tabName}`);
   };
 
   return (
@@ -151,6 +153,7 @@ PlannedRemediationsContent.propTypes = {
   refetchConnectionStatus: PropTypes.func,
   detailsLoading: PropTypes.bool,
   initialNestedTab: PropTypes.string,
+  onNavigateToTab: PropTypes.func,
   remediationId: PropTypes.string,
 };
 

--- a/src/routes/RemediationDetailsComponents/PlannedRemediationsContent.test.js
+++ b/src/routes/RemediationDetailsComponents/PlannedRemediationsContent.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlannedRemediationsContent from './PlannedRemediationsContent';
+
+jest.mock('../../components/RemediationWizard/PlanSummaryCharts', () => ({
+  PlanSummaryCharts: function MockPlanSummaryCharts() {
+    return <div>PlanSummaryCharts</div>;
+  },
+}));
+
+jest.mock('./ActionsContent/ActionsContent', () => {
+  return function MockActionsContent() {
+    return <div>ActionsContent</div>;
+  };
+});
+
+jest.mock('../../components/SystemsTable/SystemsTable', () => {
+  return function MockSystemsTable() {
+    return <div>SystemsTable</div>;
+  };
+});
+
+describe('PlannedRemediationsContent', () => {
+  const defaultProps = {
+    remediationDetailsSummary: {
+      id: 'rem-123',
+      issue_count_details: {},
+      issue_count: 2,
+      system_count: 10,
+    },
+    remediationStatus: {
+      connectedData: [],
+      areDetailsLoading: false,
+    },
+    refetchRemediationDetails: jest.fn(),
+    refetchConnectionStatus: jest.fn(),
+    detailsLoading: false,
+    remediationId: 'rem-123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates via parent callback when systems tab is selected', async () => {
+    const onNavigateToTab = jest.fn();
+
+    render(
+      <PlannedRemediationsContent
+        {...defaultProps}
+        onNavigateToTab={onNavigateToTab}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'SystemsTab' }));
+
+    await waitFor(() => {
+      expect(onNavigateToTab).toHaveBeenCalledWith(
+        expect.anything(),
+        'plannedRemediations:systems',
+      );
+    });
+    expect(screen.getByText('SystemsTable')).toBeInTheDocument();
+  });
+
+  it('syncs the active nested tab from props', async () => {
+    const { rerender } = render(
+      <PlannedRemediationsContent
+        {...defaultProps}
+        initialNestedTab="actions"
+      />,
+    );
+
+    expect(screen.getByText('ActionsContent')).toBeInTheDocument();
+
+    rerender(
+      <PlannedRemediationsContent
+        {...defaultProps}
+        initialNestedTab="systems"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('SystemsTable')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -28,10 +28,15 @@ export const deleteRemediationSystems = (systems, remediation) => {
 /**
  * Delete systems from a remediation by calling the deleteRemediationSystems with batches of system IDs.
  *
- *  @param   {Array}   systems     - Array of system objects with id property
- *  @param   {object}  remediation - Remediation object with id property
- *  @param   {number}  [batchSize] - Batch size
- *  @returns {Promise}             Axios delete promise
+ *  @param   {Array}                                                         systems     - Array of system objects with id property
+ *  @param   {object}                                                        remediation - Remediation object with id property
+ *  @param   {number}                                                        [batchSize] - Batch size
+ *  @returns {Promise<{
+ *    status: ('success' | 'partial_failure' | 'complete_failure'),
+ *    successfulBatches: number,
+ *    failedBatches: number,
+ *    errors: Array,
+ *  }>} Promise resolving to a batched deletion summary
  */
 export const deleteRemediationSystemsBatched = async (
   systems,

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,6 +1,7 @@
 import axiosInstance from '@redhat-cloud-services/frontend-components-utilities/interceptors';
 import { remediationsApi } from '../api';
 import { API_BASE } from '../constants';
+import chunk from 'lodash/chunk';
 
 /**
  * Delete systems from a remediation.
@@ -22,6 +23,54 @@ export const deleteRemediationSystems = (systems, remediation) => {
       data: { system_ids: systemIds },
     },
   );
+};
+
+/**
+ * Delete systems from a remediation by calling the deleteRemediationSystems with batches of system IDs.
+ *
+ *  @param   {Array}   systems     - Array of system objects with id property
+ *  @param   {object}  remediation - Remediation object with id property
+ *  @param   {number}  [batchSize] - Batch size
+ *  @returns {Promise}             Axios delete promise
+ */
+export const deleteRemediationSystemsBatched = async (
+  systems,
+  remediation,
+  batchSize = 100,
+) => {
+  const batches = chunk(systems, batchSize);
+  const errors = [];
+  let status = 'success';
+  let successfullBatches = 0;
+  let failedBatches = 0;
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+
+    try {
+      await deleteRemediationSystems(batch, remediation);
+      successfullBatches += 1;
+    } catch (error) {
+      // TODO: Find out a reliable path for extracting only the usable error message
+      errors.push(error.statusText || 'Unknown error');
+      failedBatches += 1;
+    }
+  }
+
+  if (failedBatches === 0) {
+    status = 'success';
+  } else if (successfullBatches === 0) {
+    status = 'complete_failure';
+  } else {
+    status = 'partial_failure';
+  }
+
+  return {
+    status,
+    successfullBatches,
+    failedBatches,
+    errors,
+  };
 };
 
 /**

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -41,7 +41,7 @@ export const deleteRemediationSystemsBatched = async (
   const batches = chunk(systems, batchSize);
   const errors = [];
   let status = 'success';
-  let successfullBatches = 0;
+  let successfulBatches = 0;
   let failedBatches = 0;
 
   for (let i = 0; i < batches.length; i++) {
@@ -49,7 +49,7 @@ export const deleteRemediationSystemsBatched = async (
 
     try {
       await deleteRemediationSystems(batch, remediation);
-      successfullBatches += 1;
+      successfulBatches += 1;
     } catch (error) {
       // TODO: Find out a reliable path for extracting only the usable error message
       errors.push(error.statusText || 'Unknown error');
@@ -59,7 +59,7 @@ export const deleteRemediationSystemsBatched = async (
 
   if (failedBatches === 0) {
     status = 'success';
-  } else if (successfullBatches === 0) {
+  } else if (successfulBatches === 0) {
     status = 'complete_failure';
   } else {
     status = 'partial_failure';
@@ -67,7 +67,7 @@ export const deleteRemediationSystemsBatched = async (
 
   return {
     status,
-    successfullBatches,
+    successfulBatches,
     failedBatches,
     errors,
   };


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-25605](https://redhat.atlassian.net/browse/RHINENG-25605)
Co-authored-by: Cursor

The endpoint for bulk deleting systems accept maximum of 100 systems. This PR adds batching so that user can remove more than 100 systems from remediation plan using UI. That naturally introduced the need to make the removal modal dialog "untouchable" while removal procedure is happening. In addiation, the redirection to the Systems nested-tab after the system removal has been fixed.


# How to test the PR

**Prerequisite**: you need a Remediation plan with 100+ systems. On stage, you can lookup for the test_hhezel_PR plan, or create own one (Content > Advisories is a good place for creating systems-intensive plans).

1. Go to the plan's detail page > Planned remediations tab > Systems subtab
2. Select 100+ systems
3. Open the dev tools > Network tab for inspecting the backend activity
4. Click the `Remove` button and confirm the removal modal dialog
5. Verify that all selected systems have been removed
6. Verify that you cannot confirm or close the removal modal dialog while systems are being removed on backend
7. Verify that the Systems subtab is opened again after the removal

In addition, verify that 

# Before the change
Removing more than 100 systems from a remediation plan fails.
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/48524a97-0682-4c9c-a09a-54a199cd6e93" />



# After the change
User can delete more than 100 systems from a remediation plan.
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/6bf2c570-724a-48bd-a106-d6f7eea9e696" />



# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[RHINENG-25605]: https://redhat.atlassian.net/browse/RHINENG-25605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add batched deletion support for remediation systems and improve the UX and navigation around bulk system removal.

New Features:
- Support deleting remediation systems in batches to handle selections larger than the backend limit.
- Expose nested tab navigation callbacks from planned remediations content so URL state stays in sync when switching subtabs.

Enhancements:
- Disable and show a loading state on the system removal modal and related controls while deletions are in progress, preventing user interaction.
- Provide success, partial failure, and failure notifications based on batched deletion outcomes, including error messaging.
- Ensure the Systems nested tab is re-selected after operations by wiring tab clicks through the main remediation details route.

Tests:
- Extend and add tests for the system removal modal and confirmation hook to cover loading/disabled states, tab navigation, and batched deletion behavior.