### PR TITLE
fix(RHINENG-25407): fix name of inventory read permission for Kessel

### DIFF
--- a/src/Utilities/Hooks/useKesselRemediationPermissionState.js
+++ b/src/Utilities/Hooks/useKesselRemediationPermissionState.js
@@ -8,14 +8,14 @@ import {
   KESSEL_REMEDIATIONS_EDIT,
   KESSEL_REMEDIATIONS_EXECUTE,
   KESSEL_REMEDIATIONS_VIEW,
-  KESSEL_INVENTORY_HOSTS_READ,
+  KESSEL_INVENTORY_HOST_VIEW,
 } from '../../constants';
 
 const KESSEL_RELATIONS = [
   KESSEL_REMEDIATIONS_VIEW,
   KESSEL_REMEDIATIONS_EDIT,
   KESSEL_REMEDIATIONS_EXECUTE,
-  KESSEL_INVENTORY_HOSTS_READ,
+  KESSEL_INVENTORY_HOST_VIEW,
 ];
 
 /** workspace + rbac reporter, aligned with fec kesselPermissions defaults */
@@ -98,7 +98,7 @@ export function useKesselRemediationPermissionState(baseUrl) {
     const read = getAllowed(checks, KESSEL_REMEDIATIONS_VIEW);
     const write = getAllowed(checks, KESSEL_REMEDIATIONS_EDIT);
     const execute = getAllowed(checks, KESSEL_REMEDIATIONS_EXECUTE);
-    const inventoryHostsRead = getAllowed(checks, KESSEL_INVENTORY_HOSTS_READ);
+    const inventoryHostsRead = getAllowed(checks, KESSEL_INVENTORY_HOST_VIEW);
     return { read, write, execute, inventoryHostsRead };
   }, [checks]);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,4 +49,4 @@ export const KESSEL_API_BASE_URL = '/api/kessel/v1beta2';
 export const KESSEL_REMEDIATIONS_VIEW = 'remediations_view_remediation';
 export const KESSEL_REMEDIATIONS_EDIT = 'remediations_edit_remediation';
 export const KESSEL_REMEDIATIONS_EXECUTE = 'remediations_execute_remediation';
-export const KESSEL_INVENTORY_HOSTS_READ = 'inventory_hosts_read';
+export const KESSEL_INVENTORY_HOST_VIEW = 'inventory_host_view';


### PR DESCRIPTION
# Description

Associated Jira ticket: RHINENG-25407

Code used wrong name of the host-read permission from Inventory, which was visible in the kessel response:
```
{
    "request": {
        "object": {
            "resourceType": "workspace",
            "resourceId": "019ae988-3fbd-7462-9a8b-3b55b0720b06",
            "reporter": {
                "type": "rbac"
            }
        },
        "relation": "inventory_hosts_read"
    },
    "error": {
        "code": 9,
        "message": "relation/permission `inventory_hosts_read` not found under definition `rbac/workspace`",
        "details": []
    }
}

```

This PR changes `inventory_hosts_read` to `inventory_host_view` which appears to be the correct name of the permission:
```
{
    "request": {
        "object": {
            "resourceType": "workspace",
            "resourceId": "019ae988-3fbd-7462-9a8b-3b55b0720b06",
            "reporter": {
                "type": "rbac"
            }
        },
        "relation": "inventory_host_view"
    },
    "item": {
        "allowed": "ALLOWED_FALSE"
    }
} 

```
# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work

## Summary by Sourcery

Bug Fixes:
- Fix incorrect inventory host permission identifier used in Kessel remediation permission checks so it aligns with the actual Inventory RBAC permission name.