### PR TITLE
fix(navigation): avoid having duplicated left-nav items

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -64,16 +64,16 @@ objects:
             - automation
             - tasks
             - ansible remediations
-      bundleSegments:
-        - segmentId: remediations-insights
-          bundleId: insights
-          position: 1500
+      navigationSegments:
+        - segmentId: remediations-nav
           navItems:
             - id: remediations
               title: Remediation Plans
               href: /insights/remediations
               icon: InsightsIcon
               product: Red Hat Insights
+
+      bundleSegments:
         - segmentId: remediations-ansible
           bundleId: ansible
           position: 2300


### PR DESCRIPTION
I tried to avoid using refs but seems there is no way to do that. Based on doc we need to have main app that will define bundle `Automation Toolkit` and app that will consume it https://github.com/RedHatInsights/frontend-starter-app/blob/master/docs/frontend-operator/navigation.md

## Summary by Sourcery

Build:
- Update frontend deployment configuration to replace the insights bundle segment for remediations with a navigation segment and retain the ansible bundle segment.