### PR TITLE
feat(RHINENG-26336): Fix tooltip for Download-Preview button

### DIFF
--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -107,6 +107,25 @@ export const renderPreviewAlert = ({
   previewStatus,
   previewLoading,
 }) => {
+  const isPreviewDisabled = !hasPlanSelection || previewLoading;
+  const previewButton = (
+    <Button
+      variant="link"
+      icon={<DownloadIcon />}
+      onClick={onPreviewClick}
+      isDisabled={isPreviewDisabled}
+    >
+      Download preview
+    </Button>
+  );
+  const previewButtonContent = !hasPlanSelection ? (
+    <Tooltip content="Enter a new plan name or select an existing plan.">
+      <span className="pf-v6-u-display-inline-flex">{previewButton}</span>
+    </Tooltip>
+  ) : (
+    previewButton
+  );
+
   return (
     <Hint variant="info" className="pf-v6-u-mt-lg">
       <HintTitle>You can download a preview of this plan</HintTitle>
@@ -123,16 +142,7 @@ export const renderPreviewAlert = ({
           alignItems={{ default: 'alignItemsCenter' }}
           className="pf-v6-u-mt-sm"
         >
-          <Tooltip content="Enter a new plan name or select an existing plan.">
-            <Button
-              variant="link"
-              icon={<DownloadIcon />}
-              onClick={onPreviewClick}
-              isDisabled={!hasPlanSelection || previewLoading}
-            >
-              Download preview
-            </Button>
-          </Tooltip>
+          {previewButtonContent}
           {previewLoading && <Spinner size="sm" />}
           {previewStatus && !previewLoading && (
             <Alert


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-26336](https://redhat.atlassian.net/browse/RHINENG-26336)

The tooltip was not showing when the button was disabled due the PF properties, thus it was displayed only when the button was enabled. Since the tooltip explains what user needs to do for a disabled button to become enabled, it should instead be shown only when the button is disabled.
In addition, button can become disabled during the loading of preview-download too; in that case, no tooltip should be displayed, because user has already selected the plan's name at that time. 

To fix this, the button was wrapped around `<span> ` (which enabled the tooltip to be displayed when the button is disabled) and simple logic for deciding when to display the tooltip was added.

# How to test the PR

1. Open the Plan Remediation modal without selecting a plan (so that Preview button is disabled)
2. Hover _Download preview_ button and verify the button is disabled and the tooltip is shown
3. Select or enter a plan name and verify the button is enabled and no tooltip is shown
4. Click _Download preview_ and verify that the button becomes disabled during loading, but the tooltip is not displayed
5. Verify the preview success/failure alert still appears after loading completes

# Before the change
Tooltip is showing only when button is enabled, which is exactly the opposite of what we want:
<img width="473" height="329" alt="image" src="https://github.com/user-attachments/assets/f2dcddc7-939d-464f-ab5b-a6112dec1a8e" />
<img width="473" height="329" alt="image" src="https://github.com/user-attachments/assets/62363e1b-e5d3-442d-9808-27cd5a5fd3b2" />


# After the change
Tooltip is shown when button is disabled due the missing plan's name:
<img width="473" height="329" alt="image" src="https://github.com/user-attachments/assets/d2739c93-f0e1-44ff-8bbb-a48a89392a2e" />

Tooltip is not shown when button is enabled
<img width="473" height="329" alt="image" src="https://github.com/user-attachments/assets/d35b6d34-d99e-42fa-8427-87c47dad40dc" />

Tooltip is not shown when button is disabled due the loading
<img width="473" height="329" alt="image" src="https://github.com/user-attachments/assets/a9461718-ead5-4d5d-a86a-761493e7d6ce" />




# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[RHINENG-26336]: https://redhat.atlassian.net/browse/RHINENG-26336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust preview download button behavior and tooltip visibility in the plan remediation modal.

Bug Fixes:
- Show the download preview tooltip only when the button is disabled due to missing plan selection.
- Prevent the tooltip from showing while the download preview button is disabled during loading.