### PR TITLE
fix(RHINENG-26336): dark mode fixes

### DIFF
--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -144,7 +144,7 @@ export const ExecuteModal = ({
           title: `Executing playbook ${remediation.name}`,
           description: (
             <span>
-              View results in the <b>Execution History tab</b>
+              View results in the <b>Execution history tab</b>
             </span>
           ),
           variant: 'success',

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -9,6 +9,7 @@ import {
   HintTitle,
   Skeleton,
   Spinner,
+  Tooltip,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import React from 'react';
@@ -122,14 +123,16 @@ export const renderPreviewAlert = ({
           alignItems={{ default: 'alignItemsCenter' }}
           className="pf-v6-u-mt-sm"
         >
-          <Button
-            variant="link"
-            icon={<DownloadIcon />}
-            onClick={onPreviewClick}
-            isDisabled={!hasPlanSelection || previewLoading}
-          >
-            Download preview
-          </Button>
+          <Tooltip content="Enter a new plan name or select an existing plan.">
+            <Button
+              variant="link"
+              icon={<DownloadIcon />}
+              onClick={onPreviewClick}
+              isDisabled={!hasPlanSelection || previewLoading}
+            >
+              Download preview
+            </Button>
+          </Tooltip>
           {previewLoading && <Spinner size="sm" />}
           {previewStatus && !previewLoading && (
             <Alert

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -204,7 +204,7 @@ const RemediationDetails = () => {
             <Tab
               eventKey={'executionHistory'}
               aria-label="ExecutionHistoryTab"
-              title={<TabTitleText>Execution History</TabTitleText>}
+              title={<TabTitleText>Execution history</TabTitleText>}
             >
               <ExecutionHistoryTab
                 remediationPlaybookRuns={remediationPlaybookRuns}

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ResolutionOptionsModal.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ResolutionOptionsModal.js
@@ -142,12 +142,6 @@ const ResolutionOptionsModal = ({
                   style={{ fontSize: '14px' }}
                 >
                   Select resolution{' '}
-                  <span
-                    style={{ color: '#c9190b', display: 'inline' }}
-                    aria-label="required"
-                  >
-                    *
-                  </span>
                 </span>
               </FlexItem>
               <FlexItem>
@@ -163,7 +157,7 @@ const ResolutionOptionsModal = ({
                 >
                   <Button
                     variant="plain"
-                    icon={<OutlinedQuestionCircleIcon color="#6a6e73" />}
+                    icon={<OutlinedQuestionCircleIcon />}
                     aria-label="Select resolution help"
                     hasNoPadding
                   />

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.js
@@ -48,9 +48,16 @@ const statusIcon = (status) => {
   return map[status] ?? <QuestionCircleIcon />;
 };
 
-const cardStyle = {
+const flexItemStyle = {
   flex: '1 1 0',
+  display: 'flex',
 };
+
+const cardStyle = {
+  minWidth: '12rem',
+  minHeight: '10rem',
+};
+
 const LogCards = ({ systemName, status, connectionType, executedBy }) => {
   const connectionTypeTitle = 'Red Hat Lightspeed connection type';
 
@@ -67,15 +74,15 @@ const LogCards = ({ systemName, status, connectionType, executedBy }) => {
       className="pf-v6-u-mb-lg"
       data-testid="flex"
     >
-      <FlexItem style={cardStyle} data-testid="flex-item">
-        <Card isFullHeight data-testid="card">
+      <FlexItem style={flexItemStyle} data-testid="flex-item">
+        <Card isFullHeight style={cardStyle} data-testid="card">
           <CardTitle>System</CardTitle>
           <CardBody data-testid="card-body">{systemName ?? '-'}</CardBody>
         </Card>
       </FlexItem>
 
-      <FlexItem style={cardStyle} data-testid="flex-item">
-        <Card isFullHeight data-testid="card">
+      <FlexItem style={flexItemStyle} data-testid="flex-item">
+        <Card isFullHeight style={cardStyle} data-testid="card">
           <CardTitle>System execution status</CardTitle>
           <CardBody data-testid="card-body">
             <Flex
@@ -92,8 +99,8 @@ const LogCards = ({ systemName, status, connectionType, executedBy }) => {
         </Card>
       </FlexItem>
 
-      <FlexItem style={cardStyle} data-testid="flex-item">
-        <Card isFullHeight data-testid="card">
+      <FlexItem style={flexItemStyle} data-testid="flex-item">
+        <Card isFullHeight style={cardStyle} data-testid="card">
           <CardTitle>
             <Flex
               spaceItems={{ default: 'spaceItemsXs' }}
@@ -118,8 +125,8 @@ const LogCards = ({ systemName, status, connectionType, executedBy }) => {
         </Card>
       </FlexItem>
 
-      <FlexItem style={cardStyle} data-testid="flex-item">
-        <Card isFullHeight data-testid="card">
+      <FlexItem style={flexItemStyle} data-testid="flex-item">
+        <Card isFullHeight style={cardStyle} data-testid="card">
           <CardTitle>Executed by user</CardTitle>
           <CardBody data-testid="card-body">{executedBy ?? '-'}</CardBody>
         </Card>

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.test.js
@@ -1,108 +1,7 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import LogCards from './LogCards';
-import { capitalize } from '../../../Utilities/utils';
-
-// Mock PatternFly components
-jest.mock('@patternfly/react-core', () => ({
-  Card: function MockCard({ isFullHeight, children, style, ...props }) {
-    return (
-      <div
-        data-testid="card"
-        data-full-height={isFullHeight}
-        style={style}
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  },
-  CardBody: function MockCardBody({ children, ...props }) {
-    return (
-      <div data-testid="card-body" {...props}>
-        {children}
-      </div>
-    );
-  },
-  CardTitle: function MockCardTitle({ children, ...props }) {
-    return (
-      <div data-testid="card-title" {...props}>
-        {children}
-      </div>
-    );
-  },
-  Flex: function MockFlex({
-    spaceItems,
-    alignItems,
-    flexWrap,
-    className,
-    children,
-    ...props
-  }) {
-    return (
-      <div
-        data-testid="flex"
-        data-space-items={JSON.stringify(spaceItems)}
-        data-align-items={JSON.stringify(alignItems)}
-        data-flex-wrap={JSON.stringify(flexWrap)}
-        className={className}
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  },
-  FlexItem: function MockFlexItem({ style, children, ...props }) {
-    return (
-      <div data-testid="flex-item" style={style} {...props}>
-        {children}
-      </div>
-    );
-  },
-  Tooltip: function MockTooltip({ content, children, ...props }) {
-    return (
-      <div data-testid="tooltip" data-content={content} {...props}>
-        {children}
-      </div>
-    );
-  },
-}));
-
-jest.mock('@patternfly/react-icons', () => ({
-  CheckCircleIcon: function MockCheckCircleIcon({ color, ...props }) {
-    return (
-      <span data-testid="check-circle-icon" data-color={color} {...props} />
-    );
-  },
-  InProgressIcon: function MockInProgressIcon({ color, ...props }) {
-    return (
-      <span data-testid="in-progress-icon" data-color={color} {...props} />
-    );
-  },
-  ExclamationCircleIcon: function MockExclamationCircleIcon({
-    color,
-    ...props
-  }) {
-    return (
-      <span
-        data-testid="exclamation-circle-icon"
-        data-color={color}
-        {...props}
-      />
-    );
-  },
-  BanIcon: function MockBanIcon({ color, ...props }) {
-    return <span data-testid="ban-icon" data-color={color} {...props} />;
-  },
-  QuestionCircleIcon: function MockQuestionCircleIcon(props) {
-    return <span data-testid="question-circle-icon" {...props} />;
-  },
-  OutlinedQuestionCircleIcon: function MockOutlinedQuestionCircleIcon(props) {
-    return <span data-testid="outlined-question-circle-icon" {...props} />;
-  },
-}));
 
 describe('LogCards', () => {
   const defaultProps = {
@@ -112,429 +11,136 @@ describe('LogCards', () => {
     executedBy: 'test-user@example.com',
   };
 
-  describe('Basic rendering', () => {
-    it('should render without crashing', () => {
-      render(<LogCards {...defaultProps} />);
+  it('renders all card labels and provided values', () => {
+    render(<LogCards {...defaultProps} />);
 
-      expect(screen.getAllByTestId('flex')).toHaveLength(3); // Main flex + 2 nested flex
-      expect(screen.getAllByTestId('card')).toHaveLength(4);
+    expect(screen.getByText('System')).toBeInTheDocument();
+    expect(screen.getByText('test-system.example.com')).toBeInTheDocument();
+
+    expect(screen.getByText('System execution status')).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByTestId('check-circle-icon')).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Red Hat Lightspeed connection type/),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Rhc connected')).toBeInTheDocument();
+
+    expect(screen.getByText('Executed by user')).toBeInTheDocument();
+    expect(screen.getByText('test-user@example.com')).toBeInTheDocument();
+  });
+
+  it('renders dashes when no props are provided', () => {
+    render(<LogCards />);
+
+    expect(screen.getAllByText('-')).toHaveLength(4);
+  });
+
+  it('renders dashes when all props are null', () => {
+    render(
+      <LogCards
+        systemName={null}
+        status={null}
+        connectionType={null}
+        executedBy={null}
+      />,
+    );
+
+    expect(screen.getAllByText('-')).toHaveLength(4);
+  });
+
+  describe('status display', () => {
+    it.each([
+      ['success', 'Success', 'check-circle-icon'],
+      ['running', 'Running', 'in-progress-icon'],
+      ['failure', 'Failure', 'exclamation-circle-icon'],
+      ['canceled', 'Canceled', 'ban-icon'],
+    ])('shows %s status with label and icon', (status, label, iconTestId) => {
+      render(<LogCards {...defaultProps} status={status} />);
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.getByTestId(iconTestId)).toBeInTheDocument();
     });
 
-    it('should render all four cards', () => {
-      render(<LogCards {...defaultProps} />);
+    it('shows a fallback label for unknown status values', () => {
+      render(<LogCards {...defaultProps} status="unknown" />);
 
-      const cards = screen.getAllByTestId('card');
-      expect(cards).toHaveLength(4);
-
-      // Check that all cards are full height
-      cards.forEach((card) => {
-        expect(card).toHaveAttribute('data-full-height', 'true');
-      });
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
     });
 
-    it('should render correct card titles', () => {
-      render(<LogCards {...defaultProps} />);
+    it('capitalizes the first letter of the status label', () => {
+      render(<LogCards {...defaultProps} status="pending" />);
 
-      expect(screen.getByText('System')).toBeInTheDocument();
-      expect(screen.getByText('System execution status')).toBeInTheDocument();
-      expect(
-        screen.getByText(/Red Hat Lightspeed connection type/),
-      ).toBeInTheDocument();
-      expect(screen.getByText('Executed by user')).toBeInTheDocument();
+      expect(screen.getByText('Pending')).toBeInTheDocument();
     });
   });
 
-  describe('System card', () => {
-    it('should display system name', () => {
-      render(<LogCards {...defaultProps} />);
-
-      expect(screen.getByText('test-system.example.com')).toBeInTheDocument();
-    });
-
-    it('should display dash when system name is null', () => {
-      render(<LogCards {...defaultProps} systemName={null} />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[0]).toHaveTextContent('-');
-    });
-
-    it('should display dash when system name is undefined', () => {
-      render(<LogCards {...defaultProps} systemName={undefined} />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[0]).toHaveTextContent('-');
-    });
-
-    it('should display empty string system name', () => {
-      render(<LogCards {...defaultProps} systemName="" />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[0]).toHaveTextContent('');
-    });
-  });
-
-  describe('Status card', () => {
-    describe('Status icons', () => {
-      it('should display success icon for success status', () => {
-        render(<LogCards {...defaultProps} status="success" />);
-
-        expect(screen.getByTestId('check-circle-icon')).toBeInTheDocument();
-        expect(screen.getByTestId('check-circle-icon')).toHaveAttribute(
-          'data-color',
-          'var(--pf-t--global--icon--color--status--success--default)',
-        );
-        expect(screen.getByText('Success')).toBeInTheDocument();
-      });
-
-      it('should display in-progress icon for running status', () => {
-        render(<LogCards {...defaultProps} status="running" />);
-
-        expect(screen.getByTestId('in-progress-icon')).toBeInTheDocument();
-        expect(screen.getByTestId('in-progress-icon')).toHaveAttribute(
-          'data-color',
-          'var(--pf-v6-global--info-color--100)',
-        );
-        expect(screen.getByText('Running')).toBeInTheDocument();
-      });
-
-      it('should display exclamation icon for failure status', () => {
-        render(<LogCards {...defaultProps} status="failure" />);
-
-        expect(
-          screen.getByTestId('exclamation-circle-icon'),
-        ).toBeInTheDocument();
-        expect(screen.getByTestId('exclamation-circle-icon')).toHaveAttribute(
-          'data-color',
-          'var(--pf-t--global--icon--color--status--danger--default)',
-        );
-        expect(screen.getByText('Failure')).toBeInTheDocument();
-      });
-
-      it('should display ban icon for canceled status', () => {
-        render(<LogCards {...defaultProps} status="canceled" />);
-
-        expect(screen.getByTestId('ban-icon')).toBeInTheDocument();
-        expect(screen.getByTestId('ban-icon')).toHaveAttribute(
-          'data-color',
-          'var(--pf-t--global--icon--color--status--danger--default)',
-        );
-        expect(screen.getByText('Canceled')).toBeInTheDocument();
-      });
-
-      it('should display question icon for unknown status', () => {
-        render(<LogCards {...defaultProps} status="unknown" />);
-
-        expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-        expect(screen.getByText('Unknown')).toBeInTheDocument();
-      });
-
-      it('should display question icon for null status', () => {
-        render(<LogCards {...defaultProps} status={null} />);
-
-        expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-        expect(screen.getByText('-')).toBeInTheDocument();
-      });
-
-      it('should display question icon for undefined status', () => {
-        render(<LogCards {...defaultProps} status={undefined} />);
-
-        expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-        expect(screen.getByText('-')).toBeInTheDocument();
-      });
-
-      it('should display question icon for empty string status', () => {
-        render(<LogCards {...defaultProps} status="" />);
-
-        expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-        expect(screen.getByText('-')).toBeInTheDocument();
-      });
-    });
-
-    describe('Status text formatting', () => {
-      it('should capitalize first letter of status', () => {
-        const testCases = [
-          { status: 'success', expected: 'Success' },
-          { status: 'running', expected: 'Running' },
-          { status: 'failure', expected: 'Failure' },
-          { status: 'canceled', expected: 'Canceled' },
-          { status: 'pending', expected: 'Pending' },
-        ];
-
-        testCases.forEach(({ status, expected }) => {
-          const { unmount } = render(
-            <LogCards {...defaultProps} status={status} />,
-          );
-          expect(screen.getByText(expected)).toBeInTheDocument();
-          unmount();
-        });
-      });
-
-      it('should handle single character status', () => {
-        render(<LogCards {...defaultProps} status="a" />);
-        expect(screen.getByText('A')).toBeInTheDocument();
-      });
-
-      it('should handle mixed case status', () => {
-        render(<LogCards {...defaultProps} status="sUcCeSs" />);
-        expect(screen.getByText('SUcCeSs')).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('Connection type card', () => {
-    it('should display connection type', () => {
+  describe('connection type display', () => {
+    it('formats the connection type for display', () => {
       render(<LogCards {...defaultProps} connectionType="satellite" />);
 
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[2]).toHaveTextContent('Satellite connected');
+      expect(screen.getByText('Satellite connected')).toBeInTheDocument();
     });
 
-    it('should display dash when connection type is null', () => {
+    it('shows a dash when connection type is missing', () => {
       render(<LogCards {...defaultProps} connectionType={null} />);
 
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[2]).toHaveTextContent('-');
-    });
-
-    it('should display dash when connection type is undefined', () => {
-      render(<LogCards {...defaultProps} connectionType={undefined} />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[2]).toHaveTextContent('-');
-    });
-
-    it('should display tooltip for connection type', () => {
-      render(<LogCards {...defaultProps} />);
-
-      const tooltip = screen.getByTestId('tooltip');
-      expect(tooltip).toHaveAttribute(
-        'data-content',
-        'Red Hat Enterprise Linux systems are connected to Red Hat Lightspeed directly via RHC, or through Satellite via Cloud Connector.',
-      );
-      expect(
-        screen.getByTestId('outlined-question-circle-icon'),
-      ).toBeInTheDocument();
+      expect(screen.queryByText('Rhc connected')).not.toBeInTheDocument();
+      expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  describe('Executed by card', () => {
-    it('should display executed by user', () => {
+  describe('executed by display', () => {
+    it('shows the executing user', () => {
       render(<LogCards {...defaultProps} executedBy="admin@company.com" />);
 
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[3]).toHaveTextContent('admin@company.com');
+      expect(screen.getByText('admin@company.com')).toBeInTheDocument();
     });
 
-    it('should display dash when executed by is null', () => {
+    it('shows a dash when executed by is missing', () => {
       render(<LogCards {...defaultProps} executedBy={null} />);
 
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[3]).toHaveTextContent('-');
-    });
-
-    it('should display dash when executed by is undefined', () => {
-      render(<LogCards {...defaultProps} executedBy={undefined} />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[3]).toHaveTextContent('-');
-    });
-
-    it('should display empty string executed by', () => {
-      render(<LogCards {...defaultProps} executedBy="" />);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[3]).toHaveTextContent('');
-    });
-  });
-
-  describe('Component structure', () => {
-    it('should render main flex container with correct props', () => {
-      render(<LogCards {...defaultProps} />);
-
-      const mainFlex = screen.getAllByTestId('flex')[0];
-      expect(mainFlex).toHaveAttribute(
-        'data-space-items',
-        '{"default":"spaceItemsLg"}',
-      );
-      expect(mainFlex).toHaveAttribute(
-        'data-align-items',
-        '{"default":"stretch"}',
-      );
-      expect(mainFlex).toHaveAttribute(
-        'data-flex-wrap',
-        '{"default":"nowrap"}',
-      );
-      expect(mainFlex).toHaveClass('pf-v6-u-mb-lg');
-    });
-
-    it('should render four flex items', () => {
-      render(<LogCards {...defaultProps} />);
-
-      const flexItems = screen.getAllByTestId('flex-item');
-      expect(flexItems).toHaveLength(4);
-
-      // Check that all flex items have the correct style
-      flexItems.forEach((item) => {
-        expect(item).toHaveStyle('flex: 1 1 0');
-        expect(item).toHaveStyle('display: flex');
-      });
-
-      const cards = screen.getAllByTestId('card');
-      cards.forEach((card) => {
-        expect(card).toHaveStyle('min-width: 12rem');
-        expect(card).toHaveStyle('min-height: 10rem');
-      });
-    });
-
-    it('should render status card with nested flex for icon and text', () => {
-      render(<LogCards {...defaultProps} />);
-
-      const flexContainers = screen.getAllByTestId('flex');
-      expect(flexContainers).toHaveLength(3); // Main flex + status flex + connection type flex
-
-      // Status card flex should have correct props
-      const statusFlex = flexContainers[1];
-      expect(statusFlex).toHaveAttribute(
-        'data-space-items',
-        '{"default":"spaceItemsXs"}',
-      );
-      expect(statusFlex).toHaveAttribute(
-        'data-align-items',
-        '{"default":"alignItemsCenter"}',
-      );
-    });
-
-    it('should render connection type card with nested flex for title and tooltip', () => {
-      render(<LogCards {...defaultProps} />);
-
-      const flexContainers = screen.getAllByTestId('flex');
-      const connectionTypeFlex = flexContainers[2];
-      expect(connectionTypeFlex).toHaveAttribute(
-        'data-space-items',
-        '{"default":"spaceItemsXs"}',
-      );
-      expect(connectionTypeFlex).toHaveAttribute(
-        'data-align-items',
-        '{"default":"alignItemsCenter"}',
-      );
-    });
-  });
-
-  describe('PropTypes', () => {
-    it('should have correct propTypes defined', () => {
-      expect(LogCards.propTypes).toBeDefined();
-      expect(LogCards.propTypes.systemName).toBeDefined();
-      expect(LogCards.propTypes.status).toBeDefined();
-      expect(LogCards.propTypes.connectionType).toBeDefined();
-      expect(LogCards.propTypes.executedBy).toBeDefined();
-    });
-  });
-
-  describe('Edge cases', () => {
-    it('should render with all props as null', () => {
-      render(
-        <LogCards
-          systemName={null}
-          status={null}
-          connectionType={null}
-          executedBy={null}
-        />,
-      );
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[0]).toHaveTextContent('-'); // System
-      expect(cardBodies[2]).toHaveTextContent('-'); // Connection type
-      expect(cardBodies[3]).toHaveTextContent('-'); // Executed by
-
-      // Status card should show question icon and dash
-      expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-      expect(screen.getAllByText('-')).toHaveLength(4); // System, status, connection, executed by
-    });
-
-    it('should render with no props', () => {
-      render(<LogCards />);
-
-      expect(screen.getAllByTestId('flex')).toHaveLength(3); // Main flex + 2 nested flex
-      expect(screen.getAllByTestId('card')).toHaveLength(4);
-
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[0]).toHaveTextContent('-'); // System
-      expect(cardBodies[2]).toHaveTextContent('-'); // Connection type
-      expect(cardBodies[3]).toHaveTextContent('-'); // Executed by
-    });
-
-    it('should handle very long values', () => {
-      const longValue = 'a'.repeat(100);
-      render(
-        <LogCards
-          systemName={longValue}
-          status="success"
-          connectionType={longValue}
-          executedBy={longValue}
-        />,
-      );
-
-      expect(screen.getAllByText(longValue)).toHaveLength(2); // Appears in 2 cards
       expect(
-        screen.getAllByText(capitalize(longValue) + ' connected'),
-      ).toHaveLength(1); // Appears in connection type card
-      expect(screen.getByText('Success')).toBeInTheDocument();
-    });
-
-    it('should handle special characters in values', () => {
-      const specialChars = 'test-system_123@domain.com!@#$%^&*()';
-      render(
-        <LogCards
-          systemName={specialChars}
-          status="success"
-          connectionType={specialChars}
-          executedBy={specialChars}
-        />,
-      );
-
-      expect(screen.getAllByText(specialChars)).toHaveLength(2); // Appears in 2 cards
-      expect(
-        screen.getAllByText(capitalize(specialChars) + ' connected'),
-      ).toHaveLength(1); // Appears in connection type card
+        screen.queryByText('test-user@example.com'),
+      ).not.toBeInTheDocument();
+      expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
     });
   });
 
-  describe('Integration scenarios', () => {
-    it('should render realistic production data', () => {
-      render(
-        <LogCards
-          systemName="prod-web-server-01.company.com"
-          status="success"
-          connectionType="direct"
-          executedBy="sysadmin@company.com"
-        />,
-      );
+  it('renders realistic production data', () => {
+    render(
+      <LogCards
+        systemName="prod-web-server-01.company.com"
+        status="success"
+        connectionType="direct"
+        executedBy="sysadmin@company.com"
+      />,
+    );
 
-      expect(
-        screen.getByText('prod-web-server-01.company.com'),
-      ).toBeInTheDocument();
-      expect(screen.getByText('Success')).toBeInTheDocument();
-      expect(screen.getByTestId('check-circle-icon')).toBeInTheDocument();
-      expect(screen.getByText('Direct connected')).toBeInTheDocument();
-      expect(screen.getByText('sysadmin@company.com')).toBeInTheDocument();
-    });
+    expect(
+      screen.getByText('prod-web-server-01.company.com'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Direct connected')).toBeInTheDocument();
+    expect(screen.getByText('sysadmin@company.com')).toBeInTheDocument();
+  });
 
-    it('should render mixed valid and null values', () => {
-      render(
-        <LogCards
-          systemName="test-system"
-          status={null}
-          connectionType="satellite"
-          executedBy={null}
-        />,
-      );
+  it('renders long and special-character values without crashing', () => {
+    const longValue = 'a'.repeat(100);
+    const specialChars = 'test-system_123@domain.com!@#$%^&*()';
 
-      expect(screen.getByText('test-system')).toBeInTheDocument();
-      expect(screen.getByTestId('question-circle-icon')).toBeInTheDocument();
-      expect(screen.getByText('Satellite connected')).toBeInTheDocument();
+    render(
+      <LogCards
+        systemName={longValue}
+        status="success"
+        connectionType="direct"
+        executedBy={specialChars}
+      />,
+    );
 
-      const cardBodies = screen.getAllByTestId('card-body');
-      expect(cardBodies[3]).toHaveTextContent('-'); // Executed by should show dash
-    });
+    expect(screen.getByText(longValue)).toBeInTheDocument();
+    expect(screen.getByText(specialChars)).toBeInTheDocument();
+    expect(screen.getByText('Direct connected')).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
   });
 });

--- a/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.test.js
+++ b/src/routes/RemediationDetailsComponents/ExecutionHistoryContent/LogCards.test.js
@@ -7,9 +7,14 @@ import { capitalize } from '../../../Utilities/utils';
 
 // Mock PatternFly components
 jest.mock('@patternfly/react-core', () => ({
-  Card: function MockCard({ isFullHeight, children, ...props }) {
+  Card: function MockCard({ isFullHeight, children, style, ...props }) {
     return (
-      <div data-testid="card" data-full-height={isFullHeight} {...props}>
+      <div
+        data-testid="card"
+        data-full-height={isFullHeight}
+        style={style}
+        {...props}
+      >
         {children}
       </div>
     );
@@ -371,6 +376,13 @@ describe('LogCards', () => {
       // Check that all flex items have the correct style
       flexItems.forEach((item) => {
         expect(item).toHaveStyle('flex: 1 1 0');
+        expect(item).toHaveStyle('display: flex');
+      });
+
+      const cards = screen.getAllByTestId('card');
+      cards.forEach((card) => {
+        expect(card).toHaveStyle('min-width: 12rem');
+        expect(card).toHaveStyle('min-height: 10rem');
       });
     });
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-26336 This address the issues in this ticket.

## Summary by Sourcery

Adjust remediation execution log cards layout and accessibility-related UI details.

New Features:
- Add a tooltip explaining how to enable the preview download action in the remediation preview alert.

Enhancements:
- Ensure execution history log cards have consistent flex layout and minimum size for better display across themes, including dark mode.
- Update tests to validate the new log card layout and sizing.
- Simplify resolution options modal header by removing the inline required asterisk styling and using default icon color for the help icon.