### PR TITLE
fix(RHINENG-24750): move to PF's native approach for Expiration column's tooltip

### DIFF
--- a/src/routes/Columns.js
+++ b/src/routes/Columns.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { Icon, Tooltip } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { wrappable, breakWord } from '@patternfly/react-table';
+import { wrappable, breakWord, info } from '@patternfly/react-table';
 import {
   Name as NameCell,
   LastExecutedCell,
@@ -12,19 +9,6 @@ import {
   LastModifiedCell,
   ExpirationCell,
 } from './Cells.js';
-
-export const ExpirationColumnHeader = () => {
-  return (
-    <span style={{ whiteSpace: 'nowrap' }}>
-      Expiration
-      <Tooltip content="Time remaining until the remediation plan is automatically deleted due to inactivity.">
-        <Icon status="custom" className="pf-v6-u-ml-xs">
-          <OutlinedQuestionCircleIcon color="var(--pf-t--global--icon--color--subtle)" />
-        </Icon>
-      </Tooltip>
-    </span>
-  );
-};
 
 export const Name = {
   title: 'Name',
@@ -68,8 +52,15 @@ export const Systems = {
 };
 
 export const Expiration = {
-  title: <ExpirationColumnHeader />,
-  transforms: [wrappable],
+  title: 'Expiration',
+  transforms: [
+    wrappable,
+    info({
+      tooltip:
+        'Time remaining until the remediation plan is automatically deleted due to inactivity.',
+      ariaLabel: 'Expiration column help',
+    }),
+  ],
   sortable: 'expires_at',
   exportKey: 'expires_at',
   Component: ExpirationCell,


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/RHINENG-22192

This changes the way how Expiration column's popover is defined. It moves from custom JSX to PF's native approach.


# How to test the PR

Visit the Remediations page (/insights/remediations) and verify that Expiration column header and its popover looks good as is functional, along with sorting the table.

# Before the change
<img width="1876" height="1005" alt="Screenshot From 2026-07-22 15-13-54" src="https://github.com/user-attachments/assets/8fa3284c-13a6-4063-8272-a3e8ea65c7e1" />


# After the change
<img width="1876" height="1005" alt="Screenshot From 2026-07-22 15-14-40" src="https://github.com/user-attachments/assets/5a57bc5e-aca8-419a-9661-01c90586767f" />



# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Enhancements:
- Align the Expiration column header tooltip with PatternFly's native table info/tooltip pattern for improved consistency and accessibility.