### PR TITLE
fix(rename): rename Details card to Overview card

### DIFF
--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { calculateActionPointsFromSummary } from '../../components/helpers';
 import { calculateExecutionLimits } from './helpers';
-import DetailsCard from './DetailsCard';
+import OverviewCard from './OverviewCard';
 import ProgressCard from './ProgressCard';
 import ActivityCard from './ActivityCard';
 
@@ -122,7 +122,7 @@ const DetailsGeneralContent = ({
             spaceItems={{ default: 'spaceItemsMd' }}
           >
             <FlexItem>
-              <DetailsCard
+              <OverviewCard
                 details={details}
                 refetch={refetch}
                 updateRemPlan={updateRemPlan}

--- a/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
+++ b/src/routes/RemediationDetailsComponents/DetailsGeneralContent.test.js
@@ -5,11 +5,11 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DetailsGeneralContent from './DetailsGeneralContent';
 
-jest.mock('./DetailsCard', () => {
-  return function MockDetailsCard(props) {
+jest.mock('./OverviewCard', () => {
+  return function MockOverviewCard(props) {
     return (
-      <div data-testid="details-card">
-        <div data-testid="details-card-props">
+      <div data-testid="overview-card">
+        <div data-testid="overview-card-props">
           {JSON.stringify(props, null, 2)}
         </div>
       </div>
@@ -156,7 +156,7 @@ describe('DetailsGeneralContent', () => {
       render(<DetailsGeneralContent {...defaultProps} />);
 
       expect(screen.getByTestId('grid')).toBeInTheDocument();
-      expect(screen.getByTestId('details-card')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
       expect(screen.getByTestId('activity-card')).toBeInTheDocument();
     });
@@ -166,7 +166,7 @@ describe('DetailsGeneralContent', () => {
 
       // Component should render without crashing and contain expected elements
       expect(screen.getByTestId('grid')).toBeInTheDocument();
-      expect(screen.getByTestId('details-card')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
       expect(screen.getByTestId('activity-card')).toBeInTheDocument();
     });
@@ -431,23 +431,25 @@ describe('DetailsGeneralContent', () => {
   });
 
   describe('Props passing to child components', () => {
-    it('should pass correct props to DetailsCard', () => {
+    it('should pass correct props to OverviewCard', () => {
       render(<DetailsGeneralContent {...defaultProps} />);
 
-      const detailsCardProps = JSON.parse(
-        screen.getByTestId('details-card-props').textContent,
+      const overviewCardProps = JSON.parse(
+        screen.getByTestId('overview-card-props').textContent,
       );
 
-      expect(detailsCardProps.details).toEqual(defaultProps.details);
-      expect(detailsCardProps.allRemediations).toEqual(
+      expect(overviewCardProps.details).toEqual(defaultProps.details);
+      expect(overviewCardProps.allRemediations).toEqual(
         defaultProps.allRemediations,
       );
-      expect(detailsCardProps).not.toHaveProperty('remediationStatus');
-      expect(detailsCardProps).not.toHaveProperty('lastRemediationPlaybookRun');
-      expect(detailsCardProps).not.toHaveProperty('isPlaybookRunsLoading');
+      expect(overviewCardProps).not.toHaveProperty('remediationStatus');
+      expect(overviewCardProps).not.toHaveProperty(
+        'lastRemediationPlaybookRun',
+      );
+      expect(overviewCardProps).not.toHaveProperty('isPlaybookRunsLoading');
 
-      // Check that DetailsCard component is rendered (functions are passed but not visible in JSON)
-      expect(screen.getByTestId('details-card')).toBeInTheDocument();
+      // Check that OverviewCard component is rendered (functions are passed but not visible in JSON)
+      expect(screen.getByTestId('overview-card')).toBeInTheDocument();
     });
 
     it('should pass correct props to ProgressCard', () => {
@@ -499,17 +501,19 @@ describe('DetailsGeneralContent', () => {
 
       render(<DetailsGeneralContent {...minimalProps} />);
 
-      expect(screen.getByTestId('details-card')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
       expect(screen.getByTestId('activity-card')).toBeInTheDocument();
 
-      const detailsCardProps = JSON.parse(
-        screen.getByTestId('details-card-props').textContent,
+      const overviewCardProps = JSON.parse(
+        screen.getByTestId('overview-card-props').textContent,
       );
-      expect(detailsCardProps.allRemediations).toBeUndefined();
-      expect(detailsCardProps).not.toHaveProperty('remediationStatus');
-      expect(detailsCardProps).not.toHaveProperty('lastRemediationPlaybookRun');
-      expect(detailsCardProps).not.toHaveProperty('isPlaybookRunsLoading');
+      expect(overviewCardProps.allRemediations).toBeUndefined();
+      expect(overviewCardProps).not.toHaveProperty('remediationStatus');
+      expect(overviewCardProps).not.toHaveProperty(
+        'lastRemediationPlaybookRun',
+      );
+      expect(overviewCardProps).not.toHaveProperty('isPlaybookRunsLoading');
 
       const activityCardProps = JSON.parse(
         screen.getByTestId('activity-card-props').textContent,
@@ -523,15 +527,15 @@ describe('DetailsGeneralContent', () => {
       render(<DetailsGeneralContent {...defaultProps} />);
 
       // Function props won't appear in JSON.stringify, but the components should render correctly
-      expect(screen.getByTestId('details-card')).toBeInTheDocument();
+      expect(screen.getByTestId('overview-card')).toBeInTheDocument();
       expect(screen.getByTestId('progress-card')).toBeInTheDocument();
       expect(screen.getByTestId('activity-card')).toBeInTheDocument();
 
       // This confirms the props are being passed (even if we can't see functions in JSON)
-      const detailsCardProps = JSON.parse(
-        screen.getByTestId('details-card-props').textContent,
+      const overviewCardProps = JSON.parse(
+        screen.getByTestId('overview-card-props').textContent,
       );
-      expect(detailsCardProps.details).toEqual(defaultProps.details);
+      expect(overviewCardProps.details).toEqual(defaultProps.details);
     });
   });
 
@@ -665,7 +669,7 @@ describe('DetailsGeneralContent', () => {
       expect(gridItems).toHaveLength(2);
       expect(grid).toContainElement(gridItems[0]);
       expect(grid).toContainElement(gridItems[1]);
-      expect(gridItems[0]).toContainElement(screen.getByTestId('details-card'));
+      expect(gridItems[0]).toContainElement(screen.getByTestId('overview-card'));
       expect(gridItems[0]).toContainElement(
         screen.getByTestId('activity-card'),
       );
@@ -679,8 +683,8 @@ describe('DetailsGeneralContent', () => {
 
       const gridItems = screen.getAllByTestId('grid-item');
 
-      // First grid item should contain DetailsCard and ActivityCard
-      expect(gridItems[0]).toContainElement(screen.getByTestId('details-card'));
+      // First grid item should contain OverviewCard and ActivityCard
+      expect(gridItems[0]).toContainElement(screen.getByTestId('overview-card'));
       expect(gridItems[0]).toContainElement(
         screen.getByTestId('activity-card'),
       );

--- a/src/routes/RemediationDetailsComponents/OverviewCard.js
+++ b/src/routes/RemediationDetailsComponents/OverviewCard.js
@@ -40,14 +40,14 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { pluralize } from '../../Utilities/utils';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
 import { getExpandableCardToggleProps } from './helpers';
-
-const DETAILS_CARD_OUIA_ID = 'details-card';
-const DETAILS_CARD_TITLE_ID = 'details-card-title';
-const DETAILS_CARD_TOGGLE_ID = 'details-card-toggle';
-const DETAILS_CARD_CONTENT_ID = 'details-card-content';
 import { PermissionContext } from '../../App';
 
-const DetailsCard = ({
+const OVERVIEW_CARD_OUIA_ID = 'overview-card';
+const OVERVIEW_CARD_TITLE_ID = 'overview-card-title';
+const OVERVIEW_CARD_TOGGLE_ID = 'overview-card-toggle';
+const OVERVIEW_CARD_CONTENT_ID = 'overview-card-content';
+
+const OverviewCard = ({
   details,
   updateRemPlan,
   onNavigateToTab,
@@ -204,9 +204,12 @@ const DetailsCard = ({
   };
 
   return (
-    <Card data-ouia-component-id={DETAILS_CARD_OUIA_ID} isExpanded={isExpanded}>
+    <Card
+      data-ouia-component-id={OVERVIEW_CARD_OUIA_ID}
+      isExpanded={isExpanded}
+    >
       <CardHeader>
-        <CardTitle id={DETAILS_CARD_TITLE_ID} style={{ width: '100%' }}>
+        <CardTitle id={OVERVIEW_CARD_TITLE_ID} style={{ width: '100%' }}>
           <Flex
             justifyContent={{ default: 'justifyContentSpaceBetween' }}
             alignItems={{ default: 'alignItemsCenter' }}
@@ -220,14 +223,14 @@ const DetailsCard = ({
                 icon={isExpanded ? <AngleUpIcon /> : <AngleDownIcon />}
                 onClick={() => setIsExpanded((current) => !current)}
                 {...getExpandableCardToggleProps(
-                  DETAILS_CARD_TOGGLE_ID,
-                  DETAILS_CARD_CONTENT_ID,
+                  OVERVIEW_CARD_TOGGLE_ID,
+                  OVERVIEW_CARD_CONTENT_ID,
                   isExpanded,
-                  'Toggle details card',
+                  'Toggle overview card',
                 )}
               />
               <Title headingLevel="h4" size="xl">
-                Details
+                Overview
               </Title>
             </Flex>
             <Flex
@@ -251,8 +254,8 @@ const DetailsCard = ({
         </CardTitle>
       </CardHeader>
       <CardExpandableContent
-        id={DETAILS_CARD_CONTENT_ID}
-        data-ouia-component-id={DETAILS_CARD_CONTENT_ID}
+        id={OVERVIEW_CARD_CONTENT_ID}
+        data-ouia-component-id={OVERVIEW_CARD_CONTENT_ID}
       >
         <CardBody>
           <Content
@@ -448,7 +451,7 @@ const DetailsCard = ({
   );
 };
 
-DetailsCard.propTypes = {
+OverviewCard.propTypes = {
   details: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
@@ -476,4 +479,4 @@ DetailsCard.propTypes = {
   refetchAllRemediations: PropTypes.func,
 };
 
-export default DetailsCard;
+export default OverviewCard;

--- a/src/routes/RemediationDetailsComponents/OverviewCard.test.js
+++ b/src/routes/RemediationDetailsComponents/OverviewCard.test.js
@@ -9,7 +9,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import DetailsCard from './DetailsCard';
+import OverviewCard from './OverviewCard';
 import { PermissionContext } from '../../App';
 import * as useVerifyName from '../../Utilities/useVerifyName';
 import useRemediations from '../../Utilities/Hooks/api/useRemediations';
@@ -33,7 +33,7 @@ jest.mock('@redhat-cloud-services/frontend-components/InsightsLink', () => {
   };
 });
 
-describe('DetailsCard', () => {
+describe('OverviewCard', () => {
   let mockUpdateRemPlan;
   let mockOnNavigateToTab;
   let mockRefetch;
@@ -109,7 +109,7 @@ describe('DetailsCard', () => {
 
     return render(
       <PermissionContext.Provider value={{ permissions }}>
-        <DetailsCard {...defaultProps} />
+        <OverviewCard {...defaultProps} />
       </PermissionContext.Provider>,
     );
   };
@@ -118,14 +118,14 @@ describe('DetailsCard', () => {
     it('renders without crashing', () => {
       renderComponent();
 
-      expect(screen.getByText('Details')).toBeInTheDocument();
+      expect(screen.getByText('Overview')).toBeInTheDocument();
     });
 
     it('displays loading spinner when no details provided', () => {
       renderComponent({ details: null });
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
-      expect(screen.queryByText('Details')).not.toBeInTheDocument();
+      expect(screen.queryByText('Overview')).not.toBeInTheDocument();
     });
 
     it('displays all required information when details are provided', () => {
@@ -144,7 +144,7 @@ describe('DetailsCard', () => {
       renderComponent();
 
       const toggle = screen.getByRole('button', {
-        name: /toggle details card/i,
+        name: /toggle overview card/i,
       });
       expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
@@ -550,7 +550,7 @@ describe('DetailsCard', () => {
         allRemediations: undefined,
       });
 
-      expect(screen.getByText('Details')).toBeInTheDocument();
+      expect(screen.getByText('Overview')).toBeInTheDocument();
     });
   });
 
@@ -586,7 +586,7 @@ describe('DetailsCard', () => {
         <PermissionContext.Provider
           value={{ permissions: { write: true, read: true } }}
         >
-          <DetailsCard
+          <OverviewCard
             details={newDetails}
             updateRemPlan={mockUpdateRemPlan}
             onNavigateToTab={mockOnNavigateToTab}

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -69,7 +69,7 @@ export const getPlaybookLogs = (params) =>
 
 /**
  * Update a remediation. Wrapper to handle the two-parameter API signature.
- * Used by RenameModal, DetailsCard, and other components that need to update remediation properties.
+ * Used by RenameModal, OverviewCard, and other components that need to update remediation properties.
  *
  * The API client's updateRemediation expects (id, data) as two separate parameters,
  * but useRemediationsQuery passes a single params object. This wrapper converts


### PR DESCRIPTION
# Description

Associated Jira ticket: none

This PRs rename the Details card in General tab on Details page

# How to test the PR

Visit Remediations Details page and verify that General tab contains Overview card instead of Details card.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Rename the remediation details "Details" card to "Overview" throughout the Remediation Details page.

Enhancements:
- Update the DetailsGeneralContent layout to use the new OverviewCard component instead of DetailsCard.

Tests:
- Update unit tests for DetailsGeneralContent and the card component to reflect the OverviewCard naming and behavior.