### PR TITLE
feat(RHINENG-24751): Implement retention policy modal

### DIFF
--- a/src/Utilities/Hooks/useIsOrgAdmin.js
+++ b/src/Utilities/Hooks/useIsOrgAdmin.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
+export function useIsOrgAdmin() {
+  const chrome = useChrome();
+  const [isOrgAdmin, setIsOrgAdmin] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const isOrgAdminFn = chrome?.visibilityFunctions?.isOrgAdmin;
+    if (typeof isOrgAdminFn !== 'function') {
+      setIsOrgAdmin(false);
+      setIsLoading(false);
+      return undefined;
+    }
+
+    Promise.resolve(isOrgAdminFn())
+      .then((result) => {
+        if (!cancelled) {
+          setIsOrgAdmin(!!result);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsOrgAdmin(false);
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chrome]);
+
+  return { isOrgAdmin, isLoading };
+}

--- a/src/Utilities/retentionPolicy.js
+++ b/src/Utilities/retentionPolicy.js
@@ -1,0 +1,46 @@
+export const RETENTION_PERIOD_OPTIONS = [
+  { value: 14, label: '14 days' },
+  { value: 30, label: '30 days' },
+  { value: 60, label: '2 months' },
+  { value: 90, label: '3 months' },
+  { value: 120, label: '4 months' },
+  { value: 150, label: '5 months' },
+  { value: 180, label: '6 months' },
+];
+
+export const EXPIRATION_WARNING_OPTIONS = [
+  { value: 3, label: '3 days' },
+  { value: 7, label: '7 days' },
+  { value: 14, label: '14 days' },
+  { value: 30, label: '30 days' },
+  { value: 60, label: '2 months' },
+  { value: 90, label: '3 months' },
+  { value: 120, label: '4 months' },
+  { value: 150, label: '5 months' },
+];
+
+export const DEFAULT_RETENTION_DAYS = 120;
+export const DEFAULT_WARNING_DAYS = 30;
+
+const ALL_DURATION_OPTIONS = [
+  ...RETENTION_PERIOD_OPTIONS,
+  ...EXPIRATION_WARNING_OPTIONS,
+];
+
+export const formatDuration = (days) => {
+  const match = ALL_DURATION_OPTIONS.find((option) => option.value === days);
+  return match?.label ?? `${days} days`;
+};
+
+export const getValidWarningOptions = (retentionDays) =>
+  EXPIRATION_WARNING_OPTIONS.filter((option) => option.value < retentionDays);
+
+export const normalizeRetentionDays = (days) =>
+  RETENTION_PERIOD_OPTIONS.find((option) => option.value === days)?.value ??
+  DEFAULT_RETENTION_DAYS;
+
+export const normalizeWarningDays = (days, retentionDays) => {
+  const validOptions = getValidWarningOptions(retentionDays);
+  const match = validOptions.find((option) => option.value === days);
+  return match?.value ?? validOptions.at(-1)?.value ?? DEFAULT_WARNING_DAYS;
+};

--- a/src/Utilities/retentionPolicy.test.js
+++ b/src/Utilities/retentionPolicy.test.js
@@ -1,0 +1,47 @@
+import {
+  DEFAULT_RETENTION_DAYS,
+  DEFAULT_WARNING_DAYS,
+  formatDuration,
+  getValidWarningOptions,
+  normalizeRetentionDays,
+  normalizeWarningDays,
+} from './retentionPolicy';
+
+describe('retentionPolicy utilities', () => {
+  describe('formatDuration', () => {
+    it('returns the label for known durations', () => {
+      expect(formatDuration(120)).toBe('4 months');
+      expect(formatDuration(30)).toBe('30 days');
+    });
+
+    it('falls back to days for unknown values', () => {
+      expect(formatDuration(45)).toBe('45 days');
+    });
+  });
+
+  describe('getValidWarningOptions', () => {
+    it('only returns warning options shorter than retention', () => {
+      const options = getValidWarningOptions(30);
+      expect(options.every((option) => option.value < 30)).toBe(true);
+      expect(options.map((option) => option.value)).toEqual([3, 7, 14]);
+    });
+  });
+
+  describe('normalizeRetentionDays', () => {
+    it('returns the default for unknown values', () => {
+      expect(normalizeRetentionDays(999)).toBe(DEFAULT_RETENTION_DAYS);
+    });
+  });
+
+  describe('normalizeWarningDays', () => {
+    it('returns the highest valid warning below retention', () => {
+      expect(normalizeWarningDays(150, 30)).toBe(14);
+    });
+
+    it('returns the default warning when the value is valid', () => {
+      expect(normalizeWarningDays(DEFAULT_WARNING_DAYS, 120)).toBe(
+        DEFAULT_WARNING_DAYS,
+      );
+    });
+  });
+});

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -11,10 +11,12 @@ import {
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import RenameModal from './RenameModal';
 import ConfirmationDialog from './ConfirmationDialog';
+import RetentionPolicyModal from './RetentionPolicyModal';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 
 import { PermissionContext } from '../App';
 import useRemediations from '../Utilities/Hooks/api/useRemediations';
+import { useIsOrgAdmin } from '../Utilities/Hooks/useIsOrgAdmin';
 
 function RemediationDetailsDropdown({
   remediation,
@@ -25,7 +27,10 @@ function RemediationDetailsDropdown({
   const [open, setOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [retentionPolicyModalOpen, setRetentionPolicyModalOpen] =
+    useState(false);
   const permission = useContext(PermissionContext);
+  const { isOrgAdmin: canManageRetentionPolicy } = useIsOrgAdmin();
   const navigate = useNavigate();
   const addNotification = useAddNotification();
 
@@ -79,7 +84,14 @@ function RemediationDetailsDropdown({
         }}
       />
 
-      {permission.permissions.write && (
+      {retentionPolicyModalOpen && (
+        <RetentionPolicyModal
+          isOpen={retentionPolicyModalOpen}
+          onClose={() => setRetentionPolicyModalOpen(false)}
+        />
+      )}
+
+      {(permission.permissions.write || canManageRetentionPolicy) && (
         <Dropdown
           onSelect={() => setOpen(false)}
           toggle={(toggleRef) => (
@@ -96,19 +108,31 @@ function RemediationDetailsDropdown({
           popperProps={{ position: 'right' }}
         >
           <DropdownList>
-            <DropdownItem
-              key="rename"
-              onClick={() => setRenameDialogOpen(true)}
-            >
-              Rename
-            </DropdownItem>
-            <DropdownItem
-              key="delete"
-              onClick={() => setDeleteDialogOpen(true)}
-              isDanger
-            >
-              Delete
-            </DropdownItem>
+            {permission.permissions.write && (
+              <DropdownItem
+                key="rename"
+                onClick={() => setRenameDialogOpen(true)}
+              >
+                Rename
+              </DropdownItem>
+            )}
+            {canManageRetentionPolicy && (
+              <DropdownItem
+                key="retention-policy"
+                onClick={() => setRetentionPolicyModalOpen(true)}
+              >
+                Edit retention policy
+              </DropdownItem>
+            )}
+            {permission.permissions.write && (
+              <DropdownItem
+                key="delete"
+                onClick={() => setDeleteDialogOpen(true)}
+                isDanger
+              >
+                Delete
+              </DropdownItem>
+            )}
           </DropdownList>
         </Dropdown>
       )}

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -12,6 +12,7 @@ import { EllipsisVIcon } from '@patternfly/react-icons';
 import RenameModal from './RenameModal';
 import ConfirmationDialog from './ConfirmationDialog';
 import RetentionPolicyModal from './RetentionPolicyModal';
+import RetentionPolicyDropdownItem from './RetentionPolicyDropdownItem';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 
 import { PermissionContext } from '../App';
@@ -30,7 +31,8 @@ function RemediationDetailsDropdown({
   const [retentionPolicyModalOpen, setRetentionPolicyModalOpen] =
     useState(false);
   const permission = useContext(PermissionContext);
-  const { isOrgAdmin: canManageRetentionPolicy } = useIsOrgAdmin();
+  const { isOrgAdmin: canManageRetentionPolicy, isLoading: isOrgAdminLoading } =
+    useIsOrgAdmin();
   const navigate = useNavigate();
   const addNotification = useAddNotification();
 
@@ -116,14 +118,11 @@ function RemediationDetailsDropdown({
                 Rename
               </DropdownItem>
             )}
-            {canManageRetentionPolicy && (
-              <DropdownItem
-                key="retention-policy"
-                onClick={() => setRetentionPolicyModalOpen(true)}
-              >
-                Edit retention policy
-              </DropdownItem>
-            )}
+            <RetentionPolicyDropdownItem
+              canManageRetentionPolicy={canManageRetentionPolicy}
+              isLoading={isOrgAdminLoading}
+              onClick={() => setRetentionPolicyModalOpen(true)}
+            />
             {permission.permissions.write && (
               <DropdownItem
                 key="delete"

--- a/src/components/RetentionPolicyDropdownItem.js
+++ b/src/components/RetentionPolicyDropdownItem.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DropdownItem } from '@patternfly/react-core';
+
+export const ORG_ADMIN_TOOLTIP_TEXT =
+  'Requires Organization Administrator privileges.';
+
+const RetentionPolicyDropdownItem = ({
+  canManageRetentionPolicy,
+  isLoading = false,
+  onClick,
+}) => {
+  const isUnauthorized = !canManageRetentionPolicy && !isLoading;
+  const handleClick =
+    canManageRetentionPolicy && !isLoading ? onClick : undefined;
+
+  return (
+    <DropdownItem
+      onClick={handleClick}
+      isDisabled={isLoading}
+      isAriaDisabled={isUnauthorized}
+      tooltipProps={
+        isUnauthorized ? { content: ORG_ADMIN_TOOLTIP_TEXT } : undefined
+      }
+    >
+      Edit retention policy
+    </DropdownItem>
+  );
+};
+
+RetentionPolicyDropdownItem.propTypes = {
+  canManageRetentionPolicy: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default RetentionPolicyDropdownItem;

--- a/src/components/RetentionPolicyDropdownItem.test.js
+++ b/src/components/RetentionPolicyDropdownItem.test.js
@@ -1,0 +1,88 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import RetentionPolicyDropdownItem, {
+  ORG_ADMIN_TOOLTIP_TEXT,
+} from './RetentionPolicyDropdownItem';
+
+jest.mock('@patternfly/react-core', () => ({
+  DropdownItem: ({
+    children,
+    onClick,
+    isDisabled,
+    isAriaDisabled,
+    tooltipProps,
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      aria-disabled={isAriaDisabled ? 'true' : undefined}
+      data-tooltip-content={tooltipProps?.content}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe('RetentionPolicyDropdownItem', () => {
+  it('disables the item and exposes the tooltip for non-admin users', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RetentionPolicyDropdownItem
+        canManageRetentionPolicy={false}
+        isLoading={false}
+        onClick={onClick}
+      />,
+    );
+
+    const item = screen.getByRole('button', { name: /edit retention policy/i });
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+    expect(item).toHaveAttribute(
+      'data-tooltip-content',
+      ORG_ADMIN_TOOLTIP_TEXT,
+    );
+
+    await user.click(item);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('enables the item for organization administrators', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RetentionPolicyDropdownItem
+        canManageRetentionPolicy={true}
+        isLoading={false}
+        onClick={onClick}
+      />,
+    );
+
+    const item = screen.getByRole('button', { name: /edit retention policy/i });
+    expect(item).not.toHaveAttribute('aria-disabled');
+    expect(item).not.toHaveAttribute('data-tooltip-content');
+
+    await user.click(item);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the item disabled without a tooltip while org-admin status loads', () => {
+    render(
+      <RetentionPolicyDropdownItem
+        canManageRetentionPolicy={false}
+        isLoading={true}
+        onClick={jest.fn()}
+      />,
+    );
+
+    const item = screen.getByRole('button', { name: /edit retention policy/i });
+    expect(item).toBeDisabled();
+    expect(item).not.toHaveAttribute('aria-disabled');
+    expect(item).not.toHaveAttribute('data-tooltip-content');
+  });
+});

--- a/src/components/RetentionPolicyModal.js
+++ b/src/components/RetentionPolicyModal.js
@@ -1,0 +1,265 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  MenuToggle,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Select,
+  SelectList,
+  SelectOption,
+  Skeleton,
+} from '@patternfly/react-core';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
+import useRemediations from '../Utilities/Hooks/api/useRemediations';
+import { getOrgConfig, putOrgConfigOverrides } from '../routes/api';
+import {
+  formatDuration,
+  getValidWarningOptions,
+  normalizeRetentionDays,
+  normalizeWarningDays,
+  RETENTION_PERIOD_OPTIONS,
+} from '../Utilities/retentionPolicy';
+
+const DurationSelect = ({
+  fieldId,
+  options,
+  selectedValue,
+  onChange,
+  isDisabled,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedLabel =
+    options.find((option) => option.value === selectedValue)?.label ?? '';
+
+  return (
+    <Select
+      id={fieldId}
+      isOpen={isOpen}
+      selected={selectedValue}
+      onSelect={(_event, value) => {
+        onChange(Number(value));
+        setIsOpen(false);
+      }}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen((current) => !current)}
+          isExpanded={isOpen}
+          isFullWidth
+          isDisabled={isDisabled}
+          aria-label={fieldId}
+        >
+          {selectedLabel}
+        </MenuToggle>
+      )}
+    >
+      <SelectList>
+        {options.map((option) => (
+          <SelectOption key={option.value} value={option.value}>
+            {option.label}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};
+
+DurationSelect.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.number.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  selectedValue: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+const RetentionPolicyModal = ({ isOpen, onClose }) => {
+  const addNotification = useAddNotification();
+  const [retentionDays, setRetentionDays] = useState(null);
+  const [warningDays, setWarningDays] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // getOrgConfig/putOrgConfigOverrides aren't in the generated remediations-client
+  // yet, so they're plain axios wrapper functions (see routes/api.js) passed directly
+  // as the "endpoint" - useRemediations supports functions the same way it supports
+  // client method name strings.
+  const {
+    result: orgConfig,
+    loading: isLoading,
+    error: orgConfigError,
+  } = useRemediations(getOrgConfig);
+
+  const { fetch: saveOrgConfigOverrides } = useRemediations(
+    putOrgConfigOverrides,
+    { skip: true },
+  );
+
+  const warningOptions = useMemo(
+    () => (retentionDays == null ? [] : getValidWarningOptions(retentionDays)),
+    [retentionDays],
+  );
+
+  useEffect(() => {
+    if (!orgConfig) {
+      return;
+    }
+
+    const normalizedRetention = normalizeRetentionDays(
+      orgConfig.plan_retention_days,
+    );
+    setRetentionDays(normalizedRetention);
+    setWarningDays(
+      normalizeWarningDays(orgConfig.plan_warning_days, normalizedRetention),
+    );
+  }, [orgConfig]);
+
+  useEffect(() => {
+    if (!orgConfigError) {
+      return;
+    }
+
+    console.error(orgConfigError);
+    addNotification({
+      title: 'Failed to load retention policy',
+      description: 'The retention policy settings could not be loaded.',
+      variant: 'danger',
+      dismissable: true,
+      autoDismiss: true,
+    });
+    onClose();
+  }, [orgConfigError, addNotification, onClose]);
+
+  const handleRetentionChange = (nextRetentionDays) => {
+    setRetentionDays(nextRetentionDays);
+    setWarningDays((currentWarningDays) =>
+      normalizeWarningDays(currentWarningDays, nextRetentionDays),
+    );
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await saveOrgConfigOverrides({
+        plan_retention_days: retentionDays,
+        plan_warning_days: warningDays,
+      });
+
+      addNotification({
+        title: 'Remediation plan retention policy updated',
+        description: `The retention policy is now ${formatDuration(retentionDays)} and the expiration warning will begin at ${formatDuration(warningDays)} before deletion.`,
+        variant: 'success',
+        dismissable: true,
+        autoDismiss: true,
+      });
+      onClose();
+    } catch (error) {
+      console.error(error);
+      addNotification({
+        title: 'Retention policy update failed',
+        description: 'The changes were not saved. Try again.',
+        variant: 'danger',
+        dismissable: true,
+        autoDismiss: true,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isReady = !isLoading && retentionDays != null && warningDays != null;
+
+  return (
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} onClose={onClose}>
+      <ModalHeader title="Remediation plan retention policy" />
+      <ModalBody>
+        {!isReady ? (
+          <Skeleton screenreaderText="Loading retention policy settings" />
+        ) : (
+          <>
+            <p className="pf-v6-u-mb-lg">
+              By default, remediation plans are deleted after 4 months of
+              inactivity. Any plan modifications or executions will reset the
+              retention period. Changes to this retention policy will affect all
+              user accounts and remediation plans across your organization.
+            </p>
+
+            <FormGroup
+              label="Retention period"
+              isRequired
+              fieldId="retention-period"
+            >
+              <DurationSelect
+                fieldId="retention-period"
+                options={RETENTION_PERIOD_OPTIONS}
+                selectedValue={retentionDays}
+                onChange={handleRetentionChange}
+                isDisabled={isSaving}
+              />
+              <HelperText className="pf-v6-u-pt-sm">
+                <HelperTextItem>
+                  The duration that an inactive remediation plan is kept before
+                  being automatically deleted.
+                </HelperTextItem>
+              </HelperText>
+            </FormGroup>
+
+            <FormGroup
+              label="Expiration warning"
+              isRequired
+              fieldId="expiration-warning"
+              className="pf-v6-u-mt-md"
+            >
+              <DurationSelect
+                fieldId="expiration-warning"
+                options={warningOptions}
+                selectedValue={warningDays}
+                onChange={setWarningDays}
+                isDisabled={isSaving}
+              />
+              <HelperText className="pf-v6-u-pt-sm">
+                <HelperTextItem>
+                  The duration to display a warning before an inactive plan is
+                  automatically deleted.
+                </HelperTextItem>
+              </HelperText>
+            </FormGroup>
+          </>
+        )}
+      </ModalBody>
+      {isReady && (
+        <ModalFooter>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            isLoading={isSaving}
+            isDisabled={isSaving}
+          >
+            Save
+          </Button>
+          <Button variant="link" onClick={onClose} isDisabled={isSaving}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      )}
+    </Modal>
+  );
+};
+
+RetentionPolicyModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default RetentionPolicyModal;

--- a/src/routes/OverViewPage/OverViewPage.test.js
+++ b/src/routes/OverViewPage/OverViewPage.test.js
@@ -31,6 +31,10 @@ jest.mock('../../Utilities/Hooks/useFeatureFlag', () => ({
   useFeatureFlag: jest.fn(),
 }));
 
+jest.mock('../../Utilities/Hooks/useIsOrgAdmin', () => ({
+  useIsOrgAdmin: jest.fn(),
+}));
+
 jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
   const MockInsightsLink = ({ children, to }) => (
     <a href={`/insights/${to}`}>{children}</a>
@@ -332,6 +336,7 @@ const renderPageWithList = (list, customStore) => {
 };
 
 const { useFeatureFlag } = require('../../Utilities/Hooks/useFeatureFlag');
+const { useIsOrgAdmin } = require('../../Utilities/Hooks/useIsOrgAdmin');
 const useRemediations =
   require('../../Utilities/Hooks/api/useRemediations').default;
 
@@ -356,6 +361,11 @@ describe('OverViewPage', () => {
     // This is critical when tests run together - mocks from other files can leak
     useFeatureFlag.mockReset();
     useFeatureFlag.mockReturnValue(false);
+    useIsOrgAdmin.mockReset();
+    useIsOrgAdmin.mockReturnValue({
+      isOrgAdmin: false,
+      isLoading: false,
+    });
 
     // Reset useRemediations to default implementation for this test file
     useRemediations.mockReset();
@@ -556,6 +566,42 @@ describe('OverViewPage', () => {
     expect(global.mockActivateQuickstart).toHaveBeenCalledWith(
       'insights-remediate-plan-create',
     );
+  });
+
+  it('shows a disabled retention policy action for non-admin users', async () => {
+    const user = userEvent.setup();
+    const view = renderPage(store);
+    cleanup = view.unmount;
+
+    const actionsToggle = await screen.findByRole('button', {
+      name: /overview page actions/i,
+    });
+    await user.click(actionsToggle);
+
+    const retentionPolicyItem = await screen.findByRole('menuitem', {
+      name: /edit retention policy/i,
+    });
+    expect(retentionPolicyItem).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('keeps the retention policy action visible in the empty state', async () => {
+    const user = userEvent.setup();
+    const view = renderPageWithList([], store);
+    cleanup = view.unmount;
+
+    await waitFor(() => {
+      expect(screen.getByText(/no remediation plans/i)).toBeInTheDocument();
+    });
+
+    const actionsToggle = screen.getByRole('button', {
+      name: /overview page actions/i,
+    });
+    await user.click(actionsToggle);
+
+    const retentionPolicyItem = await screen.findByRole('menuitem', {
+      name: /edit retention policy/i,
+    });
+    expect(retentionPolicyItem).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('hides Launch Quick Start button when no remediations exist', async () => {

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Button,
   Dropdown,
-  DropdownItem,
   DropdownList,
   Flex,
   FlexItem,
@@ -19,16 +18,16 @@ import { RemediationsPopover } from '../RemediationsPopover';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PropTypes from 'prop-types';
 import RetentionPolicyModal from '../../components/RetentionPolicyModal';
+import RetentionPolicyDropdownItem from '../../components/RetentionPolicyDropdownItem';
 import { useIsOrgAdmin } from '../../Utilities/Hooks/useIsOrgAdmin';
 
 export const OverViewPageHeader = ({ hasRemediations }) => {
   const { quickStarts } = useChrome();
-  const { isOrgAdmin: canManageRetentionPolicy } = useIsOrgAdmin();
+  const { isOrgAdmin: canManageRetentionPolicy, isLoading: isOrgAdminLoading } =
+    useIsOrgAdmin();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [retentionPolicyModalOpen, setRetentionPolicyModalOpen] =
     useState(false);
-
-  const showActions = hasRemediations || canManageRetentionPolicy;
 
   return (
     <PageHeader className="pf-v6-u-pb-lg">
@@ -69,59 +68,54 @@ export const OverViewPageHeader = ({ hasRemediations }) => {
           </Stack>
         </FlexItem>
 
-        {showActions && (
-          <FlexItem>
-            <Flex
-              spaceItems={{ default: 'spaceItemsSm' }}
-              alignItems={{ default: 'alignItemsCenter' }}
-            >
-              {hasRemediations && (
-                <FlexItem>
-                  <Button
-                    icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
-                    variant="secondary"
-                    onClick={() =>
-                      quickStarts?.activateQuickstart(
-                        'insights-remediate-plan-create',
-                      )
-                    }
+        <FlexItem>
+          <Flex
+            spaceItems={{ default: 'spaceItemsSm' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            {hasRemediations && (
+              <FlexItem>
+                <Button
+                  icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
+                  variant="secondary"
+                  onClick={() =>
+                    quickStarts?.activateQuickstart(
+                      'insights-remediate-plan-create',
+                    )
+                  }
+                >
+                  Launch Quick Start
+                </Button>
+              </FlexItem>
+            )}
+            <FlexItem>
+              <Dropdown
+                onSelect={() => setDropdownOpen(false)}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    variant="plain"
+                    onClick={() => setDropdownOpen((value) => !value)}
+                    isExpanded={dropdownOpen}
+                    aria-label="Overview page actions"
                   >
-                    Launch Quick Start
-                  </Button>
-                </FlexItem>
-              )}
-              {canManageRetentionPolicy && (
-                <FlexItem>
-                  <Dropdown
-                    onSelect={() => setDropdownOpen(false)}
-                    toggle={(toggleRef) => (
-                      <MenuToggle
-                        ref={toggleRef}
-                        variant="plain"
-                        onClick={() => setDropdownOpen((value) => !value)}
-                        isExpanded={dropdownOpen}
-                        aria-label="Overview page actions"
-                      >
-                        <EllipsisVIcon />
-                      </MenuToggle>
-                    )}
-                    isOpen={dropdownOpen}
-                    popperProps={{ position: 'right' }}
-                  >
-                    <DropdownList>
-                      <DropdownItem
-                        key="retention-policy"
-                        onClick={() => setRetentionPolicyModalOpen(true)}
-                      >
-                        Edit retention policy
-                      </DropdownItem>
-                    </DropdownList>
-                  </Dropdown>
-                </FlexItem>
-              )}
-            </Flex>
-          </FlexItem>
-        )}
+                    <EllipsisVIcon />
+                  </MenuToggle>
+                )}
+                isOpen={dropdownOpen}
+                popperProps={{ position: 'right' }}
+              >
+                <DropdownList>
+                  <RetentionPolicyDropdownItem
+                    canManageRetentionPolicy={canManageRetentionPolicy}
+                    isLoading={isOrgAdminLoading}
+                    onClick={() => setRetentionPolicyModalOpen(true)}
+                  />
+                </DropdownList>
+              </Dropdown>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
       </Flex>
     </PageHeader>
   );

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Flex,
   FlexItem,
+  MenuToggle,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { OpenDrawerRightIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, OpenDrawerRightIcon } from '@patternfly/react-icons';
 import {
   PageHeader,
   PageHeaderTitle,
@@ -14,12 +18,26 @@ import {
 import { RemediationsPopover } from '../RemediationsPopover';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import PropTypes from 'prop-types';
+import RetentionPolicyModal from '../../components/RetentionPolicyModal';
+import { useIsOrgAdmin } from '../../Utilities/Hooks/useIsOrgAdmin';
 
 export const OverViewPageHeader = ({ hasRemediations }) => {
   const { quickStarts } = useChrome();
+  const { isOrgAdmin: canManageRetentionPolicy } = useIsOrgAdmin();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [retentionPolicyModalOpen, setRetentionPolicyModalOpen] =
+    useState(false);
+
+  const showActions = hasRemediations || canManageRetentionPolicy;
 
   return (
     <PageHeader className="pf-v6-u-pb-lg">
+      {retentionPolicyModalOpen && (
+        <RetentionPolicyModal
+          isOpen={retentionPolicyModalOpen}
+          onClose={() => setRetentionPolicyModalOpen(false)}
+        />
+      )}
       <Flex
         justifyContent={{ default: 'spaceBetween' }}
         alignItems={{ default: 'alignItemsFlexStart' }}
@@ -51,19 +69,57 @@ export const OverViewPageHeader = ({ hasRemediations }) => {
           </Stack>
         </FlexItem>
 
-        {hasRemediations && (
+        {showActions && (
           <FlexItem>
-            <Button
-              icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
-              variant="secondary"
-              onClick={() =>
-                quickStarts?.activateQuickstart(
-                  'insights-remediate-plan-create',
-                )
-              }
+            <Flex
+              spaceItems={{ default: 'spaceItemsSm' }}
+              alignItems={{ default: 'alignItemsCenter' }}
             >
-              Launch Quick Start
-            </Button>
+              {hasRemediations && (
+                <FlexItem>
+                  <Button
+                    icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
+                    variant="secondary"
+                    onClick={() =>
+                      quickStarts?.activateQuickstart(
+                        'insights-remediate-plan-create',
+                      )
+                    }
+                  >
+                    Launch Quick Start
+                  </Button>
+                </FlexItem>
+              )}
+              {canManageRetentionPolicy && (
+                <FlexItem>
+                  <Dropdown
+                    onSelect={() => setDropdownOpen(false)}
+                    toggle={(toggleRef) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        variant="plain"
+                        onClick={() => setDropdownOpen((value) => !value)}
+                        isExpanded={dropdownOpen}
+                        aria-label="Overview page actions"
+                      >
+                        <EllipsisVIcon />
+                      </MenuToggle>
+                    )}
+                    isOpen={dropdownOpen}
+                    popperProps={{ position: 'right' }}
+                  >
+                    <DropdownList>
+                      <DropdownItem
+                        key="retention-policy"
+                        onClick={() => setRetentionPolicyModalOpen(true)}
+                      >
+                        Edit retention policy
+                      </DropdownItem>
+                    </DropdownList>
+                  </Dropdown>
+                </FlexItem>
+              )}
+            </Flex>
           </FlexItem>
         )}
       </Flex>

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -99,3 +99,26 @@ export const updateRemediationWrapper = (params) => {
 export const postPlaybookPreview = (payload, options = {}) => {
   return axiosInstance.post(`${API_BASE}/playbook`, payload, options);
 };
+
+/**
+ * GET /config — effective organization-wide retention configuration.
+ * Not yet available in the generated remediations-client, so this is a plain axios
+ * wrapper. Passed directly as the "endpoint" to useRemediations, same as
+ * updateRemediationWrapper. `axiosInstance` already unwraps to `response.data`
+ * via a platform interceptor, so the resolved value is the config object itself.
+ *
+ *  @returns {Promise<{ plan_retention_days: number, plan_warning_days: number }>} Effective retention config
+ */
+export const getOrgConfig = () => axiosInstance.get(`${API_BASE}/config`);
+
+/**
+ * PUT /config/overrides — replace organization-wide retention overrides (org admins only).
+ * Not yet available in the generated remediations-client; see getOrgConfig above.
+ *
+ *  @param   {object}                                                                data                     - Override values to persist
+ *  @param   {number}                                                                data.plan_retention_days - Retention override, in days
+ *  @param   {number}                                                                data.plan_warning_days   - Expiration warning override, in days
+ *  @returns {Promise<{ plan_retention_days?: number, plan_warning_days?: number }>}                          Updated overrides
+ */
+export const putOrgConfigOverrides = (data) =>
+  axiosInstance.put(`${API_BASE}/config/overrides`, data);


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-24751 

This PR implements the retention policy modal.

## Summary by Sourcery

Add an organization-wide remediation plan retention policy modal and surface it from relevant UI entry points.

New Features:
- Introduce a remediation plan retention policy modal that allows org admins to configure global retention and expiration warning durations.
- Expose an actions dropdown on the overview page and remediation details view for org admins to access retention policy settings.
- Add utilities and API wrappers for managing organization retention configuration and overrides.

Enhancements:
- Gate retention policy management actions by org admin status using a new useIsOrgAdmin hook.
- Refine the remediation details dropdown to conditionally show rename and delete actions based on write permissions while adding retention policy management for admins.

Tests:
- Add unit tests for retention policy utilities to validate duration formatting, normalization, and valid warning option calculations.