### PR TITLE
fix(RHINENG-28095): correctly format month-periods in expiration popover, activity card

### DIFF
--- a/src/routes/RemediationDetailsComponents/ActivityCard.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.js
@@ -21,7 +21,8 @@ import { formatDate } from '../Cells';
 import { execStatus, toValidDate } from './helpers';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import { getOrgConfig } from '../api';
-import { capitalize, pluralize } from '../../Utilities/utils';
+import { capitalize } from '../../Utilities/utils';
+import { formatDuration } from '../../Utilities/retentionPolicy';
 import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
@@ -109,9 +110,7 @@ const ActivityCard = ({
   // Build the retention period text from effective config
   const retentionDays = orgConfig?.plan_retention_days;
   const retentionDurationText =
-    retentionDays != null
-      ? pluralize(retentionDays, 'day')
-      : 'an unknown period';
+    retentionDays != null ? formatDuration(retentionDays) : 'an unknown period';
 
   return (
     <Card isFullHeight>

--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -150,7 +150,7 @@ describe('ActivityCard', () => {
 
       expect(
         await screen.findByText(
-          /automatically deleted after 90 days of inactivity/i,
+          /automatically deleted after 3 months of inactivity/i,
         ),
       ).toBeInTheDocument();
     });


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-28095

This PR formats the retention period in _Activity card > Expiration popover_ the same way as it is formatted in _Edit retention policy modal_, i.e. `14 days, 30 days, 2 months, 3 months...` instead of `14 days, 30 days, 60 days, 90 days...`.

# How to test the PR
Open popover on the Remediation detail page and verify that month-duration is displayed in months-format, rather than days-format.

# Before the change
<img width="1878" height="1036" alt="Screenshot From 2026-07-21 22-22-20" src="https://github.com/user-attachments/assets/bf2b02e8-27b9-4f92-9bc1-84a6730c0da9" />



# After the change
<img width="1878" height="1036" alt="Screenshot From 2026-07-21 22-16-54" src="https://github.com/user-attachments/assets/2c5ba055-798c-441e-bb03-b3e6fb063fe3" />



# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Align retention period formatting in the remediation activity card expiration popover with existing retention policy formatting.

Bug Fixes:
- Display month-based retention periods in the activity card expiration popover using month units instead of equivalent day counts.

Tests:
- Update activity card tests to assert the corrected month-based expiration message.