### PR TITLE
feat(RHINENG-26786): Adjust to new semantics of manageable field of Column Manager

### DIFF
--- a/src/routes/Columns.js
+++ b/src/routes/Columns.js
@@ -16,7 +16,6 @@ export const Name = {
   sortable: 'name',
   exportKey: 'name',
   Component: NameCell,
-  manageable: false,
 };
 
 export const LastExecuted = {

--- a/src/routes/RemediationDetailsComponents/ActionsContent/Columns.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/Columns.js
@@ -12,7 +12,6 @@ export default [
     transforms: [wrappable],
     exportKey: 'action',
     Component: ActionsCell,
-    manageable: false,
   },
   {
     title: 'Reboot required',


### PR DESCRIPTION
# Description

Associated Jira ticket: # RHINENG-26786

TableTools' Column Manager changed the semantics of columns' `manageable` field in https://github.com/bastilian/tabletools/pull/96. This hasn't been addressed in consuming Remediations frontend repo, which introduced a regression in Column Manager functionality after updating to newer version of tabletools (https://github.com/RedHatInsights/insights-remediations-frontend/pull/786).

The new version of tabletools' Column Manager filters out columns with `manageable:false`, and makes fixedly the first column "untoggleable".


# How to test the PR

Visit `Remediations List page` and `Remediations Detail page > Planned remediations > Actions table`, and verify that all table columns are listed in the Column Manager modal.

# Before the change
<img width="1875" height="1122" alt="image" src="https://github.com/user-attachments/assets/7649f7af-d500-4903-b234-50a1d9c93c1d" />
<img width="1875" height="1122" alt="image" src="https://github.com/user-attachments/assets/fb5fc59c-0a74-4fb5-8458-1a07d4f13e20" />



# After the change
<img width="1875" height="1122" alt="Screenshot From 2026-06-03 13-25-58" src="https://github.com/user-attachments/assets/170ec032-3526-4473-a540-35229f627d16" />
<img width="1875" height="1122" alt="Screenshot From 2026-06-03 13-26-12" src="https://github.com/user-attachments/assets/29d21372-380e-4438-ac5c-1f054f141235" />

# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Align column configurations with updated Column Manager semantics so all expected columns appear in the Column Manager UI.

Bug Fixes:
- Ensure the Name column in the Remediations list is manageable and visible in the Column Manager.
- Ensure the Action column in the Planned remediations Actions table is manageable and visible in the Column Manager.