### PR TITLE
feat(RHINENG-26165): Fix readiness errors count

### DIFF
--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -44,10 +44,7 @@ const DetailsGeneralContent = ({
 
   const canExecute =
     permissions?.execute &&
-    remediationStatus?.connectionError?.errors?.[0]?.status !== 403 &&
-    remediationStatus?.connectionError?.errors?.[0]?.status !== 503 &&
-    remediationStatus?.connectionError?.errors?.[0]?.code !==
-      'DEPENDENCY_UNAVAILABLE' &&
+    !remediationStatus?.connectionError &&
     remediationStatus?.connectedSystems !== 0 &&
     !exceedsExecutionLimits;
 

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -455,11 +455,11 @@ describe('DetailsGeneralContent', () => {
       const testCases = [
         {
           connectionError: { errors: [{ status: 500 }] },
-          expectedReadyOrNot: true,
+          expectedReadyOrNot: false,
         },
         {
           connectionError: { errors: [{ status: 404 }] },
-          expectedReadyOrNot: true,
+          expectedReadyOrNot: false,
         },
         {
           connectionError: { errors: [{ status: 403 }] },
@@ -477,7 +477,7 @@ describe('DetailsGeneralContent', () => {
         },
         {
           connectionError: { errors: [{ status: 0 }] },
-          expectedReadyOrNot: true,
+          expectedReadyOrNot: false,
         },
         { connectionError: null, expectedReadyOrNot: true },
         { connectionError: undefined, expectedReadyOrNot: true },

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -303,11 +303,16 @@ const ProgressCard = ({
           </ProgressStep>
           <ProgressStep
             variant={
-              remediationStatus?.connectedSystems !== 0 ? 'success' : 'danger'
+              !remediationStatus?.connectionError &&
+              remediationStatus?.connectedSystems !== 0
+                ? 'success'
+                : 'danger'
             }
             description={
               <div className="pf-v6-u-color-100">
-                {remediationStatus?.connectedSystems === 0 ? (
+                {remediationStatus?.connectionError ? (
+                  <>Couldn&apos;t verify connection status.</>
+                ) : remediationStatus?.connectedSystems === 0 ? (
                   <>
                     No connected systems. You must connect one or more systems
                     to execute this plan. Review the{' '}
@@ -347,7 +352,8 @@ const ProgressCard = ({
                 'Systems connected to Red Hat Lightspeed',
                 connectedSystemsPopoverContent,
                 popoverState,
-                remediationStatus?.connectedSystems === 0,
+                remediationStatus?.connectedSystems === 0 ||
+                  remediationStatus?.connectionError,
               )}
             </span>
           </ProgressStep>

--- a/src/routes/RemediationDetailsComponents/ProgressCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.test.js
@@ -590,7 +590,6 @@ describe('ProgressCard', () => {
         ),
       ).toBeInTheDocument();
     });
-
   });
 
   describe('Component styling and classes', () => {

--- a/src/routes/RemediationDetailsComponents/helpers.js
+++ b/src/routes/RemediationDetailsComponents/helpers.js
@@ -168,14 +168,10 @@ export const calculateReadinessErrorCount = ({
 }) => {
   let count = 0;
   if (!hasExecutePermission) count++;
-  const error = connectionError?.errors?.[0];
-  if (
-    error?.status === 403 ||
-    error?.status === 503 ||
-    error?.code === 'DEPENDENCY_UNAVAILABLE'
-  )
-    count++;
-  if (connectedSystems === 0) count++;
+  // connection_status API call can fail and thus number of connected systems will be unknown
+  // OR connection_status API call can succed and return 0 connected systems
+  // Both cases are treated as error (+1 for the count), but ProgressCard will show different error message
+  if (connectionError || connectedSystems === 0) count++;
   if (exceedsExecutionLimits) count++;
   return count;
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: This PR addresses verification findings in the [RHINENG-26165](https://redhat.atlassian.net/browse/RHINENG-26165)

1. Error counter in the uppter-right corner of the _Execution readiness summary_ card on the Remediation Detail page displayed 1 more error than there actually were. This was caused by recent removal of the RHC Manager readiness check (RHC Manager is going to be decommissioned) - the related `calculateReadinessErrorCount` function still checked whether connection_status endpoint fails, and if so, it added +1 to the count of the errors (failure of connection_status API call was indicator for failing the RHC Manager readiness check).
 
2. The _Connected systems_ readiness check is evaluated based on number of connected systems. This is calculated from the connection_status API endpoint's returned data. If this endpoint fails, the number of connected systems will be 0, and therefore the _Connected systems_ check will be displayed as failure, even though there are connected systems. This PR introduces logic that distinquish between _"failed API request"_ and _"actually 0 connected systems"_. Both conditions will make the _Connected systems_ readiness check fail, but user will be prompted different, more precise message underneath. One way of how to reproduce this is to remove `remediations:execute` RBAC permission for the user -> the connection_status will return 403.


# How to test the PR

Visit detail page for the remediation, and try to tigger different states of the readiness checks. Verify that rediness checks and numbre of errors are correctly evaluated.

# Before the change

**1. Number of errors**
<img width="1103" height="440" alt="Screenshot From 2026-06-04 20-12-32" src="https://github.com/user-attachments/assets/3a880f76-5d0b-43e2-b727-01457dae3f22" />
<img width="1087" height="401" alt="Screenshot From 2026-06-04 20-04-09" src="https://github.com/user-attachments/assets/e171eef2-d620-4def-b6cf-96631822dfa7" />

**2. Connected systems** - if connection_status failed, the check would fail and it'd say that systems are not connected, even if they were
<img width="1087" height="401" alt="Screenshot From 2026-06-04 20-04-09" src="https://github.com/user-attachments/assets/a1aa20c6-4f05-43eb-975a-148a2d718aa3" />


# After the change

**1. Number of errors**
<img width="1093" height="637" alt="Screenshot From 2026-06-05 16-26-34" src="https://github.com/user-attachments/assets/f7835166-fa70-4d8c-b480-e83d9a16a839" />
<img width="1093" height="637" alt="Screenshot From 2026-06-05 16-25-50" src="https://github.com/user-attachments/assets/83eabcd2-7169-4d10-9d65-356b0190182e" />

**2. Connected systems** - if connection_status fails, the check will fail, and it will say that it couldn't verify the connection
<img width="1093" height="637" alt="image" src="https://github.com/user-attachments/assets/7ec1adc6-94ae-46e1-b238-cf1366f60e43" />



# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[RHINENG-26165]: https://redhat.atlassian.net/browse/RHINENG-26165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust remediation readiness evaluation to treat any connection_status failure as an execution blocker while differentiating its messaging from truly zero connected systems.

Bug Fixes:
- Correct readiness error count by counting connection_status failures and zero connected systems as a single readiness issue rather than separate checks.
- Ensure the Connected systems readiness step shows a specific message when connection status cannot be verified instead of implying no systems are connected.
- Update execution permission logic so any connection_status error prevents plan execution, aligning UI readiness state with backend errors.

Tests:
- Adapt readiness-related tests to expect non-ready state for all connection_status failures regardless of HTTP status code.