### PR TITLE
chore(RHINENG-26165): Remove RHC manager from readiness check

### DIFF
--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -84,15 +84,6 @@ const ProgressCard = ({
     exceedsExecutionLimits,
   ]);
 
-  const isRhcNotEnabled = useMemo(() => {
-    const error = remediationStatus?.connectionError?.errors?.[0];
-    return (
-      error?.status === 403 ||
-      error?.status === 503 ||
-      error?.code === 'DEPENDENCY_UNAVAILABLE'
-    );
-  }, [remediationStatus?.connectionError]);
-
   const popoverState = { openPopover, setOpenPopover };
 
   const executionLimitsPopoverContent = (
@@ -225,47 +216,6 @@ const ProgressCard = ({
     </Flex>
   );
 
-  const rhcPopoverContent = (
-    <Flex
-      direction={{ default: 'column' }}
-      spaceItems={{ default: 'spaceItemsMd' }}
-    >
-      <Title headingLevel="h4">Remote Host Configuration Manager</Title>
-      <Content>
-        <p>
-          To allow users to execute a remediation plan on a remote system from{' '}
-          Red Hat Lightspeed, you must configure the Remote Host Configuration
-          Manager settings in the Lightspeed UI. You can find the settings in
-          the console under Inventory &gt; System Configurations &gt; Remote
-          Host Configuration.
-        </p>
-      </Content>
-      <Flex
-        direction={{ default: 'row' }}
-        spaceItems={{ default: 'spaceItemsSm' }}
-      >
-        <Button
-          variant="secondary"
-          onClick={() =>
-            quickStarts?.activateQuickstart('insights-remediate-plan-create')
-          }
-        >
-          Open the quick start
-        </Button>
-        <Button
-          variant="link"
-          icon={<ExternalLinkAltIcon />}
-          component="a"
-          href="https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/remote_host_configuration_and_management/index"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Go to documentation
-        </Button>
-      </Flex>
-    </Flex>
-  );
-
   return permissions === undefined || remediationStatus.areDetailsLoading ? (
     <Spinner />
   ) : (
@@ -347,45 +297,6 @@ const ProgressCard = ({
                 'permissionsStep',
                 'User access permissions',
                 permissionsPopoverContent,
-                popoverState,
-              )}
-            </span>
-          </ProgressStep>
-          <ProgressStep
-            variant={isRhcNotEnabled ? 'danger' : 'success'}
-            description={
-              <span className="pf-v6-u-color-100">
-                {isRhcNotEnabled ? (
-                  <>
-                    RHC Manager is not enabled. Enable it in&nbsp;
-                    <a
-                      href="https://console.redhat.com/insights/connector"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        textDecoration: 'underline',
-                        color:
-                          'var(--pf-t--global--text--color--link--default, #0066cc)',
-                      }}
-                    >
-                      Remote Host Configuration
-                    </a>
-                    .
-                  </>
-                ) : (
-                  'Enabled'
-                )}
-              </span>
-            }
-            id="RHCStep"
-            titleId="RHCStep-title"
-            aria-label="RHCStep2"
-          >
-            <span className="pf-v6-u-color-100">
-              {renderStepTitleWithPopover(
-                'RHCStep',
-                'Remote Host Configuration Manager',
-                rhcPopoverContent,
                 popoverState,
               )}
             </span>

--- a/src/routes/RemediationDetailsComponents/ProgressCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.test.js
@@ -370,11 +370,11 @@ describe('ProgressCard', () => {
   });
 
   describe('Progress steps', () => {
-    it('should render all four progress steps', () => {
+    it('should render all three progress steps', () => {
       render(<ProgressCard {...defaultProps} />);
 
       const steps = screen.getAllByTestId('progress-step');
-      expect(steps).toHaveLength(4);
+      expect(steps).toHaveLength(3);
     });
 
     describe('User access permissions step', () => {
@@ -431,130 +431,6 @@ describe('ProgressCard', () => {
       });
     });
 
-    describe('RHC Manager step', () => {
-      it('should show success variant when no 403 error', () => {
-        render(
-          <ProgressCard
-            {...defaultProps}
-            remediationStatus={{
-              ...defaultProps.remediationStatus,
-              connectionError: null,
-            }}
-          />,
-        );
-
-        const steps = screen.getAllByTestId('progress-step');
-        const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-        expect(rhcStep).toHaveAttribute('data-variant', 'success');
-        expect(
-          screen.getByText('Remote Host Configuration Manager'),
-        ).toBeInTheDocument();
-        expect(screen.getByText('Enabled')).toBeInTheDocument();
-      });
-
-      it('should show success variant when error is not 403', () => {
-        render(
-          <ProgressCard
-            {...defaultProps}
-            remediationStatus={{
-              ...defaultProps.remediationStatus,
-              connectionError: { errors: [{ status: 500 }] },
-            }}
-          />,
-        );
-
-        const steps = screen.getAllByTestId('progress-step');
-        const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-        expect(rhcStep).toHaveAttribute('data-variant', 'success');
-        expect(screen.getByText('Enabled')).toBeInTheDocument();
-      });
-
-      it('should show danger variant when error is 403', () => {
-        render(
-          <ProgressCard
-            {...defaultProps}
-            remediationStatus={{
-              ...defaultProps.remediationStatus,
-              connectionError: { errors: [{ status: 403 }] },
-            }}
-          />,
-        );
-
-        const steps = screen.getAllByTestId('progress-step');
-        const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-        expect(rhcStep).toHaveAttribute('data-variant', 'danger');
-        expect(
-          screen.getByText(/RHC Manager is not enabled/),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByText('Remote Host Configuration'),
-        ).toBeInTheDocument();
-      });
-
-      it('should show danger variant when error code is DEPENDENCY_UNAVAILABLE', () => {
-        render(
-          <ProgressCard
-            {...defaultProps}
-            remediationStatus={{
-              ...defaultProps.remediationStatus,
-              connectionError: {
-                errors: [
-                  {
-                    status: 503,
-                    code: 'DEPENDENCY_UNAVAILABLE',
-                    title:
-                      'Internal service dependency is temporarily unavailable.',
-                  },
-                ],
-              },
-            }}
-          />,
-        );
-
-        const steps = screen.getAllByTestId('progress-step');
-        const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-        expect(rhcStep).toHaveAttribute('data-variant', 'danger');
-        expect(
-          screen.getByText(/RHC Manager is not enabled/),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByText('Remote Host Configuration'),
-        ).toBeInTheDocument();
-      });
-
-      it('should render external link when RHC is not enabled', () => {
-        render(
-          <ProgressCard
-            {...defaultProps}
-            remediationStatus={{
-              ...defaultProps.remediationStatus,
-              connectionError: { errors: [{ status: 403 }] },
-            }}
-          />,
-        );
-
-        const link = screen.getByRole('link', {
-          name: /Remote Host Configuration/,
-        });
-        expect(link).toHaveAttribute(
-          'href',
-          'https://console.redhat.com/insights/connector',
-        );
-        expect(link).toHaveAttribute('target', '_blank');
-        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-      });
-
-      it('should have correct accessibility attributes', () => {
-        render(<ProgressCard {...defaultProps} />);
-
-        const steps = screen.getAllByTestId('progress-step');
-        const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-        expect(rhcStep).toHaveAttribute('data-id', 'RHCStep');
-        expect(rhcStep).toHaveAttribute('data-title-id', 'RHCStep-title');
-        expect(rhcStep).toHaveAttribute('aria-label', 'RHCStep2');
-      });
-    });
-
     describe('Connected systems step', () => {
       it('should show success variant when connected systems > 0', () => {
         render(
@@ -568,7 +444,7 @@ describe('ProgressCard', () => {
         );
 
         const steps = screen.getAllByTestId('progress-step');
-        const systemsStep = steps[3]; // connectedSystemsStep is now fourth (last)
+        const systemsStep = steps[2];
         expect(systemsStep).toHaveAttribute('data-variant', 'success');
         expect(
           screen.getByText('Systems connected to Red Hat Lightspeed'),
@@ -590,7 +466,7 @@ describe('ProgressCard', () => {
         );
 
         const steps = screen.getAllByTestId('progress-step');
-        const systemsStep = steps[3]; // connectedSystemsStep is now fourth (last)
+        const systemsStep = steps[2];
         expect(systemsStep).toHaveAttribute('data-variant', 'danger');
         expect(screen.getByText(/No connected systems/)).toBeInTheDocument();
       });
@@ -627,7 +503,7 @@ describe('ProgressCard', () => {
         render(<ProgressCard {...defaultProps} />);
 
         const steps = screen.getAllByTestId('progress-step');
-        const systemsStep = steps[3]; // connectedSystemsStep is now fourth (last)
+        const systemsStep = steps[2];
         expect(systemsStep).toHaveAttribute('data-id', 'connectedSystemsStep');
         expect(systemsStep).toHaveAttribute(
           'data-title-id',
@@ -715,21 +591,6 @@ describe('ProgressCard', () => {
       ).toBeInTheDocument();
     });
 
-    it('should handle complex connectionError values', () => {
-      render(
-        <ProgressCard
-          {...defaultProps}
-          remediationStatus={{
-            ...defaultProps.remediationStatus,
-            connectionError: { errors: [{ status: '403' }] },
-          }}
-        />,
-      );
-
-      const steps = screen.getAllByTestId('progress-step');
-      const rhcStep = steps[2]; // RHCStep is now third (after executionLimitsStep and permissionsStep)
-      expect(rhcStep).toHaveAttribute('data-variant', 'success'); // '403' !== 403
-    });
   });
 
   describe('Component styling and classes', () => {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-26165 

There should be no other changes than in the details page -> readiness check section. There should no longer be any referral of RHC manager in the readiness check. This removes the step as well as the test related too it

The app itself is going to be deprecated, this is just phase 1
## Summary by Sourcery

Remove the Remote Host Configuration (RHC) manager readiness step from the remediation details progress card.

Enhancements:
- Simplify the remediation readiness progress indicator by dropping the RHC manager step and related state handling.

Tests:
- Update readiness progress tests to expect three steps and remove scenarios covering the RHC manager step.