### PR TITLE
feat(RHINENG-28527): add Amplitude analytics tracking for Remediation user actions

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -15,12 +15,24 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
     getApp: () => 'remediations',
     getBundle: () => 'insights',
     quickStarts: { activateQuickstart: mockActivateQuickstart },
+    analytics: { track: jest.fn(), group: jest.fn() },
+    auth: {
+      getUser: jest
+        .fn()
+        .mockResolvedValue({ identity: { user: { username: 'test-user' } } }),
+    },
   }),
   useChrome: () => ({
     isBeta: jest.fn(),
     chrome: jest.fn(),
     updateDocumentTitle: jest.fn(),
     quickStarts: { activateQuickstart: mockActivateQuickstart },
+    analytics: { track: jest.fn(), group: jest.fn() },
+    auth: {
+      getUser: jest
+        .fn()
+        .mockResolvedValue({ identity: { user: { username: 'test-user' } } }),
+    },
   }),
 }));
 

--- a/src/Utilities/DownloadPlaybookButton.js
+++ b/src/Utilities/DownloadPlaybookButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { downloadPlaybook } from '../api';
 import keyBy from 'lodash/keyBy';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -20,7 +21,7 @@ const verifyDownload = (selectedIds, data) => {
   }, []);
 };
 
-export const download = (selectedIds, data, addNotification) => {
+export const download = (selectedIds, data, addNotification, chrome) => {
   const valid = verifyDownload(selectedIds, data);
 
   if (valid.length === 0) {
@@ -32,6 +33,10 @@ export const download = (selectedIds, data, addNotification) => {
       autoDismiss: true,
     });
   } else if (valid.length < selectedIds.length) {
+    chrome?.analytics?.track('remediations - Playbook Downloaded', {
+      module: 'remediations',
+      count: valid.length,
+    });
     downloadPlaybook(valid);
     const skipped = selectedIds.length - valid.length;
     addNotification({
@@ -40,6 +45,10 @@ export const download = (selectedIds, data, addNotification) => {
       description: `${skipped} empty remediation plan${skipped === 1 ? ' was' : 's were'} not downloaded`,
     });
   } else {
+    chrome?.analytics?.track('remediations - Playbook Downloaded', {
+      module: 'remediations',
+      count: valid.length,
+    });
     downloadPlaybook(valid);
     addNotification({
       title: `Download ready`,
@@ -53,13 +62,14 @@ export const download = (selectedIds, data, addNotification) => {
 
 export const DownloadPlaybookButton = ({ selectedItems = [], data }) => {
   const addNotification = useAddNotification();
+  const chrome = useChrome();
 
   return (
     <Button
       isDisabled={selectedItems?.length < 1}
       variant="primary"
       onClick={() => {
-        download(selectedItems, data, addNotification);
+        download(selectedItems, data, addNotification, chrome);
       }}
     >
       {`Download`}

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -134,6 +134,14 @@ export const ExecuteModal = ({
     setExecutionTimestamp(timestamp);
     setIsExecuting(true);
 
+    chrome.analytics?.track('remediations - Plan Executed', {
+      module: 'remediations',
+      remediation_id: remediation.id,
+      action_count: remediation?.issue_count,
+      system_count: connectedCount,
+      auto_reboot: remediation?.auto_reboot ?? false,
+    });
+
     executeRun({
       id: remediation.id,
       playbookRunsInput: { exclude },

--- a/src/components/Modals/ExecuteModal.js
+++ b/src/components/Modals/ExecuteModal.js
@@ -134,19 +134,18 @@ export const ExecuteModal = ({
     setExecutionTimestamp(timestamp);
     setIsExecuting(true);
 
-    chrome.analytics?.track('remediations - Plan Executed', {
-      module: 'remediations',
-      remediation_id: remediation.id,
-      action_count: remediation?.issue_count,
-      system_count: connectedCount,
-      auto_reboot: remediation?.auto_reboot ?? false,
-    });
-
     executeRun({
       id: remediation.id,
       playbookRunsInput: { exclude },
     })
       .then(() => {
+        chrome.analytics?.track('remediations - Plan Executed', {
+          module: 'remediations',
+          remediation_id: remediation.id,
+          action_count: remediation?.issue_count,
+          system_count: connectedCount,
+          auto_reboot: remediation?.auto_reboot ?? false,
+        });
         refetchRemediationPlaybookRuns();
         addNotification({
           title: `Executing playbook ${remediation.name}`,

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -44,13 +44,12 @@ function RemediationDetailsDropdown({
   });
 
   const handleDelete = async (id) => {
-    chrome.analytics?.track('remediations - Plan Deleted', {
-      module: 'remediations',
-      remediation_id: id,
-    });
-
     try {
       await deleteRemediation({ id });
+      chrome.analytics?.track('remediations - Plan Deleted', {
+        module: 'remediations',
+        remediation_id: id,
+      });
       addNotification({
         title: `Deleted remediation plan ${remediation.name}`,
         variant: 'success',

--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -15,6 +15,7 @@ import RetentionPolicyModal from './RetentionPolicyModal';
 import RetentionPolicyDropdownItem from './RetentionPolicyDropdownItem';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { PermissionContext } from '../App';
 import useRemediations from '../Utilities/Hooks/api/useRemediations';
 import { useIsOrgAdmin } from '../Utilities/Hooks/useIsOrgAdmin';
@@ -36,12 +37,18 @@ function RemediationDetailsDropdown({
     useIsOrgAdmin();
   const navigate = useNavigate();
   const addNotification = useAddNotification();
+  const chrome = useChrome();
 
   const { fetch: deleteRemediation } = useRemediations('deleteRemediation', {
     skip: true,
   });
 
   const handleDelete = async (id) => {
+    chrome.analytics?.track('remediations - Plan Deleted', {
+      module: 'remediations',
+      remediation_id: id,
+    });
+
     try {
       await deleteRemediation({ id });
       addNotification({

--- a/src/components/RemediationWizard/RemediationWizard.js
+++ b/src/components/RemediationWizard/RemediationWizard.js
@@ -349,6 +349,12 @@ export const RemediationWizard = ({
 
       downloadFile(response, sanitizedFilename, 'yml');
       setPreviewStatus('success');
+      chrome.analytics?.track('remediations - Preview Downloaded', {
+        module: 'remediations',
+        is_existing_plan: isExistingPlanSelected,
+        action_count: actionsCount,
+        system_count: systemsCount,
+      });
     } catch (error) {
       console.error('Error generating playbook preview:', error);
       setPreviewStatus('failure');
@@ -451,7 +457,16 @@ export const RemediationWizard = ({
               {isExistingPlanSelected ? 'Update' : 'Create'} plan
             </Button>
           )}
-          <Button key="cancel" variant="link" onClick={handleClose}>
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => {
+              chrome.analytics?.track('remediations - Create Modal Cancelled', {
+                module: 'remediations',
+              });
+              handleClose();
+            }}
+          >
             Cancel
           </Button>
         </Flex>
@@ -505,11 +520,20 @@ export const RemediationWizard = ({
     handleModalClose = handleClose;
   }
 
+  const handleModalCloseWithTracking = handleModalClose
+    ? () => {
+        chrome.analytics?.track('remediations - Create Modal Closed', {
+          module: 'remediations',
+        });
+        handleModalClose();
+      }
+    : undefined;
+
   return (
     <Modal
       isOpen={isOpen}
       variant={ModalVariant.medium}
-      onClose={handleModalClose}
+      onClose={handleModalCloseWithTracking}
     >
       {renderStatusContent() || renderMainContent()}
     </Modal>

--- a/src/components/RemediationWizard/RemediationWizard.js
+++ b/src/components/RemediationWizard/RemediationWizard.js
@@ -213,19 +213,6 @@ export const RemediationWizard = ({
       return;
     }
 
-    chrome.analytics?.track(
-      isExistingPlanSelected
-        ? 'remediations - Plan Updated'
-        : 'remediations - Plan Created',
-      {
-        module: 'remediations',
-        is_existing_plan: isExistingPlanSelected,
-        action_count: actionsCount,
-        system_count: systemsCount,
-        auto_reboot: autoReboot,
-      },
-    );
-
     setIsSubmitting(true);
     resetErrorState();
     totalBatchesRef.current = 0;
@@ -269,6 +256,18 @@ export const RemediationWizard = ({
         result?.status === 'success' &&
         result?.remediationId
       ) {
+        chrome.analytics?.track(
+          isExistingPlanSelected
+            ? 'remediations - Plan Updated'
+            : 'remediations - Plan Created',
+          {
+            module: 'remediations',
+            is_existing_plan: isExistingPlanSelected,
+            action_count: actionsCount,
+            system_count: systemsCount,
+            auto_reboot: autoReboot,
+          },
+        );
         // If there's only one batch (no batching occurred), add a 3-second delay
         if (totalBatchesRef.current === 1) {
           await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/src/components/RemediationWizard/RemediationWizard.js
+++ b/src/components/RemediationWizard/RemediationWizard.js
@@ -38,6 +38,7 @@ import { PlaybookSelect } from './PlaybookSelect';
 import { usePlaybookSelect } from './usePlaybookSelect';
 import ModalStatusContent from './ModalStatusContent';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { postPlaybookPreview } from '../../routes/api';
 import { downloadFile } from '../../Utilities/helpers';
 
@@ -46,6 +47,7 @@ export const RemediationWizard = ({
   data,
   isCompliancePrecedenceEnabled = false,
 }) => {
+  const chrome = useChrome();
   const [isOpen, setIsOpen] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState(null); // 'complete_failure' | 'partial_failure'
@@ -210,6 +212,20 @@ export const RemediationWizard = ({
     if (!hasPlanSelection) {
       return;
     }
+
+    chrome.analytics?.track(
+      isExistingPlanSelected
+        ? 'remediations - Plan Updated'
+        : 'remediations - Plan Created',
+      {
+        module: 'remediations',
+        is_existing_plan: isExistingPlanSelected,
+        action_count: actionsCount,
+        system_count: systemsCount,
+        auto_reboot: autoReboot,
+      },
+    );
+
     setIsSubmitting(true);
     resetErrorState();
     totalBatchesRef.current = 0;

--- a/src/components/RenameModal.js
+++ b/src/components/RenameModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TextInputDialog from './Dialogs/TextInputDialog';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import useRemediations from '../Utilities/Hooks/api/useRemediations';
 import { updateRemediationWrapper } from '../routes/api';
 
@@ -15,6 +16,7 @@ const RenameModal = ({
   refetch,
 }) => {
   const addNotification = useAddNotification();
+  const chrome = useChrome();
   const { fetch: updateRemediation } = useRemediations(
     updateRemediationWrapper,
     {
@@ -27,6 +29,11 @@ const RenameModal = ({
       name = EMPTY_NAME;
     }
     const trimmedName = name.trim();
+
+    chrome.analytics?.track('remediations - Plan Renamed', {
+      module: 'remediations',
+      remediation_id: id,
+    });
 
     try {
       await updateRemediation({ id, name: trimmedName });

--- a/src/components/RenameModal.js
+++ b/src/components/RenameModal.js
@@ -30,13 +30,12 @@ const RenameModal = ({
     }
     const trimmedName = name.trim();
 
-    chrome.analytics?.track('remediations - Plan Renamed', {
-      module: 'remediations',
-      remediation_id: id,
-    });
-
     try {
       await updateRemediation({ id, name: trimmedName });
+      chrome.analytics?.track('remediations - Plan Renamed', {
+        module: 'remediations',
+        remediation_id: id,
+      });
       addNotification({
         title: `Remediation plan renamed`,
         variant: 'success',

--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -27,6 +27,7 @@ const RemediationButtonContent = ({
   isCompliancePrecedenceEnabled,
   buttonTooltipContent,
 }) => {
+  const chrome = useChrome();
   const [remediationsData, setRemediationsData] = useState();
   const [isNoDataModalOpen, setNoDataModalOpen] = useState(false);
 
@@ -65,6 +66,14 @@ const RemediationButtonContent = ({
 
                 try {
                   validate(data);
+                  chrome.analytics?.track(
+                    'remediations - Remediate Button Clicked',
+                    {
+                      module: 'remediations',
+                      issue_count: data?.issues?.length,
+                      system_count: data?.systems?.length,
+                    },
+                  );
                   setRemediationsData(data);
                 } catch {
                   setNoDataModalOpen(true);

--- a/src/modules/RemediationsButton.js
+++ b/src/modules/RemediationsButton.js
@@ -4,6 +4,7 @@ import propTypes from 'prop-types';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import validate from './RemediationsModal/validate';
+import { normalizeRemediationData } from '../components/helpers';
 
 import { Button, Tooltip } from '@patternfly/react-core';
 import RemediationWizard from '../components/RemediationWizard/RemediationWizard';
@@ -66,12 +67,13 @@ const RemediationButtonContent = ({
 
                 try {
                   validate(data);
+                  const normalizedData = normalizeRemediationData(data);
                   chrome.analytics?.track(
                     'remediations - Remediate Button Clicked',
                     {
                       module: 'remediations',
-                      issue_count: data?.issues?.length,
-                      system_count: data?.systems?.length,
+                      issue_count: normalizedData?.issues?.length ?? 0,
+                      system_count: normalizedData?.systems?.length ?? 0,
                     },
                   );
                   setRemediationsData(data);

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -166,23 +166,22 @@ export const OverViewPage = () => {
           onClose={(confirm) => {
             setIsDeleteModalOpen(false);
             if (confirm) {
-              if (isBulkDelete) {
-                chrome.analytics?.track('remediations - Plans Bulk Deleted', {
-                  module: 'remediations',
-                  count: currentlySelected.length,
-                });
-              } else {
-                chrome.analytics?.track('remediations - Plan Deleted', {
-                  module: 'remediations',
-                  remediation_id: remediation.itemId,
-                });
-              }
-
               let executeDeleteFunction = isBulkDelete
                 ? handleBulkDeleteClick(currentlySelected)
                 : handleSingleDeleteClick(remediation.itemId);
 
               executeDeleteFunction.then(() => {
+                if (isBulkDelete) {
+                  chrome.analytics?.track('remediations - Plans Bulk Deleted', {
+                    module: 'remediations',
+                    count: currentlySelected.length,
+                  });
+                } else {
+                  chrome.analytics?.track('remediations - Plan Deleted', {
+                    module: 'remediations',
+                    remediation_id: remediation.itemId,
+                  });
+                }
                 addNotification({
                   title: `Remediation plan${
                     currentlySelected.length > 1 ? 's' : ''

--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import columns from '../Columns';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import RemediationsTable from '../../components/RemediationsTable/RemediationsTable';
@@ -36,6 +37,7 @@ import { CalendarFilterType } from './CalendarFilterType';
 
 export const OverViewPage = () => {
   const dispatch = useDispatch();
+  const chrome = useChrome();
   const addNotification = useAddNotification();
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -83,7 +85,7 @@ export const OverViewPage = () => {
   });
 
   const handleDownloadClick = async (itemId) => {
-    await download([itemId], result.data, addNotification);
+    await download([itemId], result.data, addNotification, chrome);
   };
 
   const handleBulkDeleteClick = async (selected) => {
@@ -164,6 +166,18 @@ export const OverViewPage = () => {
           onClose={(confirm) => {
             setIsDeleteModalOpen(false);
             if (confirm) {
+              if (isBulkDelete) {
+                chrome.analytics?.track('remediations - Plans Bulk Deleted', {
+                  module: 'remediations',
+                  count: currentlySelected.length,
+                });
+              } else {
+                chrome.analytics?.track('remediations - Plan Deleted', {
+                  module: 'remediations',
+                  remediation_id: remediation.itemId,
+                });
+              }
+
               let executeDeleteFunction = isBulkDelete
                 ? handleBulkDeleteClick(currentlySelected)
                 : handleSingleDeleteClick(remediation.itemId);

--- a/src/routes/OverViewPage/OverViewPageHeader.js
+++ b/src/routes/OverViewPage/OverViewPageHeader.js
@@ -25,7 +25,7 @@ export const OverViewPageHeader = ({
   hasRemediations,
   onRetentionPolicyUpdated,
 }) => {
-  const { quickStarts } = useChrome();
+  const chrome = useChrome();
   const { isOrgAdmin: canManageRetentionPolicy, isLoading: isOrgAdminLoading } =
     useIsOrgAdmin();
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -82,11 +82,18 @@ export const OverViewPageHeader = ({
                 <Button
                   icon={<OpenDrawerRightIcon className="pf-v6-u-ml-sm" />}
                   variant="secondary"
-                  onClick={() =>
-                    quickStarts?.activateQuickstart(
+                  onClick={() => {
+                    chrome.quickStarts?.activateQuickstart(
                       'insights-remediate-plan-create',
-                    )
-                  }
+                    );
+                    chrome.analytics?.track(
+                      'remediations - Quick Start Launched',
+                      {
+                        module: 'remediations',
+                        source: 'overview_page',
+                      },
+                    );
+                  }}
                 >
                   Launch Quick Start
                 </Button>

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -220,7 +220,7 @@ const ActionsContent = ({
               await handleDelete(chopped);
               chrome.analytics?.track('remediations - Actions Removed', {
                 module: 'remediations',
-                remediation_id: id,
+                remediation_id: remediationId,
                 count: chopped.length,
                 is_bulk: isBulkDelete,
               });

--- a/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
+++ b/src/routes/RemediationDetailsComponents/ActionsContent/ActionsContent.js
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import columns from './Columns';
 import { Button } from '@patternfly/react-core';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import useRemediations from '../../../Utilities/Hooks/api/useRemediations';
 import useRemediationFetchExtras from '../../../api/useRemediationFetchExtras';
 import { useParams } from 'react-router-dom';
@@ -24,6 +25,7 @@ const ActionsContent = ({
   remediationId,
   refetchRemediationDetails,
 }) => {
+  const chrome = useChrome();
   const { id } = useParams();
   const tableState = useRawTableState();
   const currentlySelected = tableState?.selected;
@@ -216,6 +218,12 @@ const ActionsContent = ({
             }
             try {
               await handleDelete(chopped);
+              chrome.analytics?.track('remediations - Actions Removed', {
+                module: 'remediations',
+                remediation_id: id,
+                count: chopped.length,
+                is_bulk: isBulkDelete,
+              });
               refetchIssues();
               addNotification({
                 title: 'Successfully deleted actions',

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -141,6 +141,10 @@ const DetailsCard = ({
         await refetchAllRemediations();
       });
 
+      chrome.analytics?.track('remediations - Plan Renamed', {
+        module: 'remediations',
+        remediation_id: details.id,
+      });
       addNotification({
         title: `Remediation plan renamed`,
         variant: 'success',
@@ -163,15 +167,15 @@ const DetailsCard = ({
     return <Spinner />;
   }
   const onToggleAutoreboot = async () => {
-    chrome.analytics?.track('remediations - Auto-Reboot Toggled', {
-      module: 'remediations',
-      remediation_id: details.id,
-      auto_reboot: !rebootToggle,
-    });
-
-    setRebootToggle(!rebootToggle);
+    const newValue = !rebootToggle;
+    setRebootToggle(newValue);
     try {
-      await updateRemPlan({ id: details.id, auto_reboot: !rebootToggle });
+      await updateRemPlan({ id: details.id, auto_reboot: newValue });
+      chrome.analytics?.track('remediations - Auto-Reboot Toggled', {
+        module: 'remediations',
+        remediation_id: details.id,
+        auto_reboot: newValue,
+      });
       await refetch();
     } catch (error) {
       console.error(error);

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -32,6 +32,7 @@ import {
 import { useVerifyName } from '../../Utilities/useVerifyName';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { pluralize } from '../../Utilities/utils';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 
@@ -43,6 +44,7 @@ const DetailsCard = ({
   refetch,
   refetchAllRemediations,
 }) => {
+  const chrome = useChrome();
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(details?.name);
   const [rebootToggle, setRebootToggle] = useState(details?.auto_reboot);
@@ -161,6 +163,12 @@ const DetailsCard = ({
     return <Spinner />;
   }
   const onToggleAutoreboot = async () => {
+    chrome.analytics?.track('remediations - Auto-Reboot Toggled', {
+      module: 'remediations',
+      remediation_id: details.id,
+      auto_reboot: !rebootToggle,
+    });
+
     setRebootToggle(!rebootToggle);
     try {
       await updateRemPlan({ id: details.id, auto_reboot: !rebootToggle });

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -6,6 +6,7 @@ import {
   GridItem,
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { calculateActionPointsFromSummary } from '../../components/helpers';
 import { calculateExecutionLimits } from './helpers';
 import DetailsCard from './DetailsCard';
@@ -26,6 +27,7 @@ const DetailsGeneralContent = ({
   retentionPolicyRefreshNonce,
   actionPoints: actionPointsProp,
 }) => {
+  const chrome = useChrome();
   const actionPointsComputed = useMemo(() => {
     return calculateActionPointsFromSummary(details?.issue_count_details);
   }, [details?.issue_count_details]);
@@ -95,6 +97,15 @@ const DetailsGeneralContent = ({
               href="http://sandbox.redhat.com"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() =>
+                chrome.analytics?.track(
+                  'remediations - AAP Trial Link Clicked',
+                  {
+                    module: 'remediations',
+                    remediation_id: details.id,
+                  },
+                )
+              }
             >
               Get a 30-day free trial of Red Hat Ansible Automation Platform
             </a>


### PR DESCRIPTION
In speaking with Talia, I threw this PR together as a prototype for the team to consider.  I think it looks fairly clean but maybe a little AI slop around proper importing of Chrome that I just wasn;t sure about nor the mocks for jest.  

Instrument 11 key user actions with chrome.analytics?.track() to enable understanding of plan creation, execution, deletion, downloads, and other high-value interactions.

# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-28527

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Instrument remediation workflows with analytics tracking for key user actions.

New Features:
- Track core remediation lifecycle events (creation, updates, execution, deletion, bulk deletion, rename) via chrome analytics.

Enhancements:
- Capture analytics for remediation-related UI interactions, including remediate button clicks, playbook downloads, action removals, and auto-reboot toggles.

Tests:
- Extend Jest chrome mocks to include analytics and auth to support the new tracking logic in tests.

Chores:
- Plumb chrome instance into remediation components and utilities that need to emit analytics events.