### PR TITLE
feat(CPUX-6733): address retention policy UX review findings

### DIFF
--- a/src/components/RetentionPolicyModal.js
+++ b/src/components/RetentionPolicyModal.js
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
+  Form,
+  FormHelperText,
   FormGroup,
   HelperText,
   HelperTextItem,
@@ -192,8 +194,8 @@ const RetentionPolicyModal = ({
         {!isReady ? (
           <Skeleton screenreaderText="Loading retention policy settings" />
         ) : (
-          <>
-            <p className="pf-v6-u-mb-lg">
+          <Form>
+            <p>
               By default, remediation plans are deleted after 4 months of
               inactivity. Any plan modifications or executions will reset the
               retention period. Changes to this retention policy will affect all
@@ -212,19 +214,20 @@ const RetentionPolicyModal = ({
                 onChange={handleRetentionChange}
                 isDisabled={isSaving}
               />
-              <HelperText className="pf-v6-u-pt-sm">
-                <HelperTextItem>
-                  The duration that an inactive remediation plan is kept before
-                  being automatically deleted.
-                </HelperTextItem>
-              </HelperText>
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    The duration that an inactive remediation plan is kept
+                    before being automatically deleted.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
             </FormGroup>
 
             <FormGroup
               label="Expiration warning"
               isRequired
               fieldId="expiration-warning"
-              className="pf-v6-u-mt-md"
             >
               <DurationSelect
                 fieldId="expiration-warning"
@@ -233,14 +236,16 @@ const RetentionPolicyModal = ({
                 onChange={setWarningDays}
                 isDisabled={isSaving}
               />
-              <HelperText className="pf-v6-u-pt-sm">
-                <HelperTextItem>
-                  The duration to display a warning before an inactive plan is
-                  automatically deleted.
-                </HelperTextItem>
-              </HelperText>
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>
+                    The duration to display a warning before an inactive plan is
+                    automatically deleted.
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
             </FormGroup>
-          </>
+          </Form>
         )}
       </ModalBody>
       {isReady && (

--- a/src/routes/Cells.js
+++ b/src/routes/Cells.js
@@ -148,21 +148,21 @@ export const ExpirationCell = ({
   const shouldShowWarning = expiration.status !== 'normal';
 
   return (
-    <Tooltip content={formatDate(expires_at)}>
-      <Flex
-        spaceItems={{ default: 'spaceItemsXs' }}
-        alignItems={{ default: 'alignItemsCenter' }}
-      >
-        {shouldShowWarning && (
-          <span aria-label="Expiration warning">
-            <Icon status="warning">
-              <ExclamationTriangleIcon />
-            </Icon>
-          </span>
-        )}
+    <Flex
+      spaceItems={{ default: 'spaceItemsXs' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+    >
+      {shouldShowWarning && (
+        <span aria-label="Expiration warning">
+          <Icon status="warning">
+            <ExclamationTriangleIcon />
+          </Icon>
+        </span>
+      )}
+      <Tooltip content={formatDate(expires_at)}>
         <Content component="p">{displayValue}</Content>
-      </Flex>
-    </Tooltip>
+      </Tooltip>
+    </Flex>
   );
 };
 

--- a/src/routes/RemediationDetailsComponents/ActivityCard.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.js
@@ -1,12 +1,13 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Card,
+  CardExpandableContent,
+  CardHeader,
   CardTitle,
   Flex,
   Title,
   Label,
-  Tooltip,
   Popover,
   DescriptionList,
   DescriptionListGroup,
@@ -16,19 +17,31 @@ import {
   Spinner,
   Button,
   Icon,
+  Timestamp,
 } from '@patternfly/react-core';
 import { formatDate } from '../Cells';
-import { execStatus, toValidDate } from './helpers';
+import {
+  execStatus,
+  getExpandableCardToggleProps,
+  toValidDate,
+} from './helpers';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import { getOrgConfig } from '../api';
 import { capitalize } from '../../Utilities/utils';
 import { formatDuration } from '../../Utilities/retentionPolicy';
 import {
+  AngleDownIcon,
+  AngleUpIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   OutlinedQuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { getExpirationState } from '../helpers';
+
+const ACTIVITY_CARD_OUIA_ID = 'activity-card';
+const ACTIVITY_CARD_TITLE_ID = 'activity-card-title';
+const ACTIVITY_CARD_TOGGLE_ID = 'activity-card-toggle';
+const ACTIVITY_CARD_CONTENT_ID = 'activity-card-content';
 
 const getActivityExpirationDisplay = (expiration) => {
   if (expiration.status === 'unknown') {
@@ -83,6 +96,7 @@ const ActivityCard = ({
   isPlaybookRunsLoading,
   retentionPolicyRefreshNonce = 0,
 }) => {
+  const [isExpanded, setIsExpanded] = useState(true);
   // Get organization configuration
   const {
     result: orgConfig,
@@ -113,140 +127,159 @@ const ActivityCard = ({
     retentionDays != null ? formatDuration(retentionDays) : 'an unknown period';
 
   return (
-    <Card isFullHeight>
-      <CardTitle>
-        <Flex
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-          alignItems={{ default: 'alignItemsCenter' }}
-        >
-          <Title headingLevel="h4" size="xl">
-            Activity
-          </Title>
-          {expirationDisplay.label && (
-            <Label status={expirationDisplay.labelStatus} variant="outline">
-              {expirationDisplay.label}
-            </Label>
-          )}
-        </Flex>
-      </CardTitle>
-      <CardBody>
-        <DescriptionList>
-          {/* Last Execution Status */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Latest execution status</DescriptionListTerm>
-            <DescriptionListDescription>
-              {isPlaybookRunsLoading ? (
-                <Spinner size="md" />
-              ) : (
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={() => onNavigateToTab(null, 'executionHistory')}
-                >
-                  {execStatus(
-                    lastRemediationPlaybookRun?.status,
-                    updatedAtDate,
-                  )}
-                </Button>
-              )}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Created */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Created</DescriptionListTerm>
-            <DescriptionListDescription>
-              {formatDate(details?.created_at)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Expiration */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>
-              <Flex
-                spaceItems={{ default: 'spaceItemsXs' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-              >
-                <span>Expiration</span>
-                <Popover
-                  aria-label="Retention policy help popover"
-                  headerContent="Retention policy"
-                  bodyContent={
-                    <div>
-                      Remediation plans are automatically deleted after{' '}
-                      {retentionDurationText} of inactivity. An administrator
-                      can change this period for your organization by editing
-                      the retention policy.
-                    </div>
-                  }
-                >
+    <Card
+      data-ouia-component-id={ACTIVITY_CARD_OUIA_ID}
+      isExpanded={isExpanded}
+    >
+      <CardHeader>
+        <CardTitle id={ACTIVITY_CARD_TITLE_ID} style={{ width: '100%' }}>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+            >
+              <Button
+                variant="plain"
+                icon={isExpanded ? <AngleUpIcon /> : <AngleDownIcon />}
+                onClick={() => setIsExpanded((current) => !current)}
+                {...getExpandableCardToggleProps(
+                  ACTIVITY_CARD_TOGGLE_ID,
+                  ACTIVITY_CARD_CONTENT_ID,
+                  isExpanded,
+                  'Toggle activity card',
+                )}
+              />
+              <Title headingLevel="h4" size="xl">
+                Activity
+              </Title>
+            </Flex>
+            {expirationDisplay.label && (
+              <Label status={expirationDisplay.labelStatus} variant="outline">
+                {expirationDisplay.label}
+              </Label>
+            )}
+          </Flex>
+        </CardTitle>
+      </CardHeader>
+      <CardExpandableContent
+        id={ACTIVITY_CARD_CONTENT_ID}
+        data-ouia-component-id={ACTIVITY_CARD_CONTENT_ID}
+      >
+        <CardBody>
+          <DescriptionList>
+            {/* Last Execution Status */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Latest execution status</DescriptionListTerm>
+              <DescriptionListDescription>
+                {isPlaybookRunsLoading ? (
+                  <Spinner size="md" />
+                ) : (
                   <Button
-                    variant="plain"
-                    icon={<OutlinedQuestionCircleIcon />}
-                    aria-label="Retention policy help"
-                    hasNoPadding
-                  />
-                </Popover>
-              </Flex>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex
-                spaceItems={{ default: 'spaceItemsSm' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-              >
-                {expirationDisplay.icon === 'danger' ? (
-                  <Icon status="danger" data-testid="icon">
-                    <ExclamationCircleIcon />
-                  </Icon>
-                ) : expirationDisplay.icon === 'warning' ? (
-                  <Icon status="warning" data-testid="icon">
-                    <ExclamationTriangleIcon />
-                  </Icon>
-                ) : null}
-                {expirationDisplay.hasTooltip ? (
-                  <Tooltip
-                    content={formatDate(expirationState.expiresAtDate)}
-                    position="top"
+                    variant="link"
+                    isInline
+                    onClick={() => onNavigateToTab(null, 'executionHistory')}
                   >
-                    <span
-                      style={{
-                        textDecorationLine: 'underline',
-                        textDecorationStyle: 'dashed',
-                        textDecorationColor:
-                          'var(--pf-t--global--border--color--default)',
-                        textUnderlineOffset: '2px',
-                        cursor: 'pointer',
+                    {execStatus(
+                      lastRemediationPlaybookRun?.status,
+                      updatedAtDate,
+                    )}
+                  </Button>
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Created */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Created</DescriptionListTerm>
+              <DescriptionListDescription>
+                {formatDate(details?.created_at)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Expiration */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <span>Expiration</span>
+                  <Popover
+                    aria-label="Retention policy help popover"
+                    headerContent="Retention policy"
+                    bodyContent={
+                      <div>
+                        Remediation plans are automatically deleted after{' '}
+                        {retentionDurationText} of inactivity. An administrator
+                        can change this period for your organization by editing
+                        the retention policy.
+                      </div>
+                    }
+                  >
+                    <Button
+                      variant="plain"
+                      icon={<OutlinedQuestionCircleIcon />}
+                      aria-label="Retention policy help"
+                      hasNoPadding
+                    />
+                  </Popover>
+                </Flex>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsSm' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  {expirationDisplay.icon === 'danger' ? (
+                    <Icon status="danger" data-testid="icon">
+                      <ExclamationCircleIcon />
+                    </Icon>
+                  ) : expirationDisplay.icon === 'warning' ? (
+                    <Icon status="warning" data-testid="icon">
+                      <ExclamationTriangleIcon />
+                    </Icon>
+                  ) : null}
+                  {expirationDisplay.hasTooltip ? (
+                    <Timestamp
+                      date={expirationState.expiresAtDate}
+                      tooltip={{
+                        variant: 'custom',
+                        content: formatDate(expirationState.expiresAtDate),
+                        tooltipProps: { position: 'top' },
                       }}
                     >
                       {expirationDisplay.text}
-                    </span>
-                  </Tooltip>
+                    </Timestamp>
+                  ) : (
+                    <span>{expirationDisplay.text}</span>
+                  )}
+                </Flex>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Last Modified */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last modified</DescriptionListTerm>
+              <DescriptionListDescription>
+                {formatDate(details?.updated_at)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Last Executed */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last executed</DescriptionListTerm>
+              <DescriptionListDescription>
+                {isPlaybookRunsLoading ? (
+                  <Spinner size="md" />
+                ) : updatedAtDate ? (
+                  formatDate(updatedAtDate)
                 ) : (
-                  <span>{expirationDisplay.text}</span>
+                  'Never'
                 )}
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Last Modified */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Last modified</DescriptionListTerm>
-            <DescriptionListDescription>
-              {formatDate(details?.updated_at)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Last Executed */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Last executed</DescriptionListTerm>
-            <DescriptionListDescription>
-              {isPlaybookRunsLoading ? (
-                <Spinner size="md" />
-              ) : updatedAtDate ? (
-                formatDate(updatedAtDate)
-              ) : (
-                'Never'
-              )}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-        </DescriptionList>
-      </CardBody>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </CardBody>
+      </CardExpandableContent>
     </Card>
   );
 };

--- a/src/routes/RemediationDetailsComponents/ActivityCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ActivityCard.test.js
@@ -133,6 +133,21 @@ describe('ActivityCard', () => {
 
       expect(refetchOrgConfig).toHaveBeenCalledTimes(1);
     });
+
+    it('toggles the expandable card state', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      renderComponent();
+
+      const toggle = screen.getByRole('button', {
+        name: /toggle activity card/i,
+      });
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
   });
 
   describe('expiration states', () => {

--- a/src/routes/RemediationDetailsComponents/DetailsCard.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardBody,
+  CardExpandableContent,
+  CardHeader,
   CardTitle,
   DescriptionList,
   DescriptionListGroup,
@@ -23,6 +25,8 @@ import {
   Skeleton,
 } from '@patternfly/react-core';
 import {
+  AngleDownIcon,
+  AngleUpIcon,
   CheckIcon,
   ExternalLinkAltIcon,
   OutlinedQuestionCircleIcon,
@@ -35,6 +39,12 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { pluralize } from '../../Utilities/utils';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
+import { getExpandableCardToggleProps } from './helpers';
+
+const DETAILS_CARD_OUIA_ID = 'details-card';
+const DETAILS_CARD_TITLE_ID = 'details-card-title';
+const DETAILS_CARD_TOGGLE_ID = 'details-card-toggle';
+const DETAILS_CARD_CONTENT_ID = 'details-card-content';
 
 const DetailsCard = ({
   details,
@@ -48,6 +58,7 @@ const DetailsCard = ({
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(details?.name);
   const [rebootToggle, setRebootToggle] = useState(details?.auto_reboot);
+  const [isExpanded, setIsExpanded] = useState(true);
   const [hasResolutionsAvailable, setHasResolutionsAvailable] = useState(false);
   const [isCheckingResolutions, setIsCheckingResolutions] = useState(true);
   const addNotification = useAddNotification();
@@ -191,19 +202,32 @@ const DetailsCard = ({
   };
 
   return (
-    <Card isFullHeight>
-      <CardTitle>
-        <Flex
-          direction={{ default: 'column' }}
-          spaceItems={{ default: 'spaceItemsMd' }}
-        >
+    <Card data-ouia-component-id={DETAILS_CARD_OUIA_ID} isExpanded={isExpanded}>
+      <CardHeader>
+        <CardTitle id={DETAILS_CARD_TITLE_ID} style={{ width: '100%' }}>
           <Flex
             justifyContent={{ default: 'justifyContentSpaceBetween' }}
             alignItems={{ default: 'alignItemsCenter' }}
           >
-            <Title headingLevel="h4" size="xl">
-              Details
-            </Title>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+            >
+              <Button
+                variant="plain"
+                icon={isExpanded ? <AngleUpIcon /> : <AngleDownIcon />}
+                onClick={() => setIsExpanded((current) => !current)}
+                {...getExpandableCardToggleProps(
+                  DETAILS_CARD_TOGGLE_ID,
+                  DETAILS_CARD_CONTENT_ID,
+                  isExpanded,
+                  'Toggle details card',
+                )}
+              />
+              <Title headingLevel="h4" size="xl">
+                Details
+              </Title>
+            </Flex>
             <Flex
               alignItems={{ default: 'alignItemsCenter' }}
               spaceItems={{ default: 'spaceItemsSm' }}
@@ -221,9 +245,17 @@ const DetailsCard = ({
               </span>
             </Flex>
           </Flex>
+        </CardTitle>
+      </CardHeader>
+      <CardExpandableContent
+        id={DETAILS_CARD_CONTENT_ID}
+        data-ouia-component-id={DETAILS_CARD_CONTENT_ID}
+      >
+        <CardBody>
           <Content
             component="p"
-            style={{ wordBreak: 'break-word', fontWeight: 'normal' }}
+            className="pf-v6-u-mb-md"
+            style={{ wordBreak: 'break-word' }}
           >
             New to remediating through Red Hat Lightspeed?{' '}
             <InsightsLink
@@ -238,176 +270,174 @@ const DetailsCard = ({
               <ExternalLinkAltIcon size="md" className="pf-v6-u-ml-sm" />
             </InsightsLink>
           </Content>
-        </Flex>
-      </CardTitle>
-      <CardBody>
-        <DescriptionList
-          orientation={{
-            sm: 'vertical',
-            md: 'vertical',
-            lg: 'vertical',
-            xl: 'vertical',
-            '2xl': 'vertical',
-          }}
-        >
-          {/* Editable Name */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>
-              <span>Name</span>
-              <Button
-                icon={
-                  <PencilAltIcon
-                    color={
-                      editing
-                        ? 'var(--pf-t--global--text--color--regular)'
-                        : undefined
-                    }
-                  />
-                }
-                variant="link"
-                onClick={() => setEditing(!editing)}
-                className="pf-v6-u-ml-sm"
-                aria-label={
-                  editing
-                    ? 'Close remediation plan name editor'
-                    : 'Edit remediation plan name'
-                }
-              ></Button>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              {editing ? (
-                <Flex
-                  direction={{ default: 'column', md: 'row' }}
-                  spaceItems={{ default: 'spaceItemsXs' }}
-                  alignItems={{ default: 'alignItemsStretch' }}
-                >
-                  <FlexItem>
-                    <FormGroup fieldId="remediation-name">
-                      <TextInput
-                        value={value}
-                        type="text"
-                        onChange={(_, v) => setValue(v)}
-                        aria-label="Rename Input"
-                        autoFocus
-                        validated={validationState}
-                      />
-                      {nameStatus === 'duplicate' && (
-                        <p className="pf-v6-u-font-size-sm pf-v6-u-danger-color-100">
-                          A remediation plan with the same name already exists
-                          in your organization. Enter a unique name and try
-                          again.
-                        </p>
-                      )}
-                      {nameStatus === 'empty' && (
-                        <p className="pf-v6-u-font-size-sm pf-v6-u-danger-color-100">
-                          Playbook name cannot be empty.
-                        </p>
-                      )}
-                    </FormGroup>
-                  </FlexItem>
-                  <FlexItem>
-                    <Flex spaceItems={{ default: 'spaceItemsXs' }}>
-                      <Button
-                        icon={
-                          <CheckIcon
-                            color={
-                              nameStatus !== 'valid'
-                                ? 'var(--pf-t--global--icon--color--disabled)'
-                                : 'var(--pf-t--global--text--color--link--default)'
-                            }
-                          />
-                        }
-                        variant="link"
-                        onClick={() => onSubmit(value)}
-                        isDisabled={nameStatus !== 'valid'}
-                        aria-label="Save remediation plan name"
-                      ></Button>
-                      <Button
-                        icon={
-                          <TimesIcon color="var(--pf-t--global--text--color--subtle)" />
-                        }
-                        variant="link"
-                        onClick={() => setEditing(false)}
-                        aria-label="Cancel remediation plan name edit"
-                      ></Button>
-                    </Flex>
-                  </FlexItem>
-                </Flex>
-              ) : (
-                <Content component="p" style={{ wordBreak: 'break-word' }}>
-                  {details.name}
-                </Content>
-              )}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Actions */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>
-              Actions
-              <Popover
-                bodyContent={() => (
-                  <>
-                    Actions taken to remediate issues on selected systems when
-                    the remediation plan is executed.
-                  </>
+          <DescriptionList
+            orientation={{
+              sm: 'vertical',
+              md: 'vertical',
+              lg: 'vertical',
+              xl: 'vertical',
+              '2xl': 'vertical',
+            }}
+          >
+            {/* Editable Name */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                <span>Name</span>
+                <Button
+                  icon={
+                    <PencilAltIcon
+                      color={
+                        editing
+                          ? 'var(--pf-t--global--text--color--regular)'
+                          : undefined
+                      }
+                    />
+                  }
+                  variant="link"
+                  onClick={() => setEditing(!editing)}
+                  className="pf-v6-u-ml-sm"
+                  aria-label={
+                    editing
+                      ? 'Close remediation plan name editor'
+                      : 'Edit remediation plan name'
+                  }
+                ></Button>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                {editing ? (
+                  <Flex
+                    direction={{ default: 'column', md: 'row' }}
+                    spaceItems={{ default: 'spaceItemsXs' }}
+                    alignItems={{ default: 'alignItemsStretch' }}
+                  >
+                    <FlexItem>
+                      <FormGroup fieldId="remediation-name">
+                        <TextInput
+                          value={value}
+                          type="text"
+                          onChange={(_, v) => setValue(v)}
+                          aria-label="Rename Input"
+                          autoFocus
+                          validated={validationState}
+                        />
+                        {nameStatus === 'duplicate' && (
+                          <p className="pf-v6-u-font-size-sm pf-v6-u-danger-color-100">
+                            A remediation plan with the same name already exists
+                            in your organization. Enter a unique name and try
+                            again.
+                          </p>
+                        )}
+                        {nameStatus === 'empty' && (
+                          <p className="pf-v6-u-font-size-sm pf-v6-u-danger-color-100">
+                            Playbook name cannot be empty.
+                          </p>
+                        )}
+                      </FormGroup>
+                    </FlexItem>
+                    <FlexItem>
+                      <Flex spaceItems={{ default: 'spaceItemsXs' }}>
+                        <Button
+                          icon={
+                            <CheckIcon
+                              color={
+                                nameStatus !== 'valid'
+                                  ? 'var(--pf-t--global--icon--color--disabled)'
+                                  : 'var(--pf-t--global--text--color--link--default)'
+                              }
+                            />
+                          }
+                          variant="link"
+                          onClick={() => onSubmit(value)}
+                          isDisabled={nameStatus !== 'valid'}
+                          aria-label="Save remediation plan name"
+                        ></Button>
+                        <Button
+                          icon={
+                            <TimesIcon color="var(--pf-t--global--text--color--subtle)" />
+                          }
+                          variant="link"
+                          onClick={() => setEditing(false)}
+                          aria-label="Cancel remediation plan name edit"
+                        ></Button>
+                      </Flex>
+                    </FlexItem>
+                  </Flex>
+                ) : (
+                  <Content component="p" style={{ wordBreak: 'break-word' }}>
+                    {details.name}
+                  </Content>
                 )}
-              >
-                <OutlinedQuestionCircleIcon style={{ marginLeft: '5px' }} />
-              </Popover>
-            </DescriptionListTerm>
-            <DescriptionListDescription>
-              <Flex
-                direction={{ default: 'row' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-                spaceItems={{ default: 'spaceItemsMd' }}
-              >
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Actions */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                Actions
+                <Popover
+                  bodyContent={() => (
+                    <>
+                      Actions taken to remediate issues on selected systems when
+                      the remediation plan is executed.
+                    </>
+                  )}
+                >
+                  <OutlinedQuestionCircleIcon style={{ marginLeft: '5px' }} />
+                </Popover>
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <Flex
+                  direction={{ default: 'row' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                  spaceItems={{ default: 'spaceItemsMd' }}
+                >
+                  <Button
+                    variant="link"
+                    onClick={() =>
+                      onNavigateToTab(null, 'plannedRemediations:actions')
+                    }
+                    isInline
+                  >
+                    {`${details?.issue_count} action${
+                      details?.issue_count !== 1 ? 's' : ''
+                    }`}
+                  </Button>
+                  {isCheckingResolutions ? (
+                    <Skeleton
+                      height="1.5rem"
+                      width="200px"
+                      screenreaderText="Checking for resolution options"
+                    />
+                  ) : (
+                    hasResolutionsAvailable && (
+                      <Alert
+                        isInline
+                        isPlain
+                        variant="info"
+                        title="Resolution options are available."
+                      />
+                    )
+                  )}
+                </Flex>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {/* Systems */}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Systems</DescriptionListTerm>
+              <DescriptionListDescription>
                 <Button
                   variant="link"
                   onClick={() =>
-                    onNavigateToTab(null, 'plannedRemediations:actions')
+                    onNavigateToTab(null, 'plannedRemediations:systems')
                   }
                   isInline
                 >
-                  {`${details?.issue_count} action${
-                    details?.issue_count !== 1 ? 's' : ''
-                  }`}
+                  {pluralize(details?.system_count, 'system')}
                 </Button>
-                {isCheckingResolutions ? (
-                  <Skeleton
-                    height="1.5rem"
-                    width="200px"
-                    screenreaderText="Checking for resolution options"
-                  />
-                ) : (
-                  hasResolutionsAvailable && (
-                    <Alert
-                      isInline
-                      isPlain
-                      variant="info"
-                      title="Resolution options are available."
-                    />
-                  )
-                )}
-              </Flex>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          {/* Systems */}
-          <DescriptionListGroup>
-            <DescriptionListTerm>Systems</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Button
-                variant="link"
-                onClick={() =>
-                  onNavigateToTab(null, 'plannedRemediations:systems')
-                }
-                isInline
-              >
-                {pluralize(details?.system_count, 'system')}
-              </Button>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-        </DescriptionList>
-      </CardBody>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </CardBody>
+      </CardExpandableContent>
     </Card>
   );
 };

--- a/src/routes/RemediationDetailsComponents/DetailsCard.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsCard.test.js
@@ -133,6 +133,21 @@ describe('DetailsCard', () => {
       expect(screen.getByText(/Auto-reboot/)).toBeInTheDocument();
     });
 
+    it('toggles the expandable card state', async () => {
+      const user = userEvent.setup();
+
+      renderComponent();
+
+      const toggle = screen.getByRole('button', {
+        name: /toggle details card/i,
+      });
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    });
+
     it('displays correct action and system counts', () => {
       renderComponent();
 

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -2,6 +2,8 @@ import React, { useMemo, useState, useEffect } from 'react';
 import {
   Alert,
   AlertActionCloseButton,
+  Flex,
+  FlexItem,
   Grid,
   GridItem,
 } from '@patternfly/react-core';
@@ -115,14 +117,30 @@ const DetailsGeneralContent = ({
 
       <Grid hasGutter>
         <GridItem span={12} md={6}>
-          <DetailsCard
-            details={details}
-            refetch={refetch}
-            updateRemPlan={updateRemPlan}
-            onNavigateToTab={onNavigateToTab}
-            allRemediations={allRemediations}
-            refetchAllRemediations={refetchAllRemediations}
-          />
+          <Flex
+            direction={{ default: 'column' }}
+            spaceItems={{ default: 'spaceItemsMd' }}
+          >
+            <FlexItem>
+              <DetailsCard
+                details={details}
+                refetch={refetch}
+                updateRemPlan={updateRemPlan}
+                onNavigateToTab={onNavigateToTab}
+                allRemediations={allRemediations}
+                refetchAllRemediations={refetchAllRemediations}
+              />
+            </FlexItem>
+            <FlexItem>
+              <ActivityCard
+                details={details}
+                lastRemediationPlaybookRun={lastRemediationPlaybookRun}
+                isPlaybookRunsLoading={isPlaybookRunsLoading}
+                onNavigateToTab={onNavigateToTab}
+                retentionPolicyRefreshNonce={retentionPolicyRefreshNonce}
+              />
+            </FlexItem>
+          </Flex>
         </GridItem>
         <GridItem span={12} md={6}>
           <ProgressCard
@@ -132,15 +150,6 @@ const DetailsGeneralContent = ({
             onNavigateToTab={onNavigateToTab}
             details={details}
             actionPoints={actionPoints}
-          />
-        </GridItem>
-        <GridItem span={12} md={6}>
-          <ActivityCard
-            details={details}
-            lastRemediationPlaybookRun={lastRemediationPlaybookRun}
-            isPlaybookRunsLoading={isPlaybookRunsLoading}
-            onNavigateToTab={onNavigateToTab}
-            retentionPolicyRefreshNonce={retentionPolicyRefreshNonce}
           />
         </GridItem>
       </Grid>

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -91,6 +91,25 @@ jest.mock('@patternfly/react-core', () => ({
       </div>
     );
   },
+  Flex: function MockFlex({ children, direction, spaceItems, ...props }) {
+    return (
+      <div
+        data-testid="flex"
+        data-direction={JSON.stringify(direction)}
+        data-space-items={JSON.stringify(spaceItems)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+  FlexItem: function MockFlexItem({ children, ...props }) {
+    return (
+      <div data-testid="flex-item" {...props}>
+        {children}
+      </div>
+    );
+  },
 }));
 
 describe('DetailsGeneralContent', () => {
@@ -163,19 +182,15 @@ describe('DetailsGeneralContent', () => {
       render(<DetailsGeneralContent {...defaultProps} />);
 
       const gridItems = screen.getAllByTestId('grid-item');
-      expect(gridItems).toHaveLength(3);
+      expect(gridItems).toHaveLength(2);
 
-      // First grid item (DetailsCard)
+      // First grid item (Details + Activity column)
       expect(gridItems[0]).toHaveAttribute('data-span', '12');
       expect(gridItems[0]).toHaveAttribute('data-md', '6');
 
       // Second grid item (ProgressCard)
       expect(gridItems[1]).toHaveAttribute('data-span', '12');
       expect(gridItems[1]).toHaveAttribute('data-md', '6');
-
-      // Third grid item (ActivityCard)
-      expect(gridItems[2]).toHaveAttribute('data-span', '12');
-      expect(gridItems[2]).toHaveAttribute('data-md', '6');
     });
   });
 
@@ -647,16 +662,15 @@ describe('DetailsGeneralContent', () => {
       const gridItems = screen.getAllByTestId('grid-item');
 
       // Check hierarchy
-      expect(gridItems).toHaveLength(3);
+      expect(gridItems).toHaveLength(2);
       expect(grid).toContainElement(gridItems[0]);
       expect(grid).toContainElement(gridItems[1]);
-      expect(grid).toContainElement(gridItems[2]);
       expect(gridItems[0]).toContainElement(screen.getByTestId('details-card'));
+      expect(gridItems[0]).toContainElement(
+        screen.getByTestId('activity-card'),
+      );
       expect(gridItems[1]).toContainElement(
         screen.getByTestId('progress-card'),
-      );
-      expect(gridItems[2]).toContainElement(
-        screen.getByTestId('activity-card'),
       );
     });
 
@@ -665,17 +679,15 @@ describe('DetailsGeneralContent', () => {
 
       const gridItems = screen.getAllByTestId('grid-item');
 
-      // First grid item should contain DetailsCard
+      // First grid item should contain DetailsCard and ActivityCard
       expect(gridItems[0]).toContainElement(screen.getByTestId('details-card'));
+      expect(gridItems[0]).toContainElement(
+        screen.getByTestId('activity-card'),
+      );
 
       // Second grid item should contain ProgressCard
       expect(gridItems[1]).toContainElement(
         screen.getByTestId('progress-card'),
-      );
-
-      // Third grid item should contain ActivityCard
-      expect(gridItems[2]).toContainElement(
-        screen.getByTestId('activity-card'),
       );
     });
   });

--- a/src/routes/RemediationDetailsComponents/ProgressCard.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.js
@@ -2,6 +2,8 @@ import {
   Button,
   Card,
   CardBody,
+  CardExpandableContent,
+  CardHeader,
   CardTitle,
   ProgressStep,
   ProgressStepper,
@@ -14,6 +16,8 @@ import {
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
+  AngleDownIcon,
+  AngleUpIcon,
   ExternalLinkAltIcon,
   OpenDrawerRightIcon,
 } from '@patternfly/react-icons';
@@ -27,7 +31,13 @@ import {
   getExecutionLimitsPopoverMessage,
   calculateReadinessErrorCount,
   renderStepTitleWithPopover,
+  getExpandableCardToggleProps,
 } from './helpers';
+
+const PROGRESS_CARD_OUIA_ID = 'progress-card';
+const PROGRESS_CARD_TITLE_ID = 'progress-card-title';
+const PROGRESS_CARD_TOGGLE_ID = 'progress-card-toggle';
+const PROGRESS_CARD_CONTENT_ID = 'progress-card-content';
 
 const ProgressCard = ({
   remediationStatus,
@@ -38,6 +48,7 @@ const ProgressCard = ({
   actionPoints: actionPointsProp,
 }) => {
   const [openPopover, setOpenPopover] = useState(null);
+  const [isExpanded, setIsExpanded] = useState(true);
   const { quickStarts } = useChrome();
 
   const actionPointsComputed = useMemo(() => {
@@ -219,146 +230,174 @@ const ProgressCard = ({
   return permissions === undefined || remediationStatus.areDetailsLoading ? (
     <Spinner />
   ) : (
-    <Card isFullHeight>
-      <CardTitle>
-        <Flex
-          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-          alignItems={{ default: 'alignItemsCenter' }}
-        >
-          <Title headingLevel="h4" size="xl">
-            Execution readiness summary
-          </Title>
-          {readyOrNot ? (
-            <Label status="success">Ready</Label>
-          ) : (
-            <Label status="danger" variant="outline">
-              {`Not ready (${pluralize(errorCount, 'error')})`}
-            </Label>
-          )}
-        </Flex>
-      </CardTitle>
-
-      <CardBody>
-        <p className="pf-v6-u-mb-md">
-          Address errors in this section to ensure that your remediation plan is
-          ready for execution.{' '}
-          <Button
-            variant="link"
-            onClick={() =>
-              quickStarts?.activateQuickstart('insights-remediate-plan-create')
-            }
+    <Card
+      data-ouia-component-id={PROGRESS_CARD_OUIA_ID}
+      isExpanded={isExpanded}
+    >
+      <CardHeader>
+        <CardTitle id={PROGRESS_CARD_TITLE_ID} style={{ width: '100%' }}>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
           >
-            Learn more
-            <OpenDrawerRightIcon size="xl" className="pf-v6-u-ml-sm" />
-          </Button>
-        </p>
+            <Flex
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+            >
+              <Button
+                variant="plain"
+                icon={isExpanded ? <AngleUpIcon /> : <AngleDownIcon />}
+                onClick={() => setIsExpanded((current) => !current)}
+                {...getExpandableCardToggleProps(
+                  PROGRESS_CARD_TOGGLE_ID,
+                  PROGRESS_CARD_CONTENT_ID,
+                  isExpanded,
+                  'Toggle execution readiness summary card',
+                )}
+              />
+              <Title headingLevel="h4" size="xl">
+                Execution readiness summary
+              </Title>
+            </Flex>
+            {readyOrNot ? (
+              <Label status="success">Ready</Label>
+            ) : (
+              <Label status="danger" variant="outline">
+                {`Not ready (${pluralize(errorCount, 'error')})`}
+              </Label>
+            )}
+          </Flex>
+        </CardTitle>
+      </CardHeader>
+      <CardExpandableContent
+        id={PROGRESS_CARD_CONTENT_ID}
+        data-ouia-component-id={PROGRESS_CARD_CONTENT_ID}
+      >
+        <CardBody>
+          <p className="pf-v6-u-mb-md">
+            Address errors in this section to ensure that your remediation plan
+            is ready for execution.{' '}
+            <Button
+              variant="link"
+              onClick={() =>
+                quickStarts?.activateQuickstart(
+                  'insights-remediate-plan-create',
+                )
+              }
+            >
+              Learn more
+              <OpenDrawerRightIcon size="xl" className="pf-v6-u-ml-sm" />
+            </Button>
+          </p>
 
-        <ProgressStepper
-          isVertical={true}
-          aria-label="Remediation Readiness card"
-        >
-          <ProgressStep
-            variant={exceedsExecutionLimits ? 'danger' : 'success'}
-            description={executionLimitsDescription}
-            id="executionLimitsStep"
-            titleId="ExecutionLimitsStep"
-            aria-label="ExecutionLimitsStep"
+          <ProgressStepper
+            isVertical={true}
+            aria-label="Remediation Readiness card"
           >
-            <span className="pf-v6-u-color-100">
-              {renderStepTitleWithPopover(
-                'executionLimitsStep',
-                'Planned remediations',
-                executionLimitsPopoverContent,
-                popoverState,
-                exceedsLimits,
-              )}
-            </span>
-          </ProgressStep>
-          <ProgressStep
-            variant={permissions?.execute ? 'success' : 'danger'}
-            description={
+            <ProgressStep
+              variant={exceedsExecutionLimits ? 'danger' : 'success'}
+              description={executionLimitsDescription}
+              id="executionLimitsStep"
+              titleId="ExecutionLimitsStep"
+              aria-label="ExecutionLimitsStep"
+            >
               <span className="pf-v6-u-color-100">
-                {permissions?.execute ? (
-                  'Authorized'
-                ) : (
-                  <>
-                    Not authorized. Check your user access permissions to ensure
-                    that you have the Remediations administrator RBAC role.
-                  </>
+                {renderStepTitleWithPopover(
+                  'executionLimitsStep',
+                  'Planned remediations',
+                  executionLimitsPopoverContent,
+                  popoverState,
+                  exceedsLimits,
                 )}
               </span>
-            }
-            id="permissionsStep"
-            titleId="PermissionsStep"
-            aria-label="PermissionsStep1"
-          >
-            <span className="pf-v6-u-color-100">
-              {renderStepTitleWithPopover(
-                'permissionsStep',
-                'User access permissions',
-                permissionsPopoverContent,
-                popoverState,
-              )}
-            </span>
-          </ProgressStep>
-          <ProgressStep
-            variant={
-              !remediationStatus?.connectionError &&
-              remediationStatus?.connectedSystems !== 0
-                ? 'success'
-                : 'danger'
-            }
-            description={
-              <div className="pf-v6-u-color-100">
-                {remediationStatus?.connectionError ? (
-                  <>Couldn&apos;t verify connection status.</>
-                ) : remediationStatus?.connectedSystems === 0 ? (
-                  <>
-                    No connected systems. You must connect one or more systems
-                    to execute this plan. Review the{' '}
-                    <strong>Connection status</strong> details for each
-                    disconnected system{' '}
-                    <Button
-                      variant="link"
-                      onClick={() =>
-                        onNavigateToTab(null, 'plannedRemediations:systems')
-                      }
-                    >
-                      View systems
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    {`${remediationStatus?.connectedSystems} (of ${remediationStatus?.totalSystems}) connected systems`}{' '}
-                    <Button
-                      variant="link"
-                      onClick={() =>
-                        onNavigateToTab(null, 'plannedRemediations:systems')
-                      }
-                    >
-                      View systems
-                    </Button>
-                  </>
+            </ProgressStep>
+            <ProgressStep
+              variant={permissions?.execute ? 'success' : 'danger'}
+              description={
+                <span className="pf-v6-u-color-100">
+                  {permissions?.execute ? (
+                    'Authorized'
+                  ) : (
+                    <>
+                      Not authorized. Check your user access permissions to
+                      ensure that you have the Remediations administrator RBAC
+                      role.
+                    </>
+                  )}
+                </span>
+              }
+              id="permissionsStep"
+              titleId="PermissionsStep"
+              aria-label="PermissionsStep1"
+            >
+              <span className="pf-v6-u-color-100">
+                {renderStepTitleWithPopover(
+                  'permissionsStep',
+                  'User access permissions',
+                  permissionsPopoverContent,
+                  popoverState,
                 )}
-              </div>
-            }
-            id="connectedSystemsStep"
-            titleId="connectedSystemsStep-title"
-            aria-label="connectedSystemsStep"
-          >
-            <span className="pf-v6-u-color-100">
-              {renderStepTitleWithPopover(
-                'connectedSystemsStep',
-                'Systems connected to Red Hat Lightspeed',
-                connectedSystemsPopoverContent,
-                popoverState,
-                remediationStatus?.connectedSystems === 0 ||
-                  remediationStatus?.connectionError,
-              )}
-            </span>
-          </ProgressStep>
-        </ProgressStepper>
-      </CardBody>
+              </span>
+            </ProgressStep>
+            <ProgressStep
+              variant={
+                !remediationStatus?.connectionError &&
+                remediationStatus?.connectedSystems !== 0
+                  ? 'success'
+                  : 'danger'
+              }
+              description={
+                <div className="pf-v6-u-color-100">
+                  {remediationStatus?.connectionError ? (
+                    <>Couldn&apos;t verify connection status.</>
+                  ) : remediationStatus?.connectedSystems === 0 ? (
+                    <>
+                      No connected systems. You must connect one or more systems
+                      to execute this plan. Review the{' '}
+                      <strong>Connection status</strong> details for each
+                      disconnected system{' '}
+                      <Button
+                        variant="link"
+                        onClick={() =>
+                          onNavigateToTab(null, 'plannedRemediations:systems')
+                        }
+                      >
+                        View systems
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {`${remediationStatus?.connectedSystems} (of ${remediationStatus?.totalSystems}) connected systems`}{' '}
+                      <Button
+                        variant="link"
+                        onClick={() =>
+                          onNavigateToTab(null, 'plannedRemediations:systems')
+                        }
+                      >
+                        View systems
+                      </Button>
+                    </>
+                  )}
+                </div>
+              }
+              id="connectedSystemsStep"
+              titleId="connectedSystemsStep-title"
+              aria-label="connectedSystemsStep"
+            >
+              <span className="pf-v6-u-color-100">
+                {renderStepTitleWithPopover(
+                  'connectedSystemsStep',
+                  'Systems connected to Red Hat Lightspeed',
+                  connectedSystemsPopoverContent,
+                  popoverState,
+                  remediationStatus?.connectedSystems === 0 ||
+                    remediationStatus?.connectionError,
+                )}
+              </span>
+            </ProgressStep>
+          </ProgressStepper>
+        </CardBody>
+      </CardExpandableContent>
     </Card>
   );
 };

--- a/src/routes/RemediationDetailsComponents/ProgressCard.test.js
+++ b/src/routes/RemediationDetailsComponents/ProgressCard.test.js
@@ -64,6 +64,23 @@ jest.mock('@patternfly/react-core', () => ({
       </div>
     );
   },
+  CardExpandableContent: function MockCardExpandableContent({
+    children,
+    ...props
+  }) {
+    return (
+      <div data-testid="card-expandable-content" {...props}>
+        {children}
+      </div>
+    );
+  },
+  CardHeader: function MockCardHeader({ children, ...props }) {
+    return (
+      <div data-testid="card-header" {...props}>
+        {children}
+      </div>
+    );
+  },
   CardFooter: function MockCardFooter({ children, className, ...props }) {
     return (
       <div data-testid="card-footer" className={className} {...props}>
@@ -194,6 +211,12 @@ jest.mock('@patternfly/react-core', () => ({
 }));
 
 jest.mock('@patternfly/react-icons', () => ({
+  AngleDownIcon: function MockAngleDownIcon(props) {
+    return <span data-testid="angle-down-icon" {...props} />;
+  },
+  AngleUpIcon: function MockAngleUpIcon(props) {
+    return <span data-testid="angle-up-icon" {...props} />;
+  },
   OpenDrawerRightIcon: function MockOpenDrawerRightIcon({
     className,
     ...props
@@ -312,9 +335,8 @@ describe('ProgressCard', () => {
       render(<ProgressCard {...defaultProps} />);
 
       expect(screen.getByTestId('card')).toBeInTheDocument();
-      expect(screen.getByTestId('card')).toHaveAttribute(
+      expect(screen.getByTestId('card')).not.toHaveAttribute(
         'data-full-height',
-        'true',
       );
       expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     });
@@ -322,6 +344,7 @@ describe('ProgressCard', () => {
     it('should render card title correctly', () => {
       render(<ProgressCard {...defaultProps} />);
 
+      expect(screen.getByTestId('card-header')).toBeInTheDocument();
       expect(screen.getByTestId('card-title')).toBeInTheDocument();
       expect(screen.getByTestId('title')).toBeInTheDocument();
       expect(screen.getByTestId('title')).toHaveAttribute(
@@ -332,6 +355,19 @@ describe('ProgressCard', () => {
       expect(
         screen.getByText('Execution readiness summary'),
       ).toBeInTheDocument();
+    });
+
+    it('should toggle the expandable card state', () => {
+      render(<ProgressCard {...defaultProps} />);
+
+      const toggle = screen.getByRole('button', {
+        name: /toggle execution readiness summary card/i,
+      });
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      fireEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('should render card body with description', () => {

--- a/src/routes/RemediationDetailsComponents/helpers.js
+++ b/src/routes/RemediationDetailsComponents/helpers.js
@@ -84,6 +84,19 @@ export const renderComponent = (Component, props) => (_data, _id, entity) => (
   <Component {...entity} {...props} />
 );
 
+export const getExpandableCardToggleProps = (
+  toggleId,
+  contentId,
+  isExpanded,
+  label,
+) => ({
+  id: toggleId,
+  'aria-label': label,
+  'aria-controls': contentId,
+  'aria-expanded': isExpanded,
+  'data-ouia-component-id': toggleId,
+});
+
 // Execution limits constants
 export const MAX_SYSTEMS = 100;
 export const MAX_ACTIONS = 1000;


### PR DESCRIPTION
# Description

Associated Jira ticket: https://redhat.atlassian.net/browse/CPUX-6733

This PR addresses findings from the UX review under the associated card:

- make cards in General tab on Detail page expandable
- use default tooltip link in Expiration field in Activity card
- color asterixes in _Edit retention policy_ modal to red
- center positioning of tooltip above the column-value in the Expiration column on Overview page


# How to test the PR

Visit the mentioned places and verify that everything works and looks good.

# Before the change
- Expandable cards:
<img width="1873" height="1126" alt="image" src="https://github.com/user-attachments/assets/8fb55d44-8fb9-4e6e-85fb-194d342ce2b2" />

- Expiration-tooltip in Activity card:
<img width="392" height="450" alt="image" src="https://github.com/user-attachments/assets/674c1ee0-b64f-49e3-9909-3e2d3a394af5" />

- Colored asterixes:
<img width="392" height="450" alt="image" src="https://github.com/user-attachments/assets/22a3ea96-e136-450f-bc8e-cdb95e450091" />

- Centered tooltip in Expiration column:
<img width="198" height="787" alt="image" src="https://github.com/user-attachments/assets/aaad66f8-3fde-413f-b136-6cdbbe006c03" />



# After the change
- Expandable cards:
<img width="1873" height="1126" alt="image" src="https://github.com/user-attachments/assets/4cc2b9fa-ae03-49d5-930d-b2b7cec0b1c5" />

- Expiration-tooltip in Activity card:
<img width="392" height="450" alt="image" src="https://github.com/user-attachments/assets/9389bd59-34a9-483a-b24e-172b146669e1" />

- Colored asterixes:
<img width="392" height="450" alt="image" src="https://github.com/user-attachments/assets/6e6a988b-bf68-4b89-8851-a55a4aac471f" />

- Centered tooltip in Expiration column:
<img width="198" height="787" alt="image" src="https://github.com/user-attachments/assets/e4046e32-9afb-4ffe-a460-e736f11809c2" />




# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Make remediation details overview cards expandable and improve retention policy and expiration UX.

New Features:
- Add expandable behavior with toggles to Details, Progress, and Activity cards on the remediation details page.

Enhancements:
- Group Details and Activity into a single column layout on the General tab for a more compact overview.
- Use PatternFly Timestamp in the Activity card expiration field to show a formatted tooltip, and adjust expiration cell tooltip to center on the value text.
- Update the retention policy modal to use form helper text components for required fields and improve visual emphasis of validation helpers.

Tests:
- Update unit tests for DetailsGeneralContent, DetailsCard, ProgressCard, and ActivityCard to cover the new expandable layout and toggle behavior.