### PR TITLE
fix(RHINENG-25407: permission edge-cases

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -44,6 +44,7 @@ PermissionsLayout.propTypes = {
     read: PropTypes.bool.isRequired,
     write: PropTypes.bool.isRequired,
     execute: PropTypes.bool.isRequired,
+    inventoryHostsRead: PropTypes.bool,
   }).isRequired,
 };
 
@@ -54,6 +55,7 @@ const RbacPermissionsGate = () => {
     read: false,
     write: false,
     execute: false,
+    inventoryHostsRead: false,
   });
   const [isLoading, setIsLoading] = useState(true);
   const didLoadRef = useRef(false);
@@ -70,19 +72,37 @@ const RbacPermissionsGate = () => {
 
     let cancelled = false;
 
-    chrome
-      .getUserPermissions('remediations')
-      .then((list) => {
+    Promise.all([
+      chrome.getUserPermissions('remediations'),
+      chrome.getUserPermissions('inventory'),
+    ])
+      .then(([remediationsList, inventoryList]) => {
         if (cancelled) return;
 
-        setPermissions(getChromePerms(list));
+        const remediationsPerms = getChromePerms(remediationsList);
+        const inventoryHostsRead = inventoryList?.some(
+          (item) =>
+            item?.permission === 'inventory:hosts:read' ||
+            item?.permission === 'inventory:hosts:*' ||
+            item?.permission === 'inventory:*:*',
+        );
+
+        setPermissions({
+          ...remediationsPerms,
+          inventoryHostsRead: !!inventoryHostsRead,
+        });
 
         setIsLoading(false);
       })
       .catch((error) => {
         console.error('Error loading user permissions:', error);
         if (!cancelled) {
-          setPermissions({ read: false, write: false, execute: false });
+          setPermissions({
+            read: false,
+            write: false,
+            execute: false,
+            inventoryHostsRead: false,
+          });
           setIsLoading(false);
         }
       });

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { downloadPlaybook } from '../api';
 import keyBy from 'lodash/keyBy';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import PropTypes from 'prop-types';
 import { pluralize } from './utils';
+import ButtonWithToolTip from './ButtonWithToolTip';
 
 const verifyDownload = (selectedIds, data) => {
   const byId = keyBy(data, (r) => r.id);
@@ -60,24 +60,32 @@ export const download = (selectedIds, data, addNotification, chrome) => {
   }
 };
 
-export const DownloadPlaybookButton = ({ selectedItems = [], data }) => {
+export const DownloadPlaybookButton = ({
+  selectedItems = [],
+  data,
+  isDisabled = false,
+  tooltipContent,
+}) => {
   const addNotification = useAddNotification();
   const chrome = useChrome();
 
   return (
-    <Button
-      isDisabled={selectedItems?.length < 1}
+    <ButtonWithToolTip
+      isDisabled={isDisabled || selectedItems?.length < 1}
       variant="primary"
       onClick={() => {
         download(selectedItems, data, addNotification, chrome);
       }}
+      tooltipContent={tooltipContent}
     >
-      {`Download`}
-    </Button>
+      Download
+    </ButtonWithToolTip>
   );
 };
 
 DownloadPlaybookButton.propTypes = {
   selectedItems: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
+  isDisabled: PropTypes.bool,
+  tooltipContent: PropTypes.node,
 };

--- a/src/Utilities/Hooks/useKesselRemediationPermissionState.js
+++ b/src/Utilities/Hooks/useKesselRemediationPermissionState.js
@@ -8,12 +8,14 @@ import {
   KESSEL_REMEDIATIONS_EDIT,
   KESSEL_REMEDIATIONS_EXECUTE,
   KESSEL_REMEDIATIONS_VIEW,
+  KESSEL_INVENTORY_HOSTS_READ,
 } from '../../constants';
 
 const KESSEL_RELATIONS = [
   KESSEL_REMEDIATIONS_VIEW,
   KESSEL_REMEDIATIONS_EDIT,
   KESSEL_REMEDIATIONS_EXECUTE,
+  KESSEL_INVENTORY_HOSTS_READ,
 ];
 
 /** workspace + rbac reporter, aligned with fec kesselPermissions defaults */
@@ -96,7 +98,8 @@ export function useKesselRemediationPermissionState(baseUrl) {
     const read = getAllowed(checks, KESSEL_REMEDIATIONS_VIEW);
     const write = getAllowed(checks, KESSEL_REMEDIATIONS_EDIT);
     const execute = getAllowed(checks, KESSEL_REMEDIATIONS_EXECUTE);
-    return { read, write, execute };
+    const inventoryHostsRead = getAllowed(checks, KESSEL_INVENTORY_HOSTS_READ);
+    return { read, write, execute, inventoryHostsRead };
   }, [checks]);
 
   const isLoading = workspaceLoading || (workspaceId ? checksLoading : false);

--- a/src/components/SystemsTable/SystemsTable.js
+++ b/src/components/SystemsTable/SystemsTable.js
@@ -5,6 +5,7 @@ import React, {
   Fragment,
   useMemo,
   useCallback,
+  useContext,
 } from 'react';
 import PropTypes from 'prop-types';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -28,6 +29,7 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import { deleteRemediationSystems } from '../../routes/api';
 import { selectEntity } from '../../actions';
+import { PermissionContext } from '../../App';
 
 const SystemsTableWrapper = ({
   remediation,
@@ -51,6 +53,7 @@ const SystemsTableWrapper = ({
   );
   const loaded = useSelector(({ entities }) => entities?.loaded);
   const rows = useSelector(({ entities }) => entities?.rows);
+  const permission = useContext(PermissionContext);
 
   const { fetch: fetchSystems } = useRemediations('getRemediationSystems', {
     skip: true,
@@ -122,9 +125,12 @@ const SystemsTableWrapper = ({
           };
           setIsOpen(true);
         },
+        isDisabled:
+          !permission.permissions.write ||
+          !permission.permissions.inventoryHostsRead,
       },
     ],
-    [],
+    [permission.permissions.write, permission.permissions.inventoryHostsRead],
   );
 
   const columns = useMemo(
@@ -174,7 +180,11 @@ const SystemsTableWrapper = ({
           <Button
             variant="secondary"
             onClick={() => setIsOpen(true)}
-            isDisabled={selected.size === 0}
+            isDisabled={
+              !permission.permissions.write ||
+              !permission.permissions.inventoryHostsRead ||
+              selected.size === 0
+            }
           >
             Remove
           </Button>

--- a/src/components/SystemsTable/SystemsTable.test.js
+++ b/src/components/SystemsTable/SystemsTable.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemsTable from './SystemsTable';
+import { PermissionContext } from '../../App';
 
 // Mock external dependencies to avoid complex integration issues
 const mockRemediationsClient = {
@@ -107,13 +108,27 @@ describe('SystemsTable', () => {
     areDetailsLoading: false,
   };
 
+  const renderWithPermissions = (
+    element,
+    permissions = { write: true, read: true, inventoryHostsRead: true },
+  ) =>
+    render(
+      <PermissionContext.Provider value={{ permissions }}>
+        {element}
+      </PermissionContext.Provider>,
+    );
+
   it('should render without crashing', () => {
-    const { container } = render(<SystemsTable {...defaultProps} />);
+    const { container } = renderWithPermissions(
+      <SystemsTable {...defaultProps} />,
+    );
     expect(container).toBeInTheDocument();
   });
 
   it('should handle loading state correctly', () => {
-    render(<SystemsTable {...defaultProps} areDetailsLoading={true} />);
+    renderWithPermissions(
+      <SystemsTable {...defaultProps} areDetailsLoading={true} />,
+    );
     // Component should handle loading state without crashing
     expect(true).toBe(true);
   });
@@ -123,7 +138,7 @@ describe('SystemsTable', () => {
       ...defaultProps,
       remediation: { id: 'empty', name: 'Empty', issues: [] },
     };
-    render(<SystemsTable {...emptyProps} />);
+    renderWithPermissions(<SystemsTable {...emptyProps} />);
     expect(true).toBe(true);
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,3 +49,4 @@ export const KESSEL_API_BASE_URL = '/api/kessel/v1beta2';
 export const KESSEL_REMEDIATIONS_VIEW = 'remediations_view_remediation';
 export const KESSEL_REMEDIATIONS_EDIT = 'remediations_edit_remediation';
 export const KESSEL_REMEDIATIONS_EXECUTE = 'remediations_execute_remediation';
+export const KESSEL_INVENTORY_HOSTS_READ = 'inventory_hosts_read';

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -254,6 +254,7 @@ export const OverViewPage = () => {
                       onClick: (_event, _index, { item }) => {
                         handleDownloadClick(item.id);
                       },
+                      isDisabled: !context.permissions.inventoryHostsRead,
                     },
                     {
                       title: 'Rename',
@@ -261,10 +262,17 @@ export const OverViewPage = () => {
                         setRemediation(item);
                         setIsRenameModalOpen(true);
                       },
+                      isDisabled: !context.permissions.write,
                     },
                     {
                       title: (
-                        <Content className="pf-v6-u-danger-color-100">
+                        <Content
+                          className={
+                            context.permissions.write
+                              ? 'pf-v6-u-danger-color-100'
+                              : ''
+                          }
+                        >
                           Delete
                         </Content>
                       ),
@@ -274,6 +282,7 @@ export const OverViewPage = () => {
                         setIsDeleteModalOpen(true);
                       },
                       props: { screenReaderText: 'Delete button' },
+                      isDisabled: !context.permissions.write,
                     },
                   ];
                 },
@@ -283,6 +292,15 @@ export const OverViewPage = () => {
                     selectedItems={currentlySelected}
                     data={result?.data}
                     dispatch={dispatch}
+                    isDisabled={!context.permissions.inventoryHostsRead}
+                    tooltipContent={
+                      !context.permissions.inventoryHostsRead ? (
+                        <div>
+                          You don&apos;t have the required permissions to
+                          download remediation plans.
+                        </div>
+                      ) : null
+                    }
                   />
                 ),
                 EmptyState: TableEmptyState,

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import columns from './Columns';
 import { Button } from '@patternfly/react-core';
@@ -19,6 +19,7 @@ import {
 } from 'bastilian-tabletools';
 import TableEmptyState from '../../OverViewPage/TableEmptyState';
 import RemediationsTable from '../../../components/RemediationsTable/RemediationsTable';
+import { PermissionContext } from '../../../App';
 
 const ActionsContent = ({
   refetch,
@@ -38,6 +39,7 @@ const ActionsContent = ({
   const [isResolutionModalOpen, setIsResolutionModalOpen] = useState(false);
   const [selectedIssueForResolution, setSelectedIssueForResolution] =
     useState(null);
+  const permission = useContext(PermissionContext);
 
   const {
     result: issuesResult,
@@ -277,13 +279,16 @@ const ActionsContent = ({
                   setAction([item.id]);
                   setIsDeleteModalOpen(true);
                 },
+                isDisabled: !permission.permissions.write,
               },
             ];
           },
           dedicatedAction: () => (
             <Button
               variant="secondary"
-              isDisabled={currentlySelected?.length === 0}
+              isDisabled={
+                !permission.permissions.write || currentlySelected?.length === 0
+              }
               onClick={() => {
                 setIsBulkDelete(true);
                 setIsDeleteModalOpen(true);

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.test.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.test.js
@@ -11,6 +11,7 @@ import {
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import ActionsContent from './ActionsContent';
+import { PermissionContext } from '../../../App';
 import * as useRemediations from '../../../Utilities/Hooks/api/useRemediations';
 import * as useRemediationFetchExtras from '../../../api/useRemediationFetchExtras';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -370,9 +371,13 @@ describe('ActionsContent', () => {
     };
 
     return render(
-      <MemoryRouter>
-        <ActionsContent {...defaultProps} />
-      </MemoryRouter>,
+      <PermissionContext.Provider
+        value={{ permissions: { write: true, read: true } }}
+      >
+        <MemoryRouter>
+          <ActionsContent {...defaultProps} />
+        </MemoryRouter>
+      </PermissionContext.Provider>,
     );
   };
 

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -298,6 +298,7 @@ const DetailsCard = ({
                   }
                   variant="link"
                   onClick={() => setEditing(!editing)}
+                  isDisabled={!permission.permissions.write}
                   className="pf-v6-u-ml-sm"
                   aria-label={
                     editing
@@ -351,7 +352,9 @@ const DetailsCard = ({
                           }
                           variant="link"
                           onClick={() => onSubmit(value)}
-                          isDisabled={nameStatus !== 'valid'}
+                          isDisabled={
+                            !permission.permissions.write || nameStatus !== 'valid'
+                          }
                           aria-label="Save remediation plan name"
                         ></Button>
                         <Button

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Card,
@@ -45,6 +45,7 @@ const DETAILS_CARD_OUIA_ID = 'details-card';
 const DETAILS_CARD_TITLE_ID = 'details-card-title';
 const DETAILS_CARD_TOGGLE_ID = 'details-card-toggle';
 const DETAILS_CARD_CONTENT_ID = 'details-card-content';
+import { PermissionContext } from '../../App';
 
 const DetailsCard = ({
   details,
@@ -62,6 +63,7 @@ const DetailsCard = ({
   const [hasResolutionsAvailable, setHasResolutionsAvailable] = useState(false);
   const [isCheckingResolutions, setIsCheckingResolutions] = useState(true);
   const addNotification = useAddNotification();
+  const permission = useContext(PermissionContext);
   //This is paginated, so we must loop through issues until we find a batch with multiple resolutions or we reach the end of the issues.
   const { fetch: fetchRemediationIssues } = useRemediations(
     'getRemediationIssues',
@@ -237,6 +239,7 @@ const DetailsCard = ({
                 id="autoreboot-switch"
                 isChecked={rebootToggle}
                 onChange={onToggleAutoreboot}
+                isDisabled={!permission.permissions.write}
                 className="pf-v6-u-font-size-sm"
                 style={{ fontSize: 'var(--pf-t--global--font-size--sm)' }}
               />

--- a/src/routes/RemediationDetailsComponents/DetailsCard.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.test.js
@@ -10,6 +10,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DetailsCard from './DetailsCard';
+import { PermissionContext } from '../../App';
 import * as useVerifyName from '../../Utilities/useVerifyName';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -95,7 +96,7 @@ describe('DetailsCard', () => {
     jest.restoreAllMocks();
   });
 
-  const renderComponent = (props = {}) => {
+  const renderComponent = (props = {}, permissions = { write: true, read: true }) => {
     const defaultProps = {
       details: mockDetails,
       updateRemPlan: mockUpdateRemPlan,
@@ -106,7 +107,11 @@ describe('DetailsCard', () => {
       ...props,
     };
 
-    return render(<DetailsCard {...defaultProps} />);
+    return render(
+      <PermissionContext.Provider value={{ permissions }}>
+        <DetailsCard {...defaultProps} />
+      </PermissionContext.Provider>,
+    );
   };
 
   describe('Component Rendering', () => {
@@ -561,14 +566,18 @@ describe('DetailsCard', () => {
       const newDetails = { ...mockDetails, name: 'Updated External Name' };
 
       rerender(
-        <DetailsCard
-          details={newDetails}
-          updateRemPlan={mockUpdateRemPlan}
-          onNavigateToTab={mockOnNavigateToTab}
-          allRemediations={mockAllRemediations}
-          refetch={mockRefetch}
-          refetchAllRemediations={mockRefetchAllRemediations}
-        />,
+        <PermissionContext.Provider
+          value={{ permissions: { write: true, read: true } }}
+        >
+          <DetailsCard
+            details={newDetails}
+            updateRemPlan={mockUpdateRemPlan}
+            onNavigateToTab={mockOnNavigateToTab}
+            allRemediations={mockAllRemediations}
+            refetch={mockRefetch}
+            refetchAllRemediations={mockRefetchAllRemediations}
+          />
+        </PermissionContext.Provider>,
       );
 
       expect(screen.getByText('Updated External Name')).toBeInTheDocument();

--- a/src/routes/RemediationDetailsComponents/DetailsCard.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.test.js
@@ -249,6 +249,23 @@ describe('DetailsCard', () => {
   });
 
   describe('Name Editing', () => {
+    it('disables inline rename for users without write permission', async () => {
+      const user = userEvent.setup();
+
+      renderComponent({}, { write: false, read: true });
+
+      const editButton = screen.getByRole('button', {
+        name: /edit remediation plan name/i,
+      });
+      expect(editButton).toBeDisabled();
+
+      await user.click(editButton);
+
+      expect(
+        screen.queryByRole('textbox', { name: /rename input/i }),
+      ).not.toBeInTheDocument();
+    });
+
     it('toggles edit mode when pencil icon is clicked', async () => {
       const user = userEvent.setup();
 

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -38,7 +38,7 @@ const RemediationDetailsPageHeader = ({
 
   const getDownloadTooltipMessage = () => {
     if (!permissions?.inventoryHostsRead) {
-      return 'The remediation plan cannot be downloaded because you dont have the required permissions.';
+      return "The remediation plan cannot be downloaded because you don't have the required permissions.";
     }
 
     const hasNoActions = !remediation?.issue_count;

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -37,6 +37,10 @@ const RemediationDetailsPageHeader = ({
   }, [remediation, addNotification]);
 
   const getDownloadTooltipMessage = () => {
+    if (!permissions?.inventoryHostsRead) {
+      return 'The remediation plan cannot be downloaded because you dont have the required permissions.';
+    }
+
     const hasNoActions = !remediation?.issue_count;
     const hasNoSystems = remediation?.system_count === 0;
     let message =
@@ -119,7 +123,9 @@ const RemediationDetailsPageHeader = ({
               <FlexItem>
                 <ButtonWithToolTip
                   isDisabled={
-                    !remediation?.issue_count || remediation.system_count === 0
+                    !remediation?.issue_count ||
+                    remediation.system_count === 0 ||
+                    !permissions?.inventoryHostsRead
                   }
                   onClick={handleDownload}
                   tooltipContent={<div>{getDownloadTooltipMessage()}</div>}


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Align remediation actions and downloads with RBAC and kessel permission checks, including inventory host read access, to prevent unauthorized operations.

New Features:
- Introduce inventory host read permission into the global permission model and kessel permission state.
- Add contextual tooltips explaining why remediation plan downloads are unavailable when permissions are missing.

Bug Fixes:
- Prevent users without write permissions from renaming remediations, toggling auto-reboot, deleting issues, or removing systems.
- Prevent users without inventory hosts read permissions from downloading remediation plans or removing systems tied to inventory hosts.

Enhancements:
- Reuse the shared permission context across remediation details, actions, overview, and systems tables to consistently gate UI actions.
- Extend the download playbook button to support disabled states with explanatory tooltips.