### PR TITLE
feat(RHINENG-28095): add Activity card to Detail page

### DIFF
--- a/src/components/RemediationDetailsDropdown.js
+++ b/src/components/RemediationDetailsDropdown.js
@@ -24,6 +24,7 @@ function RemediationDetailsDropdown({
   remediationsList,
   refetchRemediationDetails,
   refetchAllRemediations,
+  onRetentionPolicyUpdated,
 }) {
   const [open, setOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
@@ -90,6 +91,7 @@ function RemediationDetailsDropdown({
         <RetentionPolicyModal
           isOpen={retentionPolicyModalOpen}
           onClose={() => setRetentionPolicyModalOpen(false)}
+          onRetentionPolicyUpdated={onRetentionPolicyUpdated}
         />
       )}
 
@@ -144,6 +146,7 @@ RemediationDetailsDropdown.propTypes = {
   remediationsList: PropTypes.array,
   refetchRemediationDetails: PropTypes.func,
   refetchAllRemediations: PropTypes.func,
+  onRetentionPolicyUpdated: PropTypes.func,
 };
 
 export default RemediationDetailsDropdown;

--- a/src/components/RetentionPolicyModal.js
+++ b/src/components/RetentionPolicyModal.js
@@ -85,7 +85,7 @@ DurationSelect.propTypes = {
   isDisabled: PropTypes.bool,
 };
 
-const RetentionPolicyModal = ({ isOpen, onClose }) => {
+const RetentionPolicyModal = ({ isOpen, onClose, onRetentionPolicyUpdated }) => {
   const addNotification = useAddNotification();
   const [retentionDays, setRetentionDays] = useState(null);
   const [warningDays, setWarningDays] = useState(null);
@@ -163,6 +163,7 @@ const RetentionPolicyModal = ({ isOpen, onClose }) => {
         dismissable: true,
         autoDismiss: true,
       });
+      onRetentionPolicyUpdated?.();
       onClose();
     } catch (error) {
       console.error(error);
@@ -260,6 +261,7 @@ const RetentionPolicyModal = ({ isOpen, onClose }) => {
 RetentionPolicyModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onRetentionPolicyUpdated: PropTypes.func,
 };
 
 export default RetentionPolicyModal;

--- a/src/components/RetentionPolicyModal.js
+++ b/src/components/RetentionPolicyModal.js
@@ -85,7 +85,11 @@ DurationSelect.propTypes = {
   isDisabled: PropTypes.bool,
 };
 
-const RetentionPolicyModal = ({ isOpen, onClose, onRetentionPolicyUpdated }) => {
+const RetentionPolicyModal = ({
+  isOpen,
+  onClose,
+  onRetentionPolicyUpdated,
+}) => {
   const addNotification = useAddNotification();
   const [retentionDays, setRetentionDays] = useState(null);
   const [warningDays, setWarningDays] = useState(null);

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -173,7 +173,6 @@ const RemediationDetails = () => {
               <DetailsGeneralContent
                 details={remediationDetailsSummary}
                 refetchAllRemediations={refetchAllRemediations}
-                onRename={setIsRenameModalOpen}
                 refetch={refetchRemediationDetails}
                 remediationStatus={remediationStatus}
                 updateRemPlan={updateRemPlan}
@@ -181,7 +180,6 @@ const RemediationDetails = () => {
                 allRemediations={allRemediationsData}
                 permissions={context.permissions}
                 lastRemediationPlaybookRun={remediationPlaybookRuns?.data[0]}
-                detailsLoading={detailsLoading}
                 isPlaybookRunsLoading={isPlaybookRunsLoading}
                 actionPoints={actionPoints}
               />

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -180,7 +180,7 @@ const RemediationDetails = () => {
                 onNavigateToTab={handleTabClick}
                 allRemediations={allRemediationsData}
                 permissions={context.permissions}
-                remediationPlaybookRuns={remediationPlaybookRuns?.data[0]}
+                lastRemediationPlaybookRun={remediationPlaybookRuns?.data[0]}
                 detailsLoading={detailsLoading}
                 isPlaybookRunsLoading={isPlaybookRunsLoading}
                 actionPoints={actionPoints}

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,4 +1,10 @@
-import React, { useCallback, useContext, useEffect, useState, useMemo } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useMemo,
+} from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useRemediations from '../Utilities/Hooks/api/useRemediations';
 import { updateRemediationWrapper } from './api';

--- a/src/routes/RemediationDetails.js
+++ b/src/routes/RemediationDetails.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useRemediations from '../Utilities/Hooks/api/useRemediations';
 import { updateRemediationWrapper } from './api';
@@ -19,6 +19,8 @@ const RemediationDetails = () => {
   const { id } = useParams();
 
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [retentionPolicyRefreshNonce, setRetentionPolicyRefreshNonce] =
+    useState(0);
   const [searchParams, setSearchParams] = useSearchParams();
   const [showPlanNotFound, setShowPlanNotFound] = useState(false);
   const { isFedramp } = chrome;
@@ -58,6 +60,11 @@ const RemediationDetails = () => {
   const { fetch: updateRemPlan } = useRemediations(updateRemediationWrapper, {
     skip: true,
   });
+
+  const handleRetentionPolicyUpdated = useCallback(() => {
+    refetchRemediationDetails();
+    setRetentionPolicyRefreshNonce((currentNonce) => currentNonce + 1);
+  }, [refetchRemediationDetails]);
 
   useEffect(() => {
     remediationDetailsSummary &&
@@ -149,6 +156,7 @@ const RemediationDetails = () => {
             remediationPlaybookRuns={remediationPlaybookRuns}
             isPlaybookRunsLoading={isPlaybookRunsLoading}
             actionPoints={actionPoints}
+            onRetentionPolicyUpdated={handleRetentionPolicyUpdated}
           />
           <Tabs
             activeKey={searchParams.get('activeTab') || 'general'}
@@ -181,6 +189,7 @@ const RemediationDetails = () => {
                 permissions={context.permissions}
                 lastRemediationPlaybookRun={remediationPlaybookRuns?.data[0]}
                 isPlaybookRunsLoading={isPlaybookRunsLoading}
+                retentionPolicyRefreshNonce={retentionPolicyRefreshNonce}
                 actionPoints={actionPoints}
               />
             </Tab>

--- a/src/routes/RemediationDetailsComponents/ActivityCard.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.js
@@ -1,0 +1,265 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  CardTitle,
+  Flex,
+  Title,
+  Label,
+  Tooltip,
+  Popover,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  CardBody,
+  Spinner,
+  Button,
+  Icon,
+} from '@patternfly/react-core';
+import { formatDate } from '../Cells';
+import { execStatus, toValidDate } from './helpers';
+import useRemediations from '../../Utilities/Hooks/api/useRemediations';
+import { getOrgConfig } from '../api';
+import { capitalize, pluralize } from '../../Utilities/utils';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  OutlinedQuestionCircleIcon,
+} from '@patternfly/react-icons';
+import { calculateExpiresInDays, textualizeExpiresInDays } from '../helpers';
+
+const getExpirationState = ({
+  expiresAtDate,
+  warningDays,
+  hasOrgConfigError,
+}) => {
+  if (!expiresAtDate) {
+    return {
+      key: 'unknown',
+      label: 'Expiration date unknown',
+      labelStatus: 'danger',
+      text: 'Expiration date unknown',
+      icon: 'danger',
+      hasTooltip: false,
+    };
+  }
+
+  const expiresInDays = calculateExpiresInDays(expiresAtDate);
+  if (expiresInDays < 0) {
+    return {
+      key: 'expired',
+      label: 'Expired',
+      labelStatus: 'warning',
+      text: 'Expired',
+      icon: 'warning',
+      hasTooltip: true,
+    };
+  }
+
+  const remainingText = capitalize(
+    `${textualizeExpiresInDays(expiresInDays)} remaining`,
+  );
+  const isWarningWindowKnown = !hasOrgConfigError && warningDays > 0;
+  const isWithinWarningWindow =
+    isWarningWindowKnown && expiresInDays <= warningDays;
+  if (isWithinWarningWindow) {
+    return {
+      key: 'warning',
+      label: `Expires in ${textualizeExpiresInDays(expiresInDays)}`,
+      labelStatus: 'warning',
+      text: remainingText,
+      icon: 'warning',
+      hasTooltip: true,
+    };
+  }
+
+  return {
+    key: 'normal',
+    label: null,
+    labelStatus: null,
+    text: remainingText,
+    icon: null,
+    hasTooltip: true,
+  };
+};
+
+const ActivityCard = ({
+  details,
+  onNavigateToTab,
+  lastRemediationPlaybookRun,
+  isPlaybookRunsLoading,
+  retentionPolicyRefreshNonce = 0,
+}) => {
+  // Get organization configuration
+  const {
+    result: orgConfig,
+    error: orgConfigError,
+    refetch: refetchOrgConfig,
+  } =
+    useRemediations(getOrgConfig);
+
+  useEffect(() => {
+    if (retentionPolicyRefreshNonce > 0 && refetchOrgConfig) {
+      refetchOrgConfig();
+    }
+  }, [retentionPolicyRefreshNonce, refetchOrgConfig]);
+
+  // Transform timestamp fields into dates
+  // If the timestamp is invalid, set to null
+  const updatedAtDate = toValidDate(lastRemediationPlaybookRun?.updated_at);
+  const expiresAtDate = toValidDate(details?.expires_at);
+
+  const warningDays = orgConfig?.plan_warning_days;
+  const expirationState = getExpirationState({
+    expiresAtDate,
+    warningDays,
+    hasOrgConfigError: Boolean(orgConfigError),
+  });
+
+  // Build the retention period text from effective config
+  const retentionDays = orgConfig?.plan_retention_days;
+  const retentionDurationText =
+    retentionDays != null
+      ? pluralize(retentionDays, 'day')
+      : 'an unknown period';
+
+  return (
+    <Card isFullHeight>
+      <CardTitle>
+        <Flex
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+        >
+          <Title headingLevel="h4" size="xl">
+            Activity
+          </Title>
+          {expirationState.label && (
+            <Label status={expirationState.labelStatus} variant="outline">
+              {expirationState.label}
+            </Label>
+          )}
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <DescriptionList>
+          {/* Last Execution Status */}
+          <DescriptionListGroup>
+            <DescriptionListTerm>Latest execution status</DescriptionListTerm>
+            <DescriptionListDescription>
+              {isPlaybookRunsLoading ? (
+                <Spinner size="md" />
+              ) : (
+                <Button
+                  variant="link"
+                  isInline
+                  onClick={() => onNavigateToTab(null, 'executionHistory')}
+                >
+                  {execStatus(
+                    lastRemediationPlaybookRun?.status,
+                    updatedAtDate,
+                  )}
+                </Button>
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {/* Created */}
+          <DescriptionListGroup>
+            <DescriptionListTerm>Created</DescriptionListTerm>
+            <DescriptionListDescription>
+              {formatDate(details?.created_at)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {/* Expiration */}
+          <DescriptionListGroup>
+            <DescriptionListTerm>
+              <Flex
+                spaceItems={{ default: 'spaceItemsXs' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+              >
+                <span>Expiration</span>
+                <Popover
+                  aria-label="Retention policy help popover"
+                  headerContent="Retention policy"
+                  bodyContent={
+                    <div>
+                      Remediation plans are automatically deleted after{' '}
+                      {retentionDurationText} of inactivity. An administrator
+                      can change this period for your organization by editing
+                      the retention policy.
+                    </div>
+                  }
+                >
+                  <Button
+                    variant="plain"
+                    icon={<OutlinedQuestionCircleIcon />}
+                    aria-label="Retention policy help"
+                    hasNoPadding
+                  />
+                </Popover>
+              </Flex>
+            </DescriptionListTerm>
+            <DescriptionListDescription>
+              <Flex
+                spaceItems={{ default: 'spaceItemsSm' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+              >
+                {expirationState.icon === 'danger' ? (
+                  <Icon status="danger" data-testid="icon">
+                    <ExclamationCircleIcon />
+                  </Icon>
+                ) : expirationState.icon === 'warning' ? (
+                  <Icon status="warning" data-testid="icon">
+                    <ExclamationTriangleIcon />
+                  </Icon>
+                ) : null}
+                {expirationState.hasTooltip ? (
+                  <Tooltip content={formatDate(expiresAtDate)} position="top">
+                    <span
+                      style={{
+                        textDecorationLine: 'underline',
+                        textDecorationStyle: 'dashed',
+                        textDecorationColor:
+                          'var(--pf-t--global--border--color--default)',
+                        textUnderlineOffset: '2px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {expirationState.text}
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <span>{expirationState.text}</span>
+                )}
+              </Flex>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {/* Last Modified */}
+          <DescriptionListGroup>
+            <DescriptionListTerm>Last modified</DescriptionListTerm>
+            <DescriptionListDescription>
+              {formatDate(details?.updated_at)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {/* Last Execution */}
+          <DescriptionListGroup>
+            <DescriptionListTerm>Last execution</DescriptionListTerm>
+            <DescriptionListDescription>
+              {updatedAtDate ? formatDate(updatedAtDate) : 'Never'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </CardBody>
+    </Card>
+  );
+};
+
+ActivityCard.propTypes = {
+  details: PropTypes.object.isRequired,
+  onNavigateToTab: PropTypes.func.isRequired,
+  lastRemediationPlaybookRun: PropTypes.object,
+  isPlaybookRunsLoading: PropTypes.bool,
+  retentionPolicyRefreshNonce: PropTypes.number,
+};
+
+export default ActivityCard;

--- a/src/routes/RemediationDetailsComponents/ActivityCard.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.js
@@ -240,11 +240,17 @@ const ActivityCard = ({
               {formatDate(details?.updated_at)}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          {/* Last Execution */}
+          {/* Last Executed */}
           <DescriptionListGroup>
-            <DescriptionListTerm>Last execution</DescriptionListTerm>
+            <DescriptionListTerm>Last executed</DescriptionListTerm>
             <DescriptionListDescription>
-              {updatedAtDate ? formatDate(updatedAtDate) : 'Never'}
+              {isPlaybookRunsLoading ? (
+                <Spinner size="md" />
+              ) : updatedAtDate ? (
+                formatDate(updatedAtDate)
+              ) : (
+                'Never'
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>

--- a/src/routes/RemediationDetailsComponents/ActivityCard.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.js
@@ -96,8 +96,7 @@ const ActivityCard = ({
     result: orgConfig,
     error: orgConfigError,
     refetch: refetchOrgConfig,
-  } =
-    useRemediations(getOrgConfig);
+  } = useRemediations(getOrgConfig);
 
   useEffect(() => {
     if (retentionPolicyRefreshNonce > 0 && refetchOrgConfig) {

--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -1,0 +1,251 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ActivityCard from './ActivityCard';
+import useRemediations from '../../Utilities/Hooks/api/useRemediations';
+import { getOrgConfig } from '../api';
+import { formatDate } from '../Cells';
+
+jest.mock('../../Utilities/Hooks/api/useRemediations');
+
+describe('ActivityCard', () => {
+  const NOW = '2026-07-08T12:00:00Z';
+  const defaultOrgConfig = {
+    plan_warning_days: 30,
+    plan_retention_days: 90,
+  };
+
+  const createDetails = (overrides = {}) => ({
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    expires_at: '2026-07-28T00:00:00Z',
+    ...overrides,
+  });
+
+  const createPlaybookRun = (overrides = {}) => ({
+    status: 'success',
+    updated_at: '2026-07-07T12:00:00Z',
+    ...overrides,
+  });
+
+  const renderComponent = (
+    {
+      details = createDetails(),
+      lastRemediationPlaybookRun = createPlaybookRun(),
+      isPlaybookRunsLoading = false,
+      onNavigateToTab = jest.fn(),
+      retentionPolicyRefreshNonce = 0,
+    } = {},
+    orgConfigResponse = {
+      result: defaultOrgConfig,
+      error: undefined,
+      refetch: jest.fn(),
+    },
+  ) => {
+    useRemediations.mockReturnValue(orgConfigResponse);
+
+    const renderResult = render(
+      <ActivityCard
+        details={details}
+        lastRemediationPlaybookRun={lastRemediationPlaybookRun}
+        isPlaybookRunsLoading={isPlaybookRunsLoading}
+        onNavigateToTab={onNavigateToTab}
+        retentionPolicyRefreshNonce={retentionPolicyRefreshNonce}
+      />,
+    );
+
+    return { onNavigateToTab, ...renderResult };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.parse(NOW));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('rendering', () => {
+    it('shows a loading spinner while playbook runs are loading', () => {
+      renderComponent({ isPlaybookRunsLoading: true });
+
+      expect(
+        screen.getByRole('heading', { name: 'Activity' }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(
+        screen.getByText(formatDate(createDetails().created_at)),
+      ).toBeInTheDocument();
+      expect(useRemediations).toHaveBeenCalledWith(getOrgConfig);
+    });
+
+    it('renders activity details and opens execution history from the latest status link', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const { onNavigateToTab } = renderComponent();
+
+      const latestStatusButton = screen.getByRole('button', {
+        name: /Succeeded 1 day ago/i,
+      });
+
+      expect(latestStatusButton).toBeInTheDocument();
+      expect(
+        screen.getByText(formatDate(createDetails().created_at)),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(formatDate(createDetails().updated_at)),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(formatDate(createPlaybookRun().updated_at)),
+      ).toBeInTheDocument();
+
+      await user.click(latestStatusButton);
+
+      expect(onNavigateToTab).toHaveBeenCalledWith(null, 'executionHistory');
+    });
+
+    it('refetches organization config after a retention policy update', () => {
+      const refetchOrgConfig = jest.fn();
+      const props = {
+        details: createDetails(),
+        lastRemediationPlaybookRun: createPlaybookRun(),
+        isPlaybookRunsLoading: false,
+        onNavigateToTab: jest.fn(),
+      };
+
+      const { rerender } = renderComponent(
+        {
+          ...props,
+          retentionPolicyRefreshNonce: 0,
+        },
+        {
+          result: defaultOrgConfig,
+          error: undefined,
+          refetch: refetchOrgConfig,
+        },
+      );
+
+      expect(refetchOrgConfig).not.toHaveBeenCalled();
+
+      rerender(
+        <ActivityCard
+          {...props}
+          retentionPolicyRefreshNonce={1}
+        />,
+      );
+
+      expect(refetchOrgConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('expiration states', () => {
+    it('shows an expiration warning and retention policy details when the plan is close to expiring', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      renderComponent();
+
+      expect(screen.getByText('Expires in 20 days')).toBeInTheDocument();
+      expect(screen.getByText('20 days remaining')).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: /retention policy help/i }),
+      );
+
+      expect(
+        await screen.findByText(
+          /automatically deleted after 90 days of inactivity/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows month-based expiration text without a warning when outside the warning window', () => {
+      renderComponent({
+        details: createDetails({ expires_at: '2026-09-15T00:00:00Z' }),
+      });
+
+      expect(screen.queryByText(/Expires in/i)).not.toBeInTheDocument();
+      expect(screen.getByText('2 months remaining')).toBeInTheDocument();
+    });
+
+    it('falls back to an unknown expiration date and never-executed state when date data is missing', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      renderComponent(
+        {
+          details: createDetails({ expires_at: null }),
+          lastRemediationPlaybookRun: {},
+        },
+        {
+          result: {
+            plan_warning_days: 30,
+            plan_retention_days: null,
+          },
+          error: undefined,
+        },
+      );
+
+      expect(screen.getAllByText('Expiration date unknown')).toHaveLength(2);
+      expect(screen.getByRole('button', { name: 'N/A' })).toBeInTheDocument();
+      expect(screen.getByText('Never')).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: /retention policy help/i }),
+      );
+
+      expect(
+        await screen.findByText(
+          /automatically deleted after an unknown period of inactivity/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows an expired warning when the known expiration date is already in the past', () => {
+      renderComponent(
+        {
+          details: createDetails({ expires_at: '2026-07-01T00:00:00Z' }),
+        },
+        {
+          result: defaultOrgConfig,
+          error: new Error('Failed to load organization configuration'),
+        },
+      );
+
+      expect(screen.getAllByText('Expired')).toHaveLength(2);
+      expect(
+        screen.queryByText('Expiration date unknown'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows an expired state when the expiration timestamp passed earlier today', () => {
+      renderComponent(
+        {
+          details: createDetails({ expires_at: '2026-07-08T00:00:00Z' }),
+        },
+        {
+          result: defaultOrgConfig,
+          error: new Error('Failed to load organization configuration'),
+        },
+      );
+
+      expect(screen.getAllByText('Expired')).toHaveLength(2);
+      expect(screen.queryByText(/remaining/i)).not.toBeInTheDocument();
+    });
+
+    it('suppresses the expiration warning when organization configuration cannot be loaded', () => {
+      renderComponent(
+        {
+          details: createDetails({ expires_at: '2026-07-28T00:00:00Z' }),
+        },
+        {
+          result: defaultOrgConfig,
+          error: new Error('Failed to load organization configuration'),
+        },
+      );
+
+      expect(screen.queryByText('Expires in 20 days')).not.toBeInTheDocument();
+      expect(screen.getByText('20 days remaining')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -45,7 +45,7 @@ describe('ActivityCard', () => {
   ) => {
     useRemediations.mockReturnValue(orgConfigResponse);
 
-    const renderResult = render(
+    const view = render(
       <ActivityCard
         details={details}
         lastRemediationPlaybookRun={lastRemediationPlaybookRun}
@@ -55,7 +55,7 @@ describe('ActivityCard', () => {
       />,
     );
 
-    return { onNavigateToTab, ...renderResult };
+    return { onNavigateToTab, ...view };
   };
 
   beforeEach(() => {
@@ -129,12 +129,7 @@ describe('ActivityCard', () => {
 
       expect(refetchOrgConfig).not.toHaveBeenCalled();
 
-      rerender(
-        <ActivityCard
-          {...props}
-          retentionPolicyRefreshNonce={1}
-        />,
-      );
+      rerender(<ActivityCard {...props} retentionPolicyRefreshNonce={1} />);
 
       expect(refetchOrgConfig).toHaveBeenCalledTimes(1);
     });

--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -75,7 +75,7 @@ describe('ActivityCard', () => {
       expect(
         screen.getByRole('heading', { name: 'Activity' }),
       ).toBeInTheDocument();
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getAllByRole('progressbar')).toHaveLength(2);
       expect(
         screen.getByText(formatDate(createDetails().created_at)),
       ).toBeInTheDocument();

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -420,7 +420,7 @@ DetailsCard.propTypes = {
     updated_at: PropTypes.string.isRequired,
     issue_count: PropTypes.number.isRequired,
     system_count: PropTypes.number.isRequired,
-  }).isRequired,
+  }),
   onNavigateToTab: PropTypes.func,
   allRemediations: PropTypes.array,
   updateRemPlan: PropTypes.func,

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -255,6 +255,11 @@ const DetailsCard = ({
                 variant="link"
                 onClick={() => setEditing(!editing)}
                 className="pf-v6-u-ml-sm"
+                aria-label={
+                  editing
+                    ? 'Close remediation plan name editor'
+                    : 'Edit remediation plan name'
+                }
               ></Button>
             </DescriptionListTerm>
             <DescriptionListDescription>
@@ -303,6 +308,7 @@ const DetailsCard = ({
                         variant="link"
                         onClick={() => onSubmit(value)}
                         isDisabled={nameStatus !== 'valid'}
+                        aria-label="Save remediation plan name"
                       ></Button>
                       <Button
                         icon={
@@ -310,6 +316,7 @@ const DetailsCard = ({
                         }
                         variant="link"
                         onClick={() => setEditing(false)}
+                        aria-label="Cancel remediation plan name edit"
                       ></Button>
                     </Flex>
                   </FlexItem>

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -29,10 +29,8 @@ import {
   PencilAltIcon,
   TimesIcon,
 } from '@patternfly/react-icons';
-import { formatDate } from '../Cells';
 import { useVerifyName } from '../../Utilities/useVerifyName';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
-import { execStatus } from './helpers';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { pluralize } from '../../Utilities/utils';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
@@ -43,9 +41,7 @@ const DetailsCard = ({
   onNavigateToTab,
   allRemediations,
   refetch,
-  lastRemediationPlaybookRun,
   refetchAllRemediations,
-  isPlaybookRunsLoading,
 }) => {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(details?.name);
@@ -181,8 +177,6 @@ const DetailsCard = ({
       });
     }
   };
-
-  const formatedDate = new Date(lastRemediationPlaybookRun?.updated_at);
 
   return (
     <Card isFullHeight>
@@ -327,23 +321,6 @@ const DetailsCard = ({
               )}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          {/* Last Execution Status */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Latest execution status</DescriptionListTerm>
-            <DescriptionListDescription>
-              {isPlaybookRunsLoading ? (
-                <Spinner size="md" />
-              ) : (
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={() => onNavigateToTab(null, 'executionHistory')}
-                >
-                  {execStatus(lastRemediationPlaybookRun?.status, formatedDate)}
-                </Button>
-              )}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
           {/* Actions */}
           <DescriptionListGroup>
             <DescriptionListTerm>
@@ -410,20 +387,6 @@ const DetailsCard = ({
               </Button>
             </DescriptionListDescription>
           </DescriptionListGroup>
-          {/* Last Modified */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Last modified</DescriptionListTerm>
-            <DescriptionListDescription>
-              {formatDate(details?.updated_at)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Created by */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Created</DescriptionListTerm>
-            <DescriptionListDescription>
-              {formatDate(details?.created_at)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
         </DescriptionList>
       </CardBody>
     </Card>
@@ -455,9 +418,7 @@ DetailsCard.propTypes = {
   allRemediations: PropTypes.array,
   updateRemPlan: PropTypes.func,
   refetch: PropTypes.func,
-  lastRemediationPlaybookRun: PropTypes.object,
   refetchAllRemediations: PropTypes.func,
-  isPlaybookRunsLoading: PropTypes.bool,
 };
 
 export default DetailsCard;

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -43,7 +43,7 @@ const DetailsCard = ({
   onNavigateToTab,
   allRemediations,
   refetch,
-  remediationPlaybookRuns,
+  lastRemediationPlaybookRun,
   refetchAllRemediations,
   isPlaybookRunsLoading,
 }) => {
@@ -182,7 +182,7 @@ const DetailsCard = ({
     }
   };
 
-  const formatedDate = new Date(remediationPlaybookRuns?.updated_at);
+  const formatedDate = new Date(lastRemediationPlaybookRun?.updated_at);
 
   return (
     <Card isFullHeight>
@@ -339,7 +339,7 @@ const DetailsCard = ({
                   isInline
                   onClick={() => onNavigateToTab(null, 'executionHistory')}
                 >
-                  {execStatus(remediationPlaybookRuns?.status, formatedDate)}
+                  {execStatus(lastRemediationPlaybookRun?.status, formatedDate)}
                 </Button>
               )}
             </DescriptionListDescription>
@@ -455,7 +455,7 @@ DetailsCard.propTypes = {
   allRemediations: PropTypes.array,
   updateRemPlan: PropTypes.func,
   refetch: PropTypes.func,
-  remediationPlaybookRuns: PropTypes.object,
+  lastRemediationPlaybookRun: PropTypes.object,
   refetchAllRemediations: PropTypes.func,
   isPlaybookRunsLoading: PropTypes.bool,
 };

--- a/src/routes/RemediationDetailsComponents/DetailsCard.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.test.js
@@ -1,53 +1,52 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DetailsCard from './DetailsCard';
 import * as useVerifyName from '../../Utilities/useVerifyName';
-import * as formatDate from '../Cells';
-import * as helpers from './helpers';
+import useRemediations from '../../Utilities/Hooks/api/useRemediations';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 
 jest.mock('../../Utilities/useVerifyName');
-jest.mock('../Cells', () => ({
-  formatDate: jest.fn(),
-}));
-jest.mock('./helpers', () => ({
-  execStatus: jest.fn(),
-}));
-
-jest.mock('../../Utilities/Hooks/useFeatureFlag', () => ({
-  useFeatureFlag: jest.fn(),
-}));
+jest.mock('../../Utilities/Hooks/api/useRemediations');
+jest.mock(
+  '@redhat-cloud-services/frontend-components-notifications/hooks',
+  () => ({
+    useAddNotification: jest.fn(),
+  }),
+);
 jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
-  return function MockInsightsLink({ to, target, children }) {
+  return function MockInsightsLink({ to, target, children, ...props }) {
     return (
-      <a href={to} target={target} data-testid="insights-link">
+      <a href={to} target={target} {...props}>
         {children}
       </a>
     );
   };
 });
 
-const { useFeatureFlag } = require('../../Utilities/Hooks/useFeatureFlag');
-
 describe('DetailsCard', () => {
   let mockUpdateRemPlan;
   let mockOnNavigateToTab;
-
-  beforeEach(() => {
-    // Default to feature flag disabled
-    useFeatureFlag.mockReturnValue(false);
-    jest.clearAllMocks();
-  });
   let mockRefetch;
   let mockRefetchAllRemediations;
+  let mockFetchRemediationIssues;
   let mockUseVerifyName;
+  let mockAddNotification;
+
+  const learnMoreUrl =
+    'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/red_hat_lightspeed_remediations_guide/index#creating-remediation-plans_red-hat-lightspeed-remediation-guide';
 
   const mockDetails = {
     id: 'remediation-123',
     name: 'Test Remediation Plan',
-    needs_reboot: false,
     auto_reboot: true,
     archived: false,
     created_by: {
@@ -62,59 +61,8 @@ describe('DetailsCard', () => {
       last_name: 'User',
     },
     updated_at: '2024-01-20T15:45:00Z',
-    resolved_count: 5,
     issue_count: 2,
     system_count: 10,
-    issues: [
-      {
-        id: 'issue-1',
-        description: 'Fix security issue',
-        resolution: {
-          id: 'res-1',
-          description: 'Apply security patch',
-          resolution_risk: 2,
-          needs_reboot: false,
-        },
-        resolutions_available: 1,
-        systems: [
-          {
-            id: 'sys-1',
-            hostname: 'server1.example.com',
-            display_name: 'Server 1',
-            resolved: false,
-          },
-        ],
-      },
-      {
-        id: 'issue-2',
-        description: 'Update packages',
-        resolution: {
-          id: 'res-2',
-          description: 'Update system packages',
-          resolution_risk: 1,
-          needs_reboot: true,
-        },
-        resolutions_available: 2,
-        systems: [
-          {
-            id: 'sys-2',
-            hostname: 'server2.example.com',
-            display_name: 'Server 2',
-            resolved: true,
-          },
-        ],
-      },
-    ],
-    autoreboot: true,
-  };
-
-  const mockRemediationStatus = {
-    totalSystems: 10,
-  };
-
-  const mockRemediationPlaybookRuns = {
-    status: 'success',
-    updated_at: '2024-01-20T16:00:00Z',
   };
 
   const mockAllRemediations = [
@@ -123,46 +71,38 @@ describe('DetailsCard', () => {
   ];
 
   beforeEach(() => {
-    mockUpdateRemPlan = jest.fn().mockResolvedValue();
-    mockOnNavigateToTab = jest.fn();
-    mockRefetch = jest.fn().mockResolvedValue();
-    mockRefetchAllRemediations = jest.fn().mockResolvedValue();
+    jest.clearAllMocks();
 
-    mockUseVerifyName = jest.fn().mockReturnValue([false, false]); // [isVerifying, isDuplicate]
+    mockUpdateRemPlan = jest.fn().mockResolvedValue(undefined);
+    mockOnNavigateToTab = jest.fn();
+    mockRefetch = jest.fn().mockResolvedValue(undefined);
+    mockRefetchAllRemediations = jest.fn().mockResolvedValue(undefined);
+    mockFetchRemediationIssues = jest
+      .fn()
+      .mockResolvedValue({ data: [], meta: { total: 0 } });
+    mockAddNotification = jest.fn();
+
+    mockUseVerifyName = jest.fn().mockReturnValue([false, false]);
     useVerifyName.useVerifyName.mockImplementation(mockUseVerifyName);
 
-    formatDate.formatDate.mockImplementation((dateStr) => {
-      const date = new Date(dateStr);
-      return date.toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      });
+    useRemediations.mockReturnValue({
+      fetch: mockFetchRemediationIssues,
     });
-
-    helpers.execStatus.mockReturnValue(
-      <div data-testid="exec-status">Succeeded 5 hours ago</div>,
-    );
+    useAddNotification.mockReturnValue(mockAddNotification);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   const renderComponent = (props = {}) => {
     const defaultProps = {
       details: mockDetails,
-      remediationStatus: mockRemediationStatus,
       updateRemPlan: mockUpdateRemPlan,
       onNavigateToTab: mockOnNavigateToTab,
-      allRemediations: mockAllRemediations, // Now an array as component expects
+      allRemediations: mockAllRemediations,
       refetch: mockRefetch,
-      remediationPlaybookRuns: mockRemediationPlaybookRuns,
       refetchAllRemediations: mockRefetchAllRemediations,
-      // Add missing required props to fix PropType warnings
-      onRename: jest.fn(),
-      onToggleAutoreboot: jest.fn(),
-      onViewActions: jest.fn(),
       ...props,
     };
 
@@ -172,11 +112,13 @@ describe('DetailsCard', () => {
   describe('Component Rendering', () => {
     it('renders without crashing', () => {
       renderComponent();
+
       expect(screen.getByText('Details')).toBeInTheDocument();
     });
 
     it('displays loading spinner when no details provided', () => {
       renderComponent({ details: null });
+
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
       expect(screen.queryByText('Details')).not.toBeInTheDocument();
     });
@@ -186,9 +128,6 @@ describe('DetailsCard', () => {
 
       expect(screen.getByText('Test Remediation Plan')).toBeInTheDocument();
       expect(screen.getByText('Name')).toBeInTheDocument();
-      expect(screen.getByText('Created')).toBeInTheDocument();
-      expect(screen.getByText('Last modified')).toBeInTheDocument();
-      expect(screen.getByText('Latest execution status')).toBeInTheDocument();
       expect(screen.getByText('Actions')).toBeInTheDocument();
       expect(screen.getByText('Systems')).toBeInTheDocument();
       expect(screen.getByText(/Auto-reboot/)).toBeInTheDocument();
@@ -206,89 +145,135 @@ describe('DetailsCard', () => {
         ...mockDetails,
         issue_count: 1,
         system_count: 1,
-        issues: [mockDetails.issues[0]],
       };
-      const singleStatus = { totalSystems: 1 };
 
-      renderComponent({
-        details: singleDetails,
-        remediationStatus: singleStatus,
-      });
+      renderComponent({ details: singleDetails });
 
       expect(screen.getByText('1 action')).toBeInTheDocument();
       expect(screen.getByText('1 system')).toBeInTheDocument();
     });
+  });
 
-    it('calls formatDate for created and updated dates', () => {
+  describe('Resolution Availability', () => {
+    it('shows an alert when a resolution option is available', async () => {
+      mockFetchRemediationIssues.mockResolvedValueOnce({
+        data: [{ id: 'issue-1', resolutions_available: 2 }],
+        meta: { total: 1 },
+      });
+
       renderComponent();
 
-      expect(formatDate.formatDate).toHaveBeenCalledWith(
-        '2024-01-15T10:30:00Z',
-      );
-      expect(formatDate.formatDate).toHaveBeenCalledWith(
-        '2024-01-20T15:45:00Z',
-      );
+      expect(
+        await screen.findByText('Resolution options are available.'),
+      ).toBeInTheDocument();
+      expect(mockFetchRemediationIssues).toHaveBeenCalledWith({
+        id: 'remediation-123',
+        limit: 50,
+        offset: 0,
+      });
     });
 
-    it('calls execStatus with correct parameters', () => {
+    it('checks additional pages until it finds a resolution option', async () => {
+      mockFetchRemediationIssues
+        .mockResolvedValueOnce({
+          data: Array.from({ length: 50 }, (_, index) => ({
+            id: `issue-${index}`,
+            resolutions_available: 1,
+          })),
+          meta: { total: 51 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 'issue-51', resolutions_available: 2 }],
+          meta: { total: 51 },
+        });
+
       renderComponent();
 
-      expect(helpers.execStatus).toHaveBeenCalledWith(
-        'success',
-        new Date('2024-01-20T16:00:00Z'),
+      expect(
+        await screen.findByText('Resolution options are available.'),
+      ).toBeInTheDocument();
+      expect(mockFetchRemediationIssues).toHaveBeenNthCalledWith(1, {
+        id: 'remediation-123',
+        limit: 50,
+        offset: 0,
+      });
+      expect(mockFetchRemediationIssues).toHaveBeenNthCalledWith(2, {
+        id: 'remediation-123',
+        limit: 50,
+        offset: 50,
+      });
+    });
+
+    it('removes the checking skeleton when no resolution options exist', async () => {
+      mockFetchRemediationIssues
+        .mockResolvedValueOnce({
+          data: [{ id: 'issue-1', resolutions_available: 1 }],
+          meta: { total: 2 },
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 'issue-2', resolutions_available: 1 }],
+          meta: { total: 2 },
+        });
+
+      renderComponent();
+
+      const checkingState = await screen.findByText(
+        'Checking for resolution options',
       );
+      await waitForElementToBeRemoved(checkingState);
+
+      expect(
+        screen.queryByText('Resolution options are available.'),
+      ).not.toBeInTheDocument();
     });
   });
 
   describe('Name Editing', () => {
-    it('toggles edit mode when pencil icon is clicked', () => {
+    it('toggles edit mode when pencil icon is clicked', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      // The edit button is the first button (with no accessible name) - it contains the pencil icon
-      const buttons = screen.getAllByRole('button');
-      const editButton = buttons[0]; // First button is the edit button
       expect(
         screen.queryByDisplayValue('Test Remediation Plan'),
       ).not.toBeInTheDocument();
 
-      fireEvent.click(editButton);
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
+
       expect(
         screen.getByDisplayValue('Test Remediation Plan'),
       ).toBeInTheDocument();
     });
 
-    it('shows text input with current name when editing', () => {
+    it('shows text input with current name when editing', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
 
-      const input = screen.getByDisplayValue('Test Remediation Plan');
+      const input = screen.getByRole('textbox', { name: /rename input/i });
       expect(input).toBeInTheDocument();
       expect(input).toHaveFocus();
     });
 
-    it('updates input value when typing', () => {
+    it('shows duplicate error when name already exists', async () => {
+      const user = userEvent.setup();
+      mockUseVerifyName.mockReturnValue([false, true]);
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
 
-      fireEvent.change(input, { target: { value: 'Updated Plan Name' } });
-      expect(screen.getByDisplayValue('Updated Plan Name')).toBeInTheDocument();
-    });
-
-    it('shows duplicate error when name already exists', () => {
-      mockUseVerifyName.mockReturnValue([false, true]); // [isVerifying, isDuplicate]
-      renderComponent();
-
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-
-      // Change to a name that would trigger duplicate
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-      fireEvent.change(input, { target: { value: 'Existing Plan 1' } });
+      const input = screen.getByRole('textbox', { name: /rename input/i });
+      await user.clear(input);
+      await user.type(input, 'Existing Plan 1');
 
       expect(
         screen.getByText(
@@ -297,78 +282,42 @@ describe('DetailsCard', () => {
       ).toBeInTheDocument();
     });
 
-    it('shows empty error when name is empty', () => {
+    it('shows empty error when name is empty', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
+      const input = screen.getByRole('textbox', { name: /rename input/i });
 
-      fireEvent.change(input, { target: { value: '' } });
+      await user.clear(input);
 
       expect(
         screen.getByText(/Playbook name cannot be empty/),
       ).toBeInTheDocument();
-    });
-
-    it('shows checking state when verifying name', () => {
-      mockUseVerifyName.mockReturnValue([true, false]); // [isVerifying, isDuplicate]
-      renderComponent();
-
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      // The checking state is handled internally, we can verify the hook is called
-      expect(useVerifyName.useVerifyName).toHaveBeenCalled();
-    });
-
-    it('disables save button when name is invalid', () => {
-      renderComponent();
-
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-
-      fireEvent.change(input, { target: { value: '' } });
-
-      // After entering edit mode, there should be more buttons including save/cancel
-      const editButtons = screen.getAllByRole('button');
-      // The save button should be disabled when name is invalid
-      // We'll check by trying to find a disabled button
-      const disabledButtons = editButtons.filter((btn) => btn.disabled);
-      expect(disabledButtons.length).toBeGreaterThan(0);
-    });
-
-    it('enables save button when name is valid and changed', () => {
-      renderComponent();
-
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-
-      fireEvent.change(input, { target: { value: 'New Valid Name' } });
-
-      // When name is valid, save button should not be disabled
-      const editButtons = screen.getAllByRole('button');
-      const disabledButtons = editButtons.filter((btn) => btn.disabled);
-      // There should be fewer or no disabled buttons now
-      expect(disabledButtons.length).toBeLessThanOrEqual(1);
+      expect(
+        screen.getByRole('button', { name: /save remediation plan name/i }),
+      ).toBeDisabled();
     });
 
     it('saves name and exits edit mode when save is clicked', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-
-      fireEvent.change(input, { target: { value: 'Updated Name' } });
-
-      // Find and click the first non-disabled button (should be save)
-      const editButtons = screen.getAllByRole('button');
-      const saveButton = editButtons.find(
-        (btn) => !btn.disabled && btn !== buttons[0],
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
       );
-      fireEvent.click(saveButton);
+      const input = screen.getByRole('textbox', { name: /rename input/i });
+
+      await user.clear(input);
+      await user.type(input, 'Updated Name');
+
+      await user.click(
+        screen.getByRole('button', { name: /save remediation plan name/i }),
+      );
 
       await waitFor(() => {
         expect(mockUpdateRemPlan).toHaveBeenCalledWith({
@@ -377,52 +326,76 @@ describe('DetailsCard', () => {
         });
       });
 
-      await waitFor(() => {
-        expect(mockRefetch).toHaveBeenCalled();
-      });
-
-      await waitFor(() => {
-        expect(mockRefetchAllRemediations).toHaveBeenCalled();
-      });
-
+      expect(mockRefetch).toHaveBeenCalled();
+      expect(mockRefetchAllRemediations).toHaveBeenCalled();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Remediation plan renamed',
+          variant: 'success',
+        }),
+      );
       expect(
-        screen.queryByDisplayValue('Updated Name'),
+        screen.queryByRole('textbox', { name: /rename input/i }),
       ).not.toBeInTheDocument();
     });
 
-    it('cancels editing when cancel button is clicked', async () => {
+    it('shows an error notification when save fails', async () => {
+      const user = userEvent.setup();
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      mockUpdateRemPlan.mockRejectedValueOnce(new Error('rename failed'));
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]); // Enter edit mode
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
+      const input = screen.getByRole('textbox', { name: /rename input/i });
 
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-      fireEvent.change(input, { target: { value: 'Changed Name' } });
+      await user.clear(input);
+      await user.type(input, 'Updated Name');
+      await user.click(
+        screen.getByRole('button', { name: /save remediation plan name/i }),
+      );
 
-      // Find all buttons in edit mode
-      const editButtons = screen.getAllByRole('button');
-
-      // The cancel button should be the one with TimesIcon - look for the last button
-      // or we can click it by finding a button that's not disabled and not the first one
-      const cancelButton =
-        editButtons.find(
-          (btn, index) =>
-            index > 0 && // Not the edit button (first one)
-            !btn.disabled && // Not disabled
-            btn !== editButtons.find((b) => !b.disabled && b !== buttons[0]), // Not the save button
-        ) || editButtons[editButtons.length - 1]; // Fallback to last button
-
-      fireEvent.click(cancelButton);
-
-      // After cancel, we should see the original text again (not in edit mode)
       await waitFor(() => {
-        expect(screen.getByText('Test Remediation Plan')).toBeInTheDocument();
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(mockAddNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to update playbook name',
+            variant: 'danger',
+          }),
+        );
       });
 
-      // And the input should no longer be visible
+      expect(mockRefetch).not.toHaveBeenCalled();
+      expect(mockRefetchAllRemediations).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('cancels editing when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+
+      renderComponent();
+
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
+      const input = screen.getByRole('textbox', { name: /rename input/i });
+
+      await user.clear(input);
+      await user.type(input, 'Changed Name');
+      await user.click(
+        screen.getByRole('button', {
+          name: /cancel remediation plan name edit/i,
+        }),
+      );
+
       expect(
-        screen.queryByDisplayValue('Changed Name'),
+        screen.queryByRole('textbox', { name: /rename input/i }),
       ).not.toBeInTheDocument();
+      expect(screen.getByText('Test Remediation Plan')).toBeInTheDocument();
     });
   });
 
@@ -431,55 +404,70 @@ describe('DetailsCard', () => {
       renderComponent();
 
       const toggle = screen.getByRole('switch');
-      expect(toggle).toBeInTheDocument();
-      expect(toggle).toBeChecked(); // auto_reboot is true in mockDetails
-      expect(screen.queryByText(/Auto-reboot:\s*Off/i)).not.toBeInTheDocument();
+      expect(toggle).toBeChecked();
       expect(screen.getByText(/Auto-reboot:\s*On/i)).toBeInTheDocument();
     });
 
     it('displays switch as unchecked when auto_reboot is false', () => {
-      const detailsWithNoReboot = { ...mockDetails, auto_reboot: false };
-      renderComponent({ details: detailsWithNoReboot });
+      renderComponent({
+        details: { ...mockDetails, auto_reboot: false },
+      });
 
       const toggle = screen.getByRole('switch');
       expect(toggle).not.toBeChecked();
       expect(screen.getByText(/Auto-reboot:\s*Off/i)).toBeInTheDocument();
-      expect(screen.queryByText(/Auto-reboot:\s*On/i)).not.toBeInTheDocument();
     });
 
-    it('calls updateRemPlan when toggle is changed', () => {
+    it('calls updateRemPlan when toggle is changed', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const toggle = screen.getByRole('switch');
-      fireEvent.click(toggle);
+      await user.click(screen.getByRole('switch'));
 
-      expect(mockUpdateRemPlan).toHaveBeenCalledWith({
-        id: 'remediation-123',
-        auto_reboot: false, // Should toggle from true to false
+      await waitFor(() => {
+        expect(mockUpdateRemPlan).toHaveBeenCalledWith({
+          id: 'remediation-123',
+          auto_reboot: false,
+        });
       });
+      expect(mockRefetch).toHaveBeenCalled();
     });
 
-    it('updates local state when toggle is changed', () => {
+    it('reverts the toggle and shows an error notification when update fails', async () => {
+      const user = userEvent.setup();
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      mockUpdateRemPlan.mockRejectedValueOnce(new Error('toggle failed'));
+
       renderComponent();
 
       const toggle = screen.getByRole('switch');
-      expect(toggle).toBeChecked();
+      await user.click(toggle);
 
-      fireEvent.click(toggle);
-      expect(toggle).not.toBeChecked();
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(mockAddNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to update auto-reboot setting',
+            variant: 'danger',
+          }),
+        );
+      });
 
-      // Click again to toggle back
-      fireEvent.click(toggle);
       expect(toggle).toBeChecked();
+      consoleErrorSpy.mockRestore();
     });
   });
 
   describe('Navigation', () => {
-    it('navigates to actions tab when actions link is clicked', () => {
+    it('navigates to actions tab when actions link is clicked', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const actionsLink = screen.getByText('2 actions');
-      fireEvent.click(actionsLink);
+      await user.click(screen.getByText('2 actions'));
 
       expect(mockOnNavigateToTab).toHaveBeenCalledWith(
         null,
@@ -487,28 +475,16 @@ describe('DetailsCard', () => {
       );
     });
 
-    it('navigates to systems tab when systems link is clicked', () => {
+    it('navigates to systems tab when systems link is clicked', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const systemsLink = screen.getByText('10 systems');
-      fireEvent.click(systemsLink);
+      await user.click(screen.getByText('10 systems'));
 
       expect(mockOnNavigateToTab).toHaveBeenCalledWith(
         null,
         'plannedRemediations:systems',
-      );
-    });
-
-    it('navigates to execution history when status link is clicked', () => {
-      renderComponent();
-
-      // Find the button that contains the exec-status element
-      const statusButton = screen.getByRole('button', { name: /succeeded/i });
-      fireEvent.click(statusButton);
-
-      expect(mockOnNavigateToTab).toHaveBeenCalledWith(
-        null,
-        'executionHistory',
       );
     });
   });
@@ -518,120 +494,65 @@ describe('DetailsCard', () => {
       renderComponent();
 
       const learnMoreLink = screen.getByRole('link', { name: /learn more/i });
-      expect(learnMoreLink).toHaveAttribute(
-        'href',
-        'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/red_hat_lightspeed_remediations_guide/index#creating-remediation-plans_red-hat-lightspeed-remediation-guide',
-      );
+      expect(learnMoreLink).toHaveAttribute('href', learnMoreUrl);
       expect(learnMoreLink).toHaveAttribute('target', '_blank');
     });
 
     it('displays help icon for actions section', () => {
       renderComponent();
 
-      // The help icon should be present in the Actions section
-      // We can verify by checking that the Actions text is rendered
       expect(screen.getByText('Actions')).toBeInTheDocument();
-    });
-
-    it('handles missing remediation status gracefully', () => {
-      renderComponent({ remediationStatus: null });
-
-      // Should handle null remediationStatus without crashing
-      expect(screen.getByText('Details')).toBeInTheDocument();
-    });
-
-    it('handles missing playbook runs gracefully', () => {
-      renderComponent({ remediationPlaybookRuns: null });
-
-      // Should still render the component
-      expect(screen.getByText('Details')).toBeInTheDocument();
     });
   });
 
   describe('Props Handling', () => {
-    it('handles missing onNavigateToTab prop', () => {
-      renderComponent({ onNavigateToTab: undefined });
+    it('handles missing optional props', () => {
+      renderComponent({
+        onNavigateToTab: undefined,
+        updateRemPlan: undefined,
+        allRemediations: undefined,
+      });
 
-      // Should render without crashing
-      expect(screen.getByText('Details')).toBeInTheDocument();
-    });
-
-    it('handles missing updateRemPlan prop', () => {
-      renderComponent({ updateRemPlan: undefined });
-
-      // Should render without crashing
-      expect(screen.getByText('Details')).toBeInTheDocument();
-    });
-
-    it('handles missing allRemediations prop', () => {
-      renderComponent({ allRemediations: undefined });
-
-      // Should render without crashing
-      expect(screen.getByText('Details')).toBeInTheDocument();
-    });
-
-    it('handles undefined remediationStatus totalSystems', () => {
-      renderComponent({ remediationStatus: {} });
-
-      // Should handle undefined totalSystems
       expect(screen.getByText('Details')).toBeInTheDocument();
     });
   });
 
   describe('Edge Cases', () => {
-    it('handles details with empty issues array', () => {
-      const emptyDetails = {
-        ...mockDetails,
-        issues: [],
-        issue_count: 0,
-        system_count: 0,
-      };
-      renderComponent({ details: emptyDetails });
+    it('handles details with empty counts', () => {
+      renderComponent({
+        details: {
+          ...mockDetails,
+          issue_count: 0,
+          system_count: 0,
+        },
+      });
 
       expect(screen.getByText('0 actions')).toBeInTheDocument();
-    });
-
-    it('handles details with missing created_at date', () => {
-      const detailsWithoutDate = { ...mockDetails, created_at: undefined };
-      renderComponent({ details: detailsWithoutDate });
-
-      // Should still render without crashing
-      expect(screen.getByText('Details')).toBeInTheDocument();
+      expect(screen.getByText('0 systems')).toBeInTheDocument();
     });
 
     it('handles very long remediation names', () => {
       const longName = 'A'.repeat(200);
-      const longNameDetails = { ...mockDetails, name: longName };
-      renderComponent({ details: longNameDetails });
+
+      renderComponent({
+        details: { ...mockDetails, name: longName },
+      });
 
       expect(screen.getByText(longName)).toBeInTheDocument();
     });
 
-    it('handles special characters in remediation name', () => {
-      const specialName = 'Test & <script>alert("xss")</script> Plan';
-      const specialDetails = { ...mockDetails, name: specialName };
-      renderComponent({ details: specialDetails });
-
-      expect(screen.getByText(specialName)).toBeInTheDocument();
-    });
-
     it('updates name state when details prop changes', () => {
       const { rerender } = renderComponent();
-
       const newDetails = { ...mockDetails, name: 'Updated External Name' };
+
       rerender(
         <DetailsCard
           details={newDetails}
-          remediationStatus={mockRemediationStatus}
           updateRemPlan={mockUpdateRemPlan}
           onNavigateToTab={mockOnNavigateToTab}
           allRemediations={mockAllRemediations}
           refetch={mockRefetch}
-          remediationPlaybookRuns={mockRemediationPlaybookRuns}
           refetchAllRemediations={mockRefetchAllRemediations}
-          onRename={jest.fn()}
-          onToggleAutoreboot={jest.fn()}
-          onViewActions={jest.fn()}
         />,
       );
 
@@ -643,52 +564,29 @@ describe('DetailsCard', () => {
     it('calls useVerifyName with correct parameters', () => {
       renderComponent();
 
-      // Should be called with filtered list (excluding current remediation)
       expect(useVerifyName.useVerifyName).toHaveBeenCalledWith(
         'Test Remediation Plan',
         mockAllRemediations,
       );
     });
 
-    it('re-calls useVerifyName when name changes during editing', () => {
+    it('re-calls useVerifyName when name changes during editing', async () => {
+      const user = userEvent.setup();
+
       renderComponent();
 
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
+      await user.click(
+        screen.getByRole('button', { name: /edit remediation plan name/i }),
+      );
+      const input = screen.getByRole('textbox', { name: /rename input/i });
 
-      fireEvent.change(input, { target: { value: 'New Name' } });
+      await user.clear(input);
+      await user.type(input, 'New Name');
 
-      // useVerifyName should be called with the new value
       expect(useVerifyName.useVerifyName).toHaveBeenCalledWith(
         'New Name',
         mockAllRemediations,
       );
-    });
-
-    it('handles concurrent edit operations', async () => {
-      renderComponent();
-
-      const buttons = screen.getAllByRole('button');
-      fireEvent.click(buttons[0]);
-      const input = screen.getByDisplayValue('Test Remediation Plan');
-
-      fireEvent.change(input, { target: { value: 'Name 1' } });
-
-      // Find and click save button
-      const editButtons = screen.getAllByRole('button');
-      const saveButton = editButtons.find(
-        (btn) => !btn.disabled && btn !== buttons[0],
-      );
-      fireEvent.click(saveButton);
-
-      // Start another edit before the first completes
-      const newButtons = screen.getAllByRole('button');
-      fireEvent.click(newButtons[0]);
-
-      await waitFor(() => {
-        expect(mockUpdateRemPlan).toHaveBeenCalled();
-      });
     });
   });
 });

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -20,7 +20,7 @@ const DetailsGeneralContent = ({
   onNavigateToTab,
   allRemediations,
   permissions,
-  remediationPlaybookRuns,
+  lastRemediationPlaybookRun,
   refetchAllRemediations,
   isPlaybookRunsLoading,
   actionPoints: actionPointsProp,
@@ -111,7 +111,7 @@ const DetailsGeneralContent = ({
             updateRemPlan={updateRemPlan}
             onNavigateToTab={onNavigateToTab}
             allRemediations={allRemediations}
-            remediationPlaybookRuns={remediationPlaybookRuns}
+            lastRemediationPlaybookRun={lastRemediationPlaybookRun}
             refetchAllRemediations={refetchAllRemediations}
             isPlaybookRunsLoading={isPlaybookRunsLoading}
           />
@@ -140,7 +140,7 @@ DetailsGeneralContent.propTypes = {
   onNavigateToTab: PropTypes.func,
   allRemediations: PropTypes.array,
   permissions: PropTypes.object,
-  remediationPlaybookRuns: PropTypes.any,
+  lastRemediationPlaybookRun: PropTypes.any,
   refetchAllRemediations: PropTypes.func,
   detailsLoading: PropTypes.bool,
   isPlaybookRunsLoading: PropTypes.bool,

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -10,6 +10,7 @@ import { calculateActionPointsFromSummary } from '../../components/helpers';
 import { calculateExecutionLimits } from './helpers';
 import DetailsCard from './DetailsCard';
 import ProgressCard from './ProgressCard';
+import ActivityCard from './ActivityCard';
 
 const DetailsGeneralContent = ({
   details,
@@ -124,6 +125,14 @@ const DetailsGeneralContent = ({
             onNavigateToTab={onNavigateToTab}
             details={details}
             actionPoints={actionPoints}
+          />
+        </GridItem>
+        <GridItem span={12} md={6}>
+          <ActivityCard
+            details={details}
+            lastRemediationPlaybookRun={lastRemediationPlaybookRun}
+            isPlaybookRunsLoading={isPlaybookRunsLoading}
+            onNavigateToTab={onNavigateToTab}
           />
         </GridItem>
       </Grid>

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -14,7 +14,6 @@ import ActivityCard from './ActivityCard';
 
 const DetailsGeneralContent = ({
   details,
-  onRename,
   refetch,
   remediationStatus,
   updateRemPlan,
@@ -106,15 +105,11 @@ const DetailsGeneralContent = ({
         <GridItem span={12} md={6}>
           <DetailsCard
             details={details}
-            onRename={onRename}
             refetch={refetch}
-            remediationStatus={remediationStatus}
             updateRemPlan={updateRemPlan}
             onNavigateToTab={onNavigateToTab}
             allRemediations={allRemediations}
-            lastRemediationPlaybookRun={lastRemediationPlaybookRun}
             refetchAllRemediations={refetchAllRemediations}
-            isPlaybookRunsLoading={isPlaybookRunsLoading}
           />
         </GridItem>
         <GridItem span={12} md={6}>
@@ -142,7 +137,6 @@ const DetailsGeneralContent = ({
 
 DetailsGeneralContent.propTypes = {
   details: PropTypes.object.isRequired,
-  onRename: PropTypes.func.isRequired,
   refetch: PropTypes.func.isRequired,
   remediationStatus: PropTypes.object.isRequired,
   updateRemPlan: PropTypes.func,
@@ -151,7 +145,6 @@ DetailsGeneralContent.propTypes = {
   permissions: PropTypes.object,
   lastRemediationPlaybookRun: PropTypes.any,
   refetchAllRemediations: PropTypes.func,
-  detailsLoading: PropTypes.bool,
   isPlaybookRunsLoading: PropTypes.bool,
   actionPoints: PropTypes.number,
 };

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -23,6 +23,7 @@ const DetailsGeneralContent = ({
   lastRemediationPlaybookRun,
   refetchAllRemediations,
   isPlaybookRunsLoading,
+  retentionPolicyRefreshNonce,
   actionPoints: actionPointsProp,
 }) => {
   const actionPointsComputed = useMemo(() => {
@@ -128,6 +129,7 @@ const DetailsGeneralContent = ({
             lastRemediationPlaybookRun={lastRemediationPlaybookRun}
             isPlaybookRunsLoading={isPlaybookRunsLoading}
             onNavigateToTab={onNavigateToTab}
+            retentionPolicyRefreshNonce={retentionPolicyRefreshNonce}
           />
         </GridItem>
       </Grid>
@@ -146,6 +148,7 @@ DetailsGeneralContent.propTypes = {
   lastRemediationPlaybookRun: PropTypes.any,
   refetchAllRemediations: PropTypes.func,
   isPlaybookRunsLoading: PropTypes.bool,
+  retentionPolicyRefreshNonce: PropTypes.number,
   actionPoints: PropTypes.number,
 };
 

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -108,7 +108,6 @@ describe('DetailsGeneralContent', () => {
 
   const defaultProps = {
     details: createDetails(),
-    onRename: jest.fn(),
     refetch: jest.fn(),
     remediationStatus: {
       connectionError: null,
@@ -423,19 +422,13 @@ describe('DetailsGeneralContent', () => {
         screen.getByTestId('details-card-props').textContent,
       );
 
-      // Functions won't appear in JSON, so we can only check non-function props
-      expect(detailsCardProps.remediationStatus).toEqual(
-        defaultProps.remediationStatus,
-      );
+      expect(detailsCardProps.details).toEqual(defaultProps.details);
       expect(detailsCardProps.allRemediations).toEqual(
         defaultProps.allRemediations,
       );
-      expect(detailsCardProps.lastRemediationPlaybookRun).toEqual(
-        defaultProps.lastRemediationPlaybookRun,
-      );
-      expect(detailsCardProps.isPlaybookRunsLoading).toBe(
-        defaultProps.isPlaybookRunsLoading,
-      );
+      expect(detailsCardProps).not.toHaveProperty('remediationStatus');
+      expect(detailsCardProps).not.toHaveProperty('lastRemediationPlaybookRun');
+      expect(detailsCardProps).not.toHaveProperty('isPlaybookRunsLoading');
 
       // Check that DetailsCard component is rendered (functions are passed but not visible in JSON)
       expect(screen.getByTestId('details-card')).toBeInTheDocument();
@@ -478,7 +471,6 @@ describe('DetailsGeneralContent', () => {
     it('should handle missing optional props', () => {
       const minimalProps = {
         details: createDetails(),
-        onRename: jest.fn(),
         refetch: jest.fn(),
         remediationStatus: {
           connectionError: null,
@@ -495,11 +487,10 @@ describe('DetailsGeneralContent', () => {
       const detailsCardProps = JSON.parse(
         screen.getByTestId('details-card-props').textContent,
       );
-      expect(detailsCardProps.updateRemPlan).toBeUndefined();
-      expect(detailsCardProps.onNavigateToTab).toBeUndefined();
       expect(detailsCardProps.allRemediations).toBeUndefined();
-      expect(detailsCardProps.lastRemediationPlaybookRun).toBeUndefined();
-      expect(detailsCardProps.refetchAllRemediations).toBeUndefined();
+      expect(detailsCardProps).not.toHaveProperty('remediationStatus');
+      expect(detailsCardProps).not.toHaveProperty('lastRemediationPlaybookRun');
+      expect(detailsCardProps).not.toHaveProperty('isPlaybookRunsLoading');
 
       const activityCardProps = JSON.parse(
         screen.getByTestId('activity-card-props').textContent,
@@ -520,9 +511,7 @@ describe('DetailsGeneralContent', () => {
       const detailsCardProps = JSON.parse(
         screen.getByTestId('details-card-props').textContent,
       );
-      expect(detailsCardProps.remediationStatus).toEqual(
-        defaultProps.remediationStatus,
-      );
+      expect(detailsCardProps.details).toEqual(defaultProps.details);
     });
   });
 

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -125,6 +125,7 @@ describe('DetailsGeneralContent', () => {
     lastRemediationPlaybookRun: { id: 'run-1', status: 'success' },
     refetchAllRemediations: jest.fn(),
     isPlaybookRunsLoading: false,
+    retentionPolicyRefreshNonce: 0,
   };
 
   beforeEach(() => {
@@ -466,6 +467,9 @@ describe('DetailsGeneralContent', () => {
       expect(activityCardProps.isPlaybookRunsLoading).toBe(
         defaultProps.isPlaybookRunsLoading,
       );
+      expect(activityCardProps.retentionPolicyRefreshNonce).toBe(
+        defaultProps.retentionPolicyRefreshNonce,
+      );
     });
 
     it('should handle missing optional props', () => {
@@ -497,6 +501,7 @@ describe('DetailsGeneralContent', () => {
       );
       expect(activityCardProps.lastRemediationPlaybookRun).toBeUndefined();
       expect(activityCardProps.isPlaybookRunsLoading).toBeUndefined();
+      expect(activityCardProps.retentionPolicyRefreshNonce).toBeUndefined();
     });
 
     it('should render child components properly', () => {

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DetailsGeneralContent from './DetailsGeneralContent';
 
@@ -28,6 +29,18 @@ jest.mock('./ProgressCard', () => {
   };
 });
 
+jest.mock('./ActivityCard', () => {
+  return function MockActivityCard(props) {
+    return (
+      <div data-testid="activity-card">
+        <div data-testid="activity-card-props">
+          {JSON.stringify(props, null, 2)}
+        </div>
+      </div>
+    );
+  };
+});
+
 // Mock PatternFly components
 jest.mock('@patternfly/react-core', () => ({
   Alert: function MockAlert({
@@ -35,6 +48,7 @@ jest.mock('@patternfly/react-core', () => ({
     variant,
     title,
     className,
+    actionClose,
     children,
     ...props
   }) {
@@ -47,8 +61,20 @@ jest.mock('@patternfly/react-core', () => ({
         {...props}
       >
         <div data-testid="alert-title">{title}</div>
+        {actionClose}
         {children}
       </div>
+    );
+  },
+  AlertActionCloseButton: function MockAlertActionCloseButton({
+    title,
+    onClose,
+    ...props
+  }) {
+    return (
+      <button data-testid="alert-close" onClick={onClose} {...props}>
+        {title}
+      </button>
     );
   },
   Grid: function MockGrid({ hasGutter, children, ...props }) {
@@ -68,17 +94,20 @@ jest.mock('@patternfly/react-core', () => ({
 }));
 
 describe('DetailsGeneralContent', () => {
+  const createDetails = (overrides = {}) => ({
+    id: 'rem-1',
+    name: 'Test Remediation',
+    issue_count: 0,
+    system_count: 5,
+    issue_count_details: {},
+    auto_reboot: true,
+    created_at: '2023-01-01T00:00:00Z',
+    updated_at: '2023-01-01T00:00:00Z',
+    ...overrides,
+  });
+
   const defaultProps = {
-    details: {
-      id: 'rem-1',
-      name: 'Test Remediation',
-      issue_count: 0,
-      system_count: 5,
-      issue_count_details: {},
-      auto_reboot: true,
-      created_at: '2023-01-01T00:00:00Z',
-      updated_at: '2023-01-01T00:00:00Z',
-    },
+    details: createDetails(),
     onRename: jest.fn(),
     refetch: jest.fn(),
     remediationStatus: {
@@ -94,8 +123,9 @@ describe('DetailsGeneralContent', () => {
     permissions: {
       execute: true,
     },
-    remediationPlaybookRuns: [{ id: 'run-1', status: 'success' }],
+    lastRemediationPlaybookRun: { id: 'run-1', status: 'success' },
     refetchAllRemediations: jest.fn(),
+    isPlaybookRunsLoading: false,
   };
 
   beforeEach(() => {
@@ -109,6 +139,7 @@ describe('DetailsGeneralContent', () => {
       expect(screen.getByTestId('grid')).toBeInTheDocument();
       expect(screen.getByTestId('details-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
+      expect(screen.getByTestId('activity-card')).toBeInTheDocument();
     });
 
     it('should render with correct structure', () => {
@@ -118,6 +149,7 @@ describe('DetailsGeneralContent', () => {
       expect(screen.getByTestId('grid')).toBeInTheDocument();
       expect(screen.getByTestId('details-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
+      expect(screen.getByTestId('activity-card')).toBeInTheDocument();
     });
 
     it('should render grid with correct props', () => {
@@ -131,7 +163,7 @@ describe('DetailsGeneralContent', () => {
       render(<DetailsGeneralContent {...defaultProps} />);
 
       const gridItems = screen.getAllByTestId('grid-item');
-      expect(gridItems).toHaveLength(2);
+      expect(gridItems).toHaveLength(3);
 
       // First grid item (DetailsCard)
       expect(gridItems[0]).toHaveAttribute('data-span', '12');
@@ -140,6 +172,10 @@ describe('DetailsGeneralContent', () => {
       // Second grid item (ProgressCard)
       expect(gridItems[1]).toHaveAttribute('data-span', '12');
       expect(gridItems[1]).toHaveAttribute('data-md', '6');
+
+      // Third grid item (ActivityCard)
+      expect(gridItems[2]).toHaveAttribute('data-span', '12');
+      expect(gridItems[2]).toHaveAttribute('data-md', '6');
     });
   });
 
@@ -275,6 +311,20 @@ describe('DetailsGeneralContent', () => {
       expect(progressCardProps.readyOrNot).toBe(false);
     });
 
+    it('should calculate readyOrNot as false when execution limits are exceeded', () => {
+      const props = {
+        ...defaultProps,
+        details: createDetails({ system_count: 101 }),
+      };
+
+      render(<DetailsGeneralContent {...props} />);
+
+      const progressCardProps = JSON.parse(
+        screen.getByTestId('progress-card-props').textContent,
+      );
+      expect(progressCardProps.readyOrNot).toBe(false);
+    });
+
     it('should handle missing permissions object', () => {
       const props = {
         ...defaultProps,
@@ -335,6 +385,34 @@ describe('DetailsGeneralContent', () => {
 
       expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
     });
+
+    it('should render AAP alert when execution limits are exceeded', () => {
+      const props = {
+        ...defaultProps,
+        actionPoints: 1001,
+      };
+
+      render(<DetailsGeneralContent {...props} />);
+
+      expect(screen.getByTestId('alert')).toBeInTheDocument();
+      expect(screen.getByTestId('alert-title')).toHaveTextContent(
+        'Remediate at scale with Red Hat Ansible Automation Platform (AAP)',
+      );
+    });
+
+    it('should dismiss the AAP alert when the close button is clicked', async () => {
+      const user = userEvent.setup();
+      const props = {
+        ...defaultProps,
+        actionPoints: 1001,
+      };
+
+      render(<DetailsGeneralContent {...props} />);
+
+      await user.click(screen.getByTestId('alert-close'));
+
+      expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
+    });
   });
 
   describe('Props passing to child components', () => {
@@ -352,8 +430,11 @@ describe('DetailsGeneralContent', () => {
       expect(detailsCardProps.allRemediations).toEqual(
         defaultProps.allRemediations,
       );
-      expect(detailsCardProps.remediationPlaybookRuns).toEqual(
-        defaultProps.remediationPlaybookRuns,
+      expect(detailsCardProps.lastRemediationPlaybookRun).toEqual(
+        defaultProps.lastRemediationPlaybookRun,
+      );
+      expect(detailsCardProps.isPlaybookRunsLoading).toBe(
+        defaultProps.isPlaybookRunsLoading,
       );
 
       // Check that DetailsCard component is rendered (functions are passed but not visible in JSON)
@@ -372,14 +453,31 @@ describe('DetailsGeneralContent', () => {
       );
       expect(progressCardProps.permissions).toEqual(defaultProps.permissions);
       expect(progressCardProps.readyOrNot).toBe(true);
+      expect(progressCardProps.actionPoints).toBe(0);
 
       // Function props won't appear in JSON, but component should render
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
     });
 
+    it('should pass correct props to ActivityCard', () => {
+      render(<DetailsGeneralContent {...defaultProps} />);
+
+      const activityCardProps = JSON.parse(
+        screen.getByTestId('activity-card-props').textContent,
+      );
+
+      expect(activityCardProps.details).toEqual(defaultProps.details);
+      expect(activityCardProps.lastRemediationPlaybookRun).toEqual(
+        defaultProps.lastRemediationPlaybookRun,
+      );
+      expect(activityCardProps.isPlaybookRunsLoading).toBe(
+        defaultProps.isPlaybookRunsLoading,
+      );
+    });
+
     it('should handle missing optional props', () => {
       const minimalProps = {
-        details: jest.fn(),
+        details: createDetails(),
         onRename: jest.fn(),
         refetch: jest.fn(),
         remediationStatus: {
@@ -392,6 +490,7 @@ describe('DetailsGeneralContent', () => {
 
       expect(screen.getByTestId('details-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
+      expect(screen.getByTestId('activity-card')).toBeInTheDocument();
 
       const detailsCardProps = JSON.parse(
         screen.getByTestId('details-card-props').textContent,
@@ -399,8 +498,14 @@ describe('DetailsGeneralContent', () => {
       expect(detailsCardProps.updateRemPlan).toBeUndefined();
       expect(detailsCardProps.onNavigateToTab).toBeUndefined();
       expect(detailsCardProps.allRemediations).toBeUndefined();
-      expect(detailsCardProps.remediationPlaybookRuns).toBeUndefined();
+      expect(detailsCardProps.lastRemediationPlaybookRun).toBeUndefined();
       expect(detailsCardProps.refetchAllRemediations).toBeUndefined();
+
+      const activityCardProps = JSON.parse(
+        screen.getByTestId('activity-card-props').textContent,
+      );
+      expect(activityCardProps.lastRemediationPlaybookRun).toBeUndefined();
+      expect(activityCardProps.isPlaybookRunsLoading).toBeUndefined();
     });
 
     it('should render child components properly', () => {
@@ -409,6 +514,7 @@ describe('DetailsGeneralContent', () => {
       // Function props won't appear in JSON.stringify, but the components should render correctly
       expect(screen.getByTestId('details-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
+      expect(screen.getByTestId('activity-card')).toBeInTheDocument();
 
       // This confirms the props are being passed (even if we can't see functions in JSON)
       const detailsCardProps = JSON.parse(
@@ -429,6 +535,7 @@ describe('DetailsGeneralContent', () => {
           connectionError: { errors: [{ status: 403 }] },
           connectedSystems: 0,
         },
+        details: createDetails({ system_count: 101 }),
       };
 
       render(<DetailsGeneralContent {...props} />);
@@ -440,6 +547,9 @@ describe('DetailsGeneralContent', () => {
     });
 
     it('should handle null remediationStatus', () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       const props = {
         ...defaultProps,
         remediationStatus: null,
@@ -447,8 +557,10 @@ describe('DetailsGeneralContent', () => {
 
       render(<DetailsGeneralContent {...props} />);
 
-      // Should NOT show alert because null?.connectionError?.errors?.[0]?.status !== 403 and null?.connectedSystems !== 0 are both true
+      // Should NOT show alert because null?.connectionError and null?.connectedSystems do not block execution
       expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
+
+      consoleErrorSpy.mockRestore();
     });
 
     it('should handle different connectionError values', () => {
@@ -541,12 +653,16 @@ describe('DetailsGeneralContent', () => {
       const gridItems = screen.getAllByTestId('grid-item');
 
       // Check hierarchy
-      expect(gridItems).toHaveLength(2);
+      expect(gridItems).toHaveLength(3);
       expect(grid).toContainElement(gridItems[0]);
       expect(grid).toContainElement(gridItems[1]);
+      expect(grid).toContainElement(gridItems[2]);
       expect(gridItems[0]).toContainElement(screen.getByTestId('details-card'));
       expect(gridItems[1]).toContainElement(
         screen.getByTestId('progress-card'),
+      );
+      expect(gridItems[2]).toContainElement(
+        screen.getByTestId('activity-card'),
       );
     });
 
@@ -561,6 +677,11 @@ describe('DetailsGeneralContent', () => {
       // Second grid item should contain ProgressCard
       expect(gridItems[1]).toContainElement(
         screen.getByTestId('progress-card'),
+      );
+
+      // Third grid item should contain ActivityCard
+      expect(gridItems[2]).toContainElement(
+        screen.getByTestId('activity-card'),
       );
     });
   });

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.js
@@ -29,6 +29,7 @@ const RemediationDetailsPageHeader = ({
   remediationPlaybookRuns,
   isPlaybookRunsLoading,
   actionPoints = 0,
+  onRetentionPolicyUpdated,
 }) => {
   const addNotification = useAddNotification();
   const handleDownload = useCallback(() => {
@@ -133,6 +134,7 @@ const RemediationDetailsPageHeader = ({
                   refetchAllRemediations={refetchAllRemediations}
                   updateRemPlan={updateRemPlan}
                   refetchRemediationDetails={refetchRemediationDetails}
+                  onRetentionPolicyUpdated={onRetentionPolicyUpdated}
                 />
               </FlexItem>
             </Flex>
@@ -182,6 +184,7 @@ RemediationDetailsPageHeader.propTypes = {
   remediationPlaybookRuns: PropTypes.object,
   isPlaybookRunsLoading: PropTypes.bool,
   actionPoints: PropTypes.number,
+  onRetentionPolicyUpdated: PropTypes.func,
 };
 
 export default RemediationDetailsPageHeader;

--- a/src/routes/RemediationDetailsComponents/DetailsPageHeader.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsPageHeader.test.js
@@ -51,7 +51,7 @@ const remediationStatus = {
   areDetailsLoading: false,
   connectionError: null,
 };
-const allRemediations = { data: [] };
+const allRemediations = [];
 const permissions = { execute: true };
 const updateRemPlan = jest.fn();
 const refetch = jest.fn();

--- a/src/routes/RemediationDetailsComponents/helpers.js
+++ b/src/routes/RemediationDetailsComponents/helpers.js
@@ -5,6 +5,14 @@ import {
 } from '@patternfly/react-icons';
 import React from 'react';
 
+export const toValidDate = (value) => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 export const execStatus = (status, date) => {
   let icon;
   let displayValue = 'N/A';

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -8,6 +8,9 @@ import {
   BanIcon,
 } from '@patternfly/react-icons';
 import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { pluralize } from '../Utilities/utils';
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
 const STATUS_META = {
   success: {
@@ -38,6 +41,31 @@ const STATUS_META = {
 export const getStatusMeta = (status = '') => {
   if (!status || typeof status !== 'string') return null;
   return STATUS_META[status.toLowerCase()] ?? null;
+};
+
+export const calculateExpiresInDays = (expiresAtDate) => {
+  // Expects a valid Date. Unknown or invalid expiration values are handled
+  // before this helper is called.
+  const msUntilExpiration = expiresAtDate.getTime() - Date.now();
+  const daysUntilExpiration = msUntilExpiration / DAY_IN_MS;
+
+  // Future expirations round up so partial days still read as time remaining:
+  // e.g. +19.5 days => 20 days remaining.
+  // Past expirations round down so anything already expired stays negative:
+  // e.g. -0.5 day => -1, not -0/0.
+  // This keeps "expired earlier today" in the expired state instead of
+  // showing it as if the plan still had 0 days remaining.
+  return msUntilExpiration < 0
+    ? Math.floor(daysUntilExpiration)
+    : Math.ceil(daysUntilExpiration);
+};
+
+export const textualizeExpiresInDays = (expiresInDays) => {
+  if (expiresInDays < 30) {
+    return pluralize(expiresInDays, 'day');
+  }
+
+  return pluralize(Math.floor(expiresInDays / 30), 'month');
 };
 
 export const StatusLabel = ({ status = '' }) => {

--- a/src/routes/helpers.test.js
+++ b/src/routes/helpers.test.js
@@ -4,16 +4,18 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {
+  calculateExpiresInDays,
   getStatusMeta,
   StatusLabel,
   getStatusText,
   getStatusColor,
   renderConnectionStatus,
+  textualizeExpiresInDays,
 } from './helpers';
 
 // Mock PatternFly components
 jest.mock('@patternfly/react-core', () => ({
-  Icon: (props) => <div data-testid="icon">{props.children}</div>,
+  Icon: (props) => <span data-testid="icon">{props.children}</span>,
   Label: (props) => (
     <span
       data-testid="label"
@@ -35,12 +37,14 @@ jest.mock('@patternfly/react-core', () => ({
 }));
 
 jest.mock('@patternfly/react-icons', () => ({
-  CheckCircleIcon: () => <div data-testid="check-circle-icon">CheckCircle</div>,
-  InProgressIcon: () => <div data-testid="in-progress-icon">InProgress</div>,
-  ExclamationCircleIcon: () => (
-    <div data-testid="exclamation-circle-icon">ExclamationCircle</div>
+  CheckCircleIcon: () => (
+    <span data-testid="check-circle-icon">CheckCircle</span>
   ),
-  BanIcon: () => <div data-testid="ban-icon">Ban</div>,
+  InProgressIcon: () => <span data-testid="in-progress-icon">InProgress</span>,
+  ExclamationCircleIcon: () => (
+    <span data-testid="exclamation-circle-icon">ExclamationCircle</span>
+  ),
+  BanIcon: () => <span data-testid="ban-icon">Ban</span>,
 }));
 
 jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
@@ -52,6 +56,40 @@ jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
 });
 
 describe('routes/helpers', () => {
+  describe('expiration helpers', () => {
+    const now = Date.parse('2026-07-08T12:00:00Z');
+
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should round up remaining days until expiration', () => {
+      const expiresAtDate = new Date('2026-07-28T00:00:00Z');
+
+      expect(calculateExpiresInDays(expiresAtDate)).toBe(20);
+    });
+
+    it('should treat an expiration earlier today as expired', () => {
+      const expiresAtDate = new Date('2026-07-08T00:00:00Z');
+
+      expect(calculateExpiresInDays(expiresAtDate)).toBe(-1);
+    });
+
+    it('should render day-based expiration text for short periods', () => {
+      expect(textualizeExpiresInDays(20)).toBe('20 days');
+      expect(textualizeExpiresInDays(1)).toBe('1 day');
+    });
+
+    it('should render month-based expiration text for longer periods', () => {
+      expect(textualizeExpiresInDays(30)).toBe('1 month');
+      expect(textualizeExpiresInDays(69)).toBe('2 months');
+    });
+  });
+
   describe('getStatusMeta', () => {
     it('should return success meta for success status', () => {
       const result = getStatusMeta('success');


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-28095


# How to test the PR

Visit Remediation Detail page, and verify that Activity tab is implemented according to Prototype and Microcopy document attached in the linked JIRA.
Expiration field should display warning for expired/expiring plans.

# Before the change
<img width="1872" height="1002" alt="image" src="https://github.com/user-attachments/assets/d0a9528b-7b37-4d22-b5f6-c4d2d39c7b3c" />



# After the change
**Before expiration, inside warning period:**
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-24-58" src="https://github.com/user-attachments/assets/d7f1c954-2fd1-4c41-a3fb-ac1db7e18da3" />
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-25-01" src="https://github.com/user-attachments/assets/f9ce17af-503b-4313-9f65-f58f240c11fd" />
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-25-11" src="https://github.com/user-attachments/assets/8e7f567f-18b4-411e-b78c-76c0f530fa11" />

**Before expiration, outside warning period:**
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-28-27" src="https://github.com/user-attachments/assets/513a3b62-7981-4c4d-a614-85880e2dfee8" />
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-28-30" src="https://github.com/user-attachments/assets/3c9c8cf3-51d5-4bf3-abe4-2d6c9e117620" />
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-28-34" src="https://github.com/user-attachments/assets/4e791cb8-8177-4030-9bcc-480647418106" />

**Expired:**
<img width="1879" height="1005" alt="Screenshot From 2026-07-08 23-28-53" src="https://github.com/user-attachments/assets/609481e1-23f9-4661-8990-f95064146459" />



# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Introduce an Activity card on the remediation details page that surfaces execution activity and plan expiration based on organization retention settings.

New Features:
- Add an Activity card on remediation details showing latest execution status, creation and modification times, last execution, and plan expiration details.
- Expose API helpers to read and update organization-wide remediation retention configuration.

Enhancements:
- Refactor remediation details props to pass the last playbook run explicitly and centralize execution status and date handling in shared helpers.

## Summary by Sourcery

Add an Activity card to the remediation details page that surfaces execution activity and plan expiration based on organization-wide retention settings, while simplifying the existing details card layout.

New Features:
- Introduce an Activity card on the remediation details page showing latest execution status, creation and modification timestamps, last execution time, and remediation plan expiration.
- Load and display organization-wide remediation retention configuration to compute expiration and warning states for remediation plans.
- Trigger automatic refresh of remediation details and retention configuration after updates to the organization retention policy.

Enhancements:
- Restructure the remediation details layout so that lifecycle and execution information moves from the details card into the new activity card.
- Add shared helpers for expiration calculations and date validation to consistently derive remaining time and textual representations.
- Extend the general details content and header to pass playbook run metadata and retention refresh signals to child components, and to surface an AAP upsell alert when execution limits are exceeded.

Tests:
- Expand and adjust unit tests for details, general content, and header components to cover the new activity card, updated props, expiration helpers, and retention policy flows.
- Add dedicated tests for the new ActivityCard component to verify rendering of execution status, expiration states, retention messaging, and behavior when organization configuration is unavailable.