### PR TITLE
feat(RHINENG-25725): Make PlanSummaryCharts dark-mode-friendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@data-driven-forms/pf4-component-mapper": "^4.1.15",
         "@data-driven-forms/react-form-renderer": "^4.1.13",
         "@patternfly/patternfly": "^6.4.0",
-        "@patternfly/react-charts": "^7.4.9",
+        "@patternfly/react-charts": "^8.4.1",
         "@patternfly/react-component-groups": "^6.4.0",
         "@patternfly/react-core": "^6.4.2",
         "@patternfly/react-icons": "^6.4.0",
@@ -4371,14 +4371,21 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "7.4.9",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.4.1.tgz",
+      "integrity": "sha512-kqP5TFr9F/SDTp+nXfcX8gMuZIQ6Uxl55qqiWYgR2zflo0UZWnyL/d2s1fI6Bfi5IuycNdlvJJ/i8QdOsLr5mw==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
+        "@patternfly/react-styles": "^6.4.0",
+        "@patternfly/react-tokens": "^6.4.0",
         "hoist-non-react-statics": "^3.3.2",
-        "lodash": "^4.17.21",
-        "tslib": "^2.7.0",
+        "lodash": "^4.17.23",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "echarts": "^5.6.0 || ^6.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19",
         "victory-area": "^37.3.6",
         "victory-axis": "^37.3.6",
         "victory-bar": "^37.3.6",
@@ -4397,18 +4404,62 @@
         "victory-voronoi-container": "^37.3.6",
         "victory-zoom-container": "^37.3.6"
       },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
+      "peerDependenciesMeta": {
+        "echarts": {
+          "optional": true
+        },
+        "victory-area": {
+          "optional": true
+        },
+        "victory-axis": {
+          "optional": true
+        },
+        "victory-bar": {
+          "optional": true
+        },
+        "victory-box-plot": {
+          "optional": true
+        },
+        "victory-chart": {
+          "optional": true
+        },
+        "victory-core": {
+          "optional": true
+        },
+        "victory-create-container": {
+          "optional": true
+        },
+        "victory-cursor-container": {
+          "optional": true
+        },
+        "victory-group": {
+          "optional": true
+        },
+        "victory-legend": {
+          "optional": true
+        },
+        "victory-line": {
+          "optional": true
+        },
+        "victory-pie": {
+          "optional": true
+        },
+        "victory-scatter": {
+          "optional": true
+        },
+        "victory-stack": {
+          "optional": true
+        },
+        "victory-tooltip": {
+          "optional": true
+        },
+        "victory-voronoi-container": {
+          "optional": true
+        },
+        "victory-zoom-container": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-styles": {
-      "version": "5.4.1",
-      "license": "MIT"
-    },
-    "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-tokens": {
-      "version": "5.4.1",
-      "license": "MIT"
     },
     "node_modules/@patternfly/react-component-groups": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@data-driven-forms/pf4-component-mapper": "^4.1.15",
     "@data-driven-forms/react-form-renderer": "^4.1.13",
     "@patternfly/patternfly": "^6.4.0",
-    "@patternfly/react-charts": "^7.4.9",
+    "@patternfly/react-charts": "^8.4.1",
     "@patternfly/react-component-groups": "^6.4.0",
     "@patternfly/react-core": "^6.4.2",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/components/RemediationWizard.test.js
+++ b/src/components/RemediationWizard.test.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
 
-jest.mock('@patternfly/react-charts', () => {
+jest.mock('@patternfly/react-charts/victory', () => {
   const React = require('react');
   const PropTypes = require('prop-types');
   const ChartBullet = (props) =>

--- a/src/components/RemediationWizard/PlanSummaryCharts.js
+++ b/src/components/RemediationWizard/PlanSummaryCharts.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
+import { ChartAxis, ChartBullet } from '@patternfly/react-charts/victory';
 import { pluralize } from '../../Utilities/utils';
 import { renderChartSkeleton } from '../helpers';
 import propTypes from 'prop-types';
@@ -27,6 +27,19 @@ export const PlanSummaryCharts = ({
     detailsLoading && isExistingPlanSelected
       ? { default: 'row' }
       : { default: 'column', md: 'row' };
+  const chartContainerStyle = {
+    maxWidth: 'fit-content',
+    '--pf-v6-chart-global--label--Fill':
+      'var(--pf-t--global--text--color--regular)',
+    '--pf-v6-chart-bullet--label--title--Fill':
+      'var(--pf-t--global--text--color--regular)',
+    '--pf-v6-chart-axis--tick-label--Fill':
+      'var(--pf-t--global--text--color--subtle)',
+    '--pf-v6-chart-axis--axis--stroke--Color':
+      'var(--pf-t--global--border--color--default)',
+    '--pf-v6-chart-axis--tick--stroke--Color':
+      'var(--pf-t--global--border--color--default)',
+  };
 
   return (
     <Flex
@@ -43,10 +56,7 @@ export const PlanSummaryCharts = ({
               renderChartSkeleton()
             ) : (
               <>
-                <div
-                  id="actions-chart-container"
-                  style={{ maxWidth: 'fit-content' }}
-                >
+                <div id="actions-chart-container" style={chartContainerStyle}>
                   <ChartBullet
                     ariaDesc="Action points bullet chart"
                     ariaTitle="Action points"
@@ -67,7 +77,7 @@ export const PlanSummaryCharts = ({
                       }
                       return `${datum.name}: ${datum.y}`;
                     }}
-                    {...(actionsExceedsLimit && { themeColor: 'gold' })}
+                    {...(actionsExceedsLimit && { themeColor: 'yellow' })}
                     height={120}
                     padding={{
                       bottom: 50,
@@ -119,10 +129,7 @@ export const PlanSummaryCharts = ({
             {detailsLoading && isExistingPlanSelected ? (
               renderChartSkeleton()
             ) : (
-              <div
-                id="systems-chart-container"
-                style={{ maxWidth: 'fit-content' }}
-              >
+              <div id="systems-chart-container" style={chartContainerStyle}>
                 <ChartBullet
                   ariaDesc="Systems bullet chart"
                   ariaTitle="Systems"
@@ -140,7 +147,7 @@ export const PlanSummaryCharts = ({
                     }
                     return `${datum.name}: ${datum.y}`;
                   }}
-                  {...(systemsExceedsLimit && { themeColor: 'gold' })}
+                  {...(systemsExceedsLimit && { themeColor: 'yellow' })}
                   height={120}
                   padding={{
                     bottom: 50,


### PR DESCRIPTION
# Description

Associated Jira ticket: RHINENG-25725

This PR addresses a dark text coloring within the Bullet Charts for remediation's systems and action points in a **dark mode**, which is un-readable. This required:

- updating `patternfly/react-charts` to `^8.4.1`, as currently used version renders charts in PF5
- to scope in the dependency import from `patternfly/react-charts` to `patternfly/react-charts/victory`, which is the PF6 import path for Victory-based charts, in order to import charts more explicitly as recommended in [PF6 upgrade guide](https://www.patternfly.org/get-started/upgrade)
- to rename the chart `themeColor` from `gold` to `yellow` -> gold was renamed to yellow in newer versions of `patternfly/react-charts`
- adding a local chart-container override of text stylings, mapping them to PF6 semantics tokens (`regular`, `subtle` and `default`) which are dark-mode-friendly -> current PF charts still resolve `ChartBullet` title styling through `ChartBulletStyles.label.title` -> `chart_bullet_label_title_Fill`, and the published token fallback is still a fixed light-theme value (`#1f1f1f`)


# How to test the PR

Check that bullet charts are visually correctly displayed in both dark and light mode at two places:

- Modal dialog for creating remediation plan (reachable through Advisor, Vulnerability, Compliance or Patch).
- Remediation plan's detail page > _Planned remediations_ tab

# Before the change
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/4bc8a1c2-14a9-4822-9daf-3b9621c54adf" />
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/b2418762-5146-45e0-b37c-9b00ceb6b983" />



# After the change
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/c6cf3c37-9993-4c0f-a8f0-90c517b8bfb7" />
<img width="2508" height="1388" alt="image" src="https://github.com/user-attachments/assets/05bc0737-1faf-4b64-98ae-22be2d77fe54" />




# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Improve remediation plan summary bullet charts to support dark mode and align with PatternFly 6 chart styling.

Bug Fixes:
- Fix unreadable text and styling in remediation plan summary bullet charts when using dark mode.

Enhancements:
- Apply shared chart container styling using PatternFly 6 semantic tokens for labels and axes in remediation plan summary charts.
- Update bullet chart color usage from the deprecated gold themeColor to yellow for limit-exceeding states.

Build:
- Upgrade @patternfly/react-charts dependency to version ^8.4.1 to use the PatternFly 6 Victory-based chart implementation.