### PR TITLE
fix(CI): add codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,10 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npm run ci:verify
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage-final.json,./coverage-jest/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: npm run build


### PR DESCRIPTION
# Description
ci:verify script was taking care of uploading coverage before, but it got broken because of outdated codecov cli. To avoid such issues in the future, we better use upload codecov action which is supported


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

CI:
- Add a Codecov upload step to the test workflow to publish multiple coverage report files and fail the job if upload fails.