### PR TITLE
fix(RHINENG-28784): update sdk library to fix workspaces call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@patternfly/react-log-viewer": "^6.3.0",
         "@patternfly/react-table": "^6.4.2",
         "@patternfly/react-tokens": "^6.4.0",
-        "@project-kessel/react-kessel-access-check": "^0.5.0",
+        "@project-kessel/react-kessel-access-check": "^0.5.2",
         "@redhat-cloud-services/frontend-components": "^7.3.0",
         "@redhat-cloud-services/frontend-components-notifications": "^6.5.0",
         "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",
@@ -4847,9 +4847,9 @@
       }
     },
     "node_modules/@project-kessel/react-kessel-access-check": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.0.tgz",
-      "integrity": "sha512-yOQEsX/Z53PSFuiemdGkKNKCRXRVb3Tzo/z8JpmC1uMGm7cT9ny49VqJokRHVuqCLGPH3IqbBd1USD1I2vi1Ew==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.2.tgz",
+      "integrity": "sha512-6a9SSyPWdhcJqxOF9hcrbuLfVqcwrkNf21G7prmCBsNoIygvKApe/fHH7o0AzSkVatcfwPhNA3JgdxNffN4wtw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@patternfly/react-log-viewer": "^6.3.0",
     "@patternfly/react-table": "^6.4.2",
     "@patternfly/react-tokens": "^6.4.0",
-    "@project-kessel/react-kessel-access-check": "^0.5.0",
+    "@project-kessel/react-kessel-access-check": "^0.5.2",
     "@redhat-cloud-services/frontend-components": "^7.3.0",
     "@redhat-cloud-services/frontend-components-notifications": "^6.5.0",
     "@redhat-cloud-services/frontend-components-utilities": "^7.2.0",


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Upgrade the Kessel access-check SDK dependency to resolve issues with workspace-related calls.

Bug Fixes:
- Update workspace access-check functionality by upgrading the @project-kessel/react-kessel-access-check SDK dependency.

Build:
- Bump @project-kessel/react-kessel-access-check from 0.5.0 to 0.5.2 in package.json and lockfile.