### PR TITLE
fix(RHINENG-24750): restore default-sort column back to last_modified

### DIFF
--- a/src/routes/OverViewPage/OverViewPage.js
+++ b/src/routes/OverViewPage/OverViewPage.js
@@ -223,7 +223,7 @@ export const OverViewPage = () => {
               }}
               options={{
                 sortBy: {
-                  index: 6,
+                  index: 7,
                   direction: 'desc',
                 },
                 manageColumns: true,


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-24750

After adding `Expiration` column, the default sorting column has changed. This PR sets default sorting column back to `Last modified` for the Remediations table.


# How to test the PR

Visit `/insights/remediations` page and check that Remediations table is sorted by `Last modified` by default.

# Before the change
<img width="1878" height="1036" alt="Screenshot From 2026-07-21 21-36-41" src="https://github.com/user-attachments/assets/fff248db-533c-41a1-a762-f9782355124f" />



# After the change
<img width="1878" height="1036" alt="Screenshot From 2026-07-21 21-37-09" src="https://github.com/user-attachments/assets/4238e2b0-71c0-44a7-ad9c-55f2e5afe782" />



# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Bug Fixes:
- Correct the Remediations table initial sort configuration so it defaults to Last modified instead of the newly added Expiration column.