### PR TITLE
fix(expiration): align months and days rounding for Expiration column

### DIFF
--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -161,7 +161,7 @@ describe('ActivityCard', () => {
       });
 
       expect(screen.queryByText(/Expires in/i)).not.toBeInTheDocument();
-      expect(screen.getByText('2 months remaining')).toBeInTheDocument();
+      expect(screen.getByText('3 months remaining')).toBeInTheDocument();
     });
 
     it('falls back to an unknown expiration date and never-executed state when date data is missing', async () => {

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -74,7 +74,7 @@ export const textualizeExpiresInDays = (expiresInDays) => {
     return pluralize(expiresInDays, 'day');
   }
 
-  return pluralize(Math.floor(expiresInDays / 30), 'month');
+  return pluralize(Math.ceil(expiresInDays / 30), 'month');
 };
 
 export const isWithinExpirationWarningWindow = (expiresInDays, warningDays) => {

--- a/src/routes/helpers.test.js
+++ b/src/routes/helpers.test.js
@@ -332,6 +332,8 @@ describe('routes/helpers', () => {
 
     it('should textualize longer windows as months', () => {
       expect(textualizeExpiresInDays(30)).toBe('1 month');
+      expect(textualizeExpiresInDays(31)).toBe('2 months');
+      expect(textualizeExpiresInDays(69)).toBe('3 months');
       expect(textualizeExpiresInDays(90)).toBe('3 months');
       expect(textualizeExpiresInDays(180)).toBe('6 months');
     });
@@ -386,7 +388,7 @@ describe('routes/helpers', () => {
         status: 'normal',
         expiresAtDate: new Date('2026-09-15T00:00:00Z'),
         expiresInDays: 69,
-        durationText: '2 months',
+        durationText: '3 months',
       });
     });
 


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-24750

Align rounding of `months` within Expiration column to the same rounding as is used for `days`. That way, both 

# How to test the PR

Check warning-highlightings within Expiration column on /insights/remediations page using various Retention policy configs.

# Before the change
Month-logic was rounding down, which was not consistent with how days are rounded. In addition, it created this edge-case in which plans with same Expiration value displayed could have different warning-state.

(warning period is set to 4 months on the screenshot)
<img width="1580" height="900" alt="Screenshot From 2026-07-21 19-28-13" src="https://github.com/user-attachments/assets/322d2b91-6d78-4682-aee9-d46753a361e3" />



# After the change
(warning period is set to 4 months on the screenshot)
<img width="1580" height="900" alt="Screenshot From 2026-07-21 19-33-37" src="https://github.com/user-attachments/assets/76564771-1ac0-430e-9301-553fa6a4361b" />


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Align expiration month calculations with day-based rounding to ensure consistent expiration text and warning behavior.

Bug Fixes:
- Fix month-based expiration rounding by switching to ceiling division so that month labels match the underlying days and warning logic.

Tests:
- Update and extend helper and ActivityCard tests to reflect the new month rounding behavior for expiration values.